### PR TITLE
Capped list fields

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -31,6 +31,7 @@ __all__ = ['StringField', 'IntField', 'FloatField', 'BooleanField',
            'DecimalField', 'ComplexDateTimeField', 'URLField', 'DynamicField',
            'GenericReferenceField', 'FileField', 'BinaryField',
            'SortedListField', 'EmailField', 'GeoPointField', 'ImageField',
+           'CappedListField', 'CappedSortedListField',
            'SequenceField', 'UUIDField', 'GenericEmbeddedDocumentField']
 
 RECURSIVE_REFERENCE_CONSTANT = 'self'
@@ -617,6 +618,27 @@ class SortedListField(ListField):
         if self._ordering is not None:
             return sorted(value, key=itemgetter(self._ordering), reverse=self._order_reverse)
         return sorted(value, reverse=self._order_reverse)
+
+
+class CappedListField(ListField):
+    """A ListField that is capped at a given number of items before writing to
+    the database.
+    """
+
+    def __init__(self, field, cap, **kwargs):
+        self.cap = cap
+        super(CappedListField, self).__init__(field, **kwargs)
+
+    def to_mongo(self, value):
+        value = super(CappedListField, self).to_mongo(value)
+        return value[:self.cap]
+
+
+class CappedSortedListField(CappedListField, SortedListField):
+    """A SortedListField that is capped at a given number of items after sorting and 
+    before writing to the database.
+    """
+    pass
 
 
 class DictField(ComplexBaseField):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -2298,6 +2298,36 @@ class FieldTest(unittest.TestCase):
         post.comments[1].content = 'here we go'
         post.validate()
 
+    def test_capped_list_capping(self):
+        """Ensure that a capped list field properly caps values.
+        """
+        class BlogPost(Document):
+            content = StringField()
+            tags = CappedListField(StringField(), cap=3)
+
+        post = BlogPost(content='Programming is fun')
+        post.save()
+
+        post.tags = ['python', 'java', 'c++', 'ruby', 'perl']
+        post.save()
+        post.reload()
+        self.assertEqual(post.tags, ['python', 'java', 'c++'])
+
+    def test_capped_sorted_list_capping(self):
+        """Ensure that a capped, sorted list field properly caps values.
+        """
+        class BlogPost(Document):
+            content = StringField()
+            tags = CappedSortedListField(StringField(), cap=3)
+
+        post = BlogPost(content='Programming is fun')
+        post.save()
+
+        post.tags = ['python', 'java', 'c++', 'ruby', 'perl']
+        post.save()
+        post.reload()
+        self.assertEqual(post.tags, ['c++', 'java', 'perl'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Two new fields (CappedListField & CappedSortedListField), that cap the length of the list to a given number of items before saving to the DB (similar to how SortedListField applies its ordering).
