### PR TITLE
Minor bug fix to get "id_field" meta working

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -757,7 +757,13 @@ class ReferenceField(BaseField):
 
         if isinstance(document, Document):
             # We need the id from the saved object to create the DBRef
-            id_ = document.id
+            #
+            # we reference "pk" here, rather than hard-coding ".id", so that
+            # a
+            #   meta = {'id_field':'FOO'} 
+            # will actually work...
+            id_ = document.pk
+
             if id_ is None:
                 self.error('You can only reference documents once they have'
                            ' been saved to the database')


### PR DESCRIPTION
A derived class with an overloaded id() method was causing issues, so I used the "id_field" meta to get around it, setting up my class as

class Foo(orm.Document):
    # avoid conflict between our library's expected id()
    # method and the document's auto-gen'ed primary key (rename to uid)
    meta = {'id_field':'uid'}

```
uid=orm.ObjectIdField(db_field='_id', name="uid")

# ....
```

However, this was failing with messages a-la:
mongoengine.base.ValidationError: <bound method Foo.id of <Foo: bar (5033dc8b86449774402f15e7)>> is not a valid ObjectId.

Fixed with a simple patch to fields.py (accessing the .pk, rather than hardcoding .id).

Regards,
Pat Deegan
