### PR TITLE
Only allow QNode instances to be passed as query objects

### DIFF
--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -423,6 +423,9 @@ class QuerySet(object):
         """
         query = Q(**query)
         if q_obj:
+            # make sure proper query object is passed
+            if not isinstance(q_obj, QNode):
+                raise InvalidQueryError('Not a query object: %s. Did you intend to use key=value?' % q_obj)
             query &= q_obj
         self._query_obj &= query
         self._mongo_query = None

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -1289,6 +1289,14 @@ class QuerySetTest(unittest.TestCase):
         self.assertEqual(len(self.Person.objects(Q(age__in=[20]))), 2)
         self.assertEqual(len(self.Person.objects(Q(age__in=[20, 30]))), 3)
 
+        # Test invalid query objs
+        def wrong_query_objs():
+            self.Person.objects('user1')
+        def wrong_query_objs_filter():
+            self.Person.objects('user1')
+        self.assertRaises(InvalidQueryError, wrong_query_objs)
+        self.assertRaises(InvalidQueryError, wrong_query_objs_filter)
+
     def test_q_regex(self):
         """Ensure that Q objects can be queried using regexes.
         """


### PR DESCRIPTION
Assume `SomeDoc.objects.filter(obj1=obj1, obj2=obj2)` returns some objects. `SomeDoc.objects.filter(obj1, obj2)` should not return ALL of them (i. e. be the same as `SomeDoc.objects.all()`). This is especially unsafe, if combined with `.delete()`. This fix makes sure the positional arguments passed to `filter` are in fact instances of QNode.
