### PR TITLE
Issue #173 - EmailField doesn't honor regex or other StringField Validation

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -141,6 +141,7 @@ class EmailField(StringField):
     def validate(self, value):
         if not EmailField.EMAIL_REGEX.match(value):
             self.error('Invalid Mail-address: %s' % value)
+        super(EmailField, self).validate(value)
 
 
 class IntField(BaseField):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -2114,6 +2114,18 @@ class FieldTest(unittest.TestCase):
         post.comments[1].content = 'here we go'
         post.validate()
 
+    def test_email_field_honors_regex(self):
+        class User(Document):
+            email = EmailField(regex=r'\w+@example.com')
+
+        # Fails regex validation
+        user = User(email='me@foo.com')
+        self.assertRaises(ValidationError, user.validate)
+
+        # Passes regex validation
+        user = User(email='me@example.com')
+        self.assertTrue(user.validate() is None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Have EmailField apply validation rules defined in StringField to enable regex/max_length/min_length checking. Supporting tests included
