### PR TITLE
propagate the shard_key from abstract base classes' meta

### DIFF
--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -654,6 +654,7 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
                 keys_to_propogate = (
                     'index_background', 'index_drop_dups', 'index_opts',
                     'allow_inheritance', 'queryset_class', 'db_alias',
+                    'shard_key'
                 )
                 for key in keys_to_propogate:
                     if key in base._meta:


### PR DESCRIPTION
When creating an abstract base class the defines a shard_key in it's meta, It's not propagated to it's children.
