### PR TITLE
Allow to bulk-insert documents with custom pks

### DIFF
--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -927,9 +927,6 @@ class QuerySet(object):
             if not isinstance(doc, self._document):
                 msg = "Some documents inserted aren't instances of %s" % str(self._document)
                 raise OperationError(msg)
-            if doc.pk:
-                msg = "Some documents have ObjectIds use doc.update() instead"
-                raise OperationError(msg)
             raw.append(doc.to_mongo())
 
         signals.pre_bulk_insert.send(self._document, documents=docs)

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -584,13 +584,6 @@ class QuerySetTest(unittest.TestCase):
 
         self.assertEqual(Blog.objects.count(), 2)
 
-        # test handles people trying to upsert
-        def throw_operation_error():
-            blogs = Blog.objects
-            Blog.objects.insert(blogs)
-
-        self.assertRaises(OperationError, throw_operation_error)
-
         # test handles other classes being inserted
         def throw_operation_error_wrong_doc():
             class Author(Document):


### PR DESCRIPTION
Documents with a custom pk have it set before being inserted into the db. Rather than adding an allow_pk=False to the insert() method, I think it makes more sense to just remove the check, as the same problem this is trying to prevent (duplicated pk) could still happen due to any other unique field being duplicated; so it feels a bit useless to try to avoid it only in this case!
