### PR TITLE
saving a document with shard_key == _id failed

### DIFF
--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -235,7 +235,9 @@ class Document(BaseDocument):
                 message = u'Tried to save duplicate unique keys (%s)'
             raise OperationError(message % unicode(err))
         id_field = self._meta['id_field']
-        self[id_field] = self._fields[id_field].to_python(object_id)
+        # don't update the id field if it's the shard_key (because it's immutable and will raise an error)
+        if id_field not in self._meta.get('shard_key', ()):
+            self[id_field] = self._fields[id_field].to_python(object_id)
 
         self._changed_fields = []
         self._created = False


### PR DESCRIPTION
saving a document with shard_key == _id failed saying the shard key is immutable even though I haven't changed the _id (because save always sets the _id, even if it is unchanged). 
Fixed by testing whether the _id is in the shard key before setting it.

Tests are passing in travis. (although i don't think sharding has any tests. also tested on my setup)
