### PR TITLE
Fix GridFSProxy __getattr__ behaviour

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -960,7 +960,7 @@ class GridFSProxy(object):
         if name in attrs:
             return self.__getattribute__(name)
         obj = self.get()
-        if name in dir(obj):
+        if hasattr(obj, name):
             return getattr(obj, name)
         raise AttributeError
 


### PR DESCRIPTION
Because the PyMongo GridOut also proxies attributes, using dir() to
detect the existence of an attribute fails in many cases.
