### PR TITLE
Provide property '_parent' for EmbeddedDocument

### DIFF
--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -148,6 +148,7 @@ class BaseField(object):
     # Fields may have _types inserted into indexes by default
     _index_with_types = True
     _geo_index = False
+    _parent = None
 
     # These track each time a Field instance is created. Used to retain order.
     # The auto_creation_counter is used for fields that MongoEngine implicitly
@@ -199,6 +200,10 @@ class BaseField(object):
             if callable(value):
                 value = value()
 
+        if isinstance(value, BaseDocument):
+            # if the field is an EmbeddedDocument, set the parent document
+            value._parent = instance
+
         return value
 
     def __set__(self, instance, value):
@@ -207,6 +212,10 @@ class BaseField(object):
         instance._data[self.name] = value
         if instance._initialised:
             instance._mark_as_changed(self.name)
+
+        if isinstance(value, BaseDocument):
+            # if the field is an EmbeddedDocument, set the parent document
+            value._parent = instance
 
     def error(self, message="", errors=None, field_name=None):
         """Raises a ValidationError.

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -2680,6 +2680,34 @@ class DocumentTest(unittest.TestCase):
         promoted_employee.reload()
         self.assertEqual(promoted_employee.details, None)
 
+    def test_embedded_document_parents(self):
+        """Ensure that embedded documents provide a _parent property
+        """
+        class Position(EmbeddedDocument):
+            name = StringField()
+
+        class Employee(self.Person):
+            salary = IntField()
+            position = EmbeddedDocumentField(Position)
+            previous_positions = ListField(EmbeddedDocumentField(Position))
+
+        # assert _position is populated on __set__
+        employee = Employee(name='Test Employee', salary=20000)
+        position = Position(name='Developer')
+        employee.position = position
+        self.assertEqual(position._parent, employee)
+
+        # assert _position is populated on __get__
+        employee.save()
+        employee.reload()
+
+        self.assertEqual(employee.position._parent, employee)
+
+        # TODO get this working for list fields
+        employee.previous_positions = [Position(name='Analyst'),
+                                       Position(name='Intern')]
+        #self.assertEqual(employee.previous_positions[0]._parent, employee)
+
     def test_mixins_dont_add_to_types(self):
 
         class Mixin(object):


### PR DESCRIPTION
It would be convenient to get the containing document when you have an embedded document. Here's an idea for how to do that. I find I want this sometime when I am passing the embedded document to a function but not the parent.

However, I think people might have a variety of reasons why this is not a good idea. Is this useful or a bad idea?
