### PR TITLE
Document subclasses with a different db_alias setting from their base class were not using the correct db_alias

### DIFF
--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -130,6 +130,13 @@ class Document(BaseDocument):
     @classmethod
     def _get_collection(cls):
         """Returns the collection for the document."""
+
+        # Invalidate existing cls._collection if it's not using the correct
+        # database.
+        if getattr(cls, '_collection', None) is not None:
+            if cls._collection.database.name != cls._get_db().name:
+                cls._collection = None
+
         if not hasattr(cls, '_collection') or cls._collection is None:
             db = cls._get_db()
             collection_name = cls._get_collection_name()

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -3261,6 +3261,31 @@ class DocumentTest(unittest.TestCase):
 
         self.assertEqual('testdb-1', B._meta.get('db_alias'))
 
+    def test_db_alias_overrides(self):
+        """db_alias can be overriden
+        """
+        # Register a connection with db_alias testdb-2
+        register_connection('testdb-2', 'mongoenginetest2')
+
+        class A(Document):
+            """Uses default db_alias
+            """
+            name = StringField()
+            meta = {"allow_inheritance": True}
+
+        class B(A):
+            """Uses testdb-2 db_alias
+            """
+            meta = {"db_alias": "testdb-2"}
+
+        # query with A, to initiate a connection to the default db_alias
+        A.objects.count()
+
+        self.assertEquals('testdb-2', B._meta.get('db_alias'))
+        self.assertEquals('mongoenginetest2', 
+                           B._get_collection().database.name)
+
+
     def test_db_ref_usage(self):
         """ DB Ref usage  in dict_fields"""
 


### PR DESCRIPTION
When subclassing a Document class, if you overrode the db_alias setting in the subclass, the setting was not taking effect if an operation had already been done that set the _collection attribute on the base class.

The subclass was re-using the _collection object from the base class which is pointed at the wrong db.   This gist illustrates the issue: https://gist.github.com/3801013  You'll notice the SubUser that is created is saved to the db with the default alias (db1 in this case), and not db2.

This commit (with test case) resolves the issue by setting the _collection attribute to None (forcing a refresh) if the name of the database that is set does not match what is expected.
