### PR TITLE
Error whan running python setup.py bdist_rpm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ try:
 except ImportError:
     pass
 
-DESCRIPTION = """MongoEngine is a Python Object-Document
-Mapper for working with MongoDB."""
+DESCRIPTION = 'MongoEngine is a Python Object-Document ' + \
+'Mapper for working with MongoDB.'
 LONG_DESCRIPTION = None
 try:
     LONG_DESCRIPTION = open('README.rst').read()


### PR DESCRIPTION
 This change in how the variable is declared DESCRIPTION corrects problems when running the command `python setup.py bdist_rpm`.

This is the error that is corrected with this change:

creating dist
Creating tar archive
removing 'mongoengine-0.7.5' (and everything under it)
copying dist/mongoengine-0.7.5.tar.gz -> build/bdist.linux-x86_64/rpm/SOURCES
building RPMs
error: line 8: Unknown tag: Mapper for working with MongoDB.
error: query of specfile build/bdist.linux-x86_64/rpm/SPECS/mongoengine.spec failed, can't parse
error: Failed to execute: "rpm -q --qf '%{name}-%{version}-%{release}.src.rpm %{arch}/%{name}-%{version}-%{release}.%{arch}.rpm\n' --specfile 'build/bdist.linux-x86_64/rpm/SPECS/mongoengine.spec'"
