### PR TITLE
fix for #473

### DIFF
--- a/mongoengine/dereference.py
+++ b/mongoengine/dereference.py
@@ -112,10 +112,11 @@ class DeReference(object):
                     for ref in references:
                         if '_cls' in ref:
                             doc = get_document(ref["_cls"])._from_son(ref)
+                        elif doc_type is None:
+                            doc = get_document(
+                                ''.join(x.capitalize() 
+                                        for x in col.split('_')))._from_son(ref)
                         else:
-                            if doc_type is None:
-                                doc_type = get_document(
-                                        ''.join(x.capitalize() for x in col.split('_')))
                             doc = doc_type._from_son(ref)
                         object_map[doc.id] = doc
         return object_map

--- a/tests/dereference.py
+++ b/tests/dereference.py
@@ -815,17 +815,29 @@ class FieldTest(unittest.TestCase):
         class Foo(Document):
             meta = {'allow_inheritance': False}
             bar = ReferenceField('Bar')
+            baz = ReferenceField('Baz')
 
         class Bar(Document):
             meta = {'allow_inheritance': False}
             msg = StringField(required=True, default='Blammo!')
 
+        class Baz(Document):
+            meta = {'allow_inheritance': False}
+            msg = StringField(required=True, default='Kaboom!')
+
         Foo.drop_collection()
         Bar.drop_collection()
+        Baz.drop_collection()
 
         bar = Bar()
         bar.save()
+        baz = Baz()
+        baz.save()
         foo = Foo()
         foo.bar = bar
+        foo.baz = baz
         foo.save()
         foo.reload()
+
+        self.assertEquals(type(foo.bar), Bar)
+        self.assertEquals(type(foo.baz), Baz)


### PR DESCRIPTION
Convert col to document name so that it can be looked up in _document_registry when doc_type is None.

Not sure if this is ideal, but it seems to work. I also added a unit test that exercises the test case I mentioned in the relevant issue thread.
