### PR TITLE
Fix query chaining with .order_by()

### DIFF
--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -586,11 +586,13 @@ class QuerySet(object):
             if self._where_clause:
                 self._cursor_obj.where(self._where_clause)
 
-            # apply default ordering
             if self._ordering:
+                # Apply query ordering
                 self._cursor_obj.sort(self._ordering)
             elif self._document._meta['ordering']:
+                # Otherwise, apply the ordering from the document model
                 self.order_by(*self._document._meta['ordering'])
+                self._cursor_obj.sort(self._ordering)
 
             if self._limit is not None:
                 self._cursor_obj.limit(self._limit - (self._skip or 0))
@@ -1274,7 +1276,7 @@ class QuerySet(object):
             key_list.append((key, direction))
 
         self._ordering = key_list
-        self._cursor.sort(key_list)
+
         return self
 
     def explain(self, format=False):

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -1793,6 +1793,22 @@ class QuerySetTest(unittest.TestCase):
         ages = [p.age for p in self.Person.objects.order_by('-name')]
         self.assertEqual(ages, [30, 40, 20])
 
+    def test_order_by_chaining(self):
+        """Ensure that an order_by query chains properly and allows .only()
+        """
+        self.Person(name="User A", age=20).save()
+        self.Person(name="User B", age=40).save()
+        self.Person(name="User C", age=30).save()
+
+        only_age = self.Person.objects.order_by('-age').only('age')
+
+        names = [p.name for p in only_age]
+        ages = [p.age for p in only_age]
+
+        # The .only('age') clause should mean that all names are None
+        self.assertEqual(names, [None, None, None])
+        self.assertEqual(ages, [40, 30, 20])
+
     def test_confirm_order_by_reference_wont_work(self):
         """Ordering by reference is not possible.  Use map / reduce.. or
         denormalise"""


### PR DESCRIPTION
We create helper methods in our models for common filtering operations. Here's an example:

```
@classmethod                                                                
def filter_by_user(cls, user, order_by="-ctime", include_hidden=False, **kwargs):
    params = {"user_id": user.id}

    if not include_hidden:
        params["hidden__ne"] = True

    params.update(kwargs)

    return cls.objects(**params).order_by(order_by)
```

This gives us a general-purpose filtering function that we can use elsewhere:

```
Foo.filter_by_user(user).only("id")
```

However, the implementation of .order_by() accesses QuerySet._cursor, which effectively freezes the query. An .only() clause doesn't take effect at all.

This patch delays the effect of .order_by() until the QuerySet is executed.
