### PR TITLE
Fix nested queryset iterations in Django templates and for loops

### DIFF
--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -423,6 +423,11 @@ class QuerySet(object):
             replica secondary.
         :param query: Django-style query keyword arguments
         """
+        if self._iter:
+            # Already iterating, and the __call__ is most likely made by
+            # Django's template engine to evaluate a nested variable
+            # expression. In this situation, don't reset everything.
+            return self
         query = Q(**query)
         if q_obj:
             query &= q_obj
@@ -603,7 +608,6 @@ class QuerySet(object):
     @property
     def _cursor(self):
         if self._cursor_obj is None:
-
             self._cursor_obj = self._collection.find(self._query,
                                                      **self._cursor_args)
             # Apply where clauses to cursor

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -103,6 +103,25 @@ class QuerySetTest(unittest.TestCase):
             start = end - 1
             self.assertEqual(t.render(Context(d)), u'%d:%d:' % (start, end))
 
+    def test_nested_queryset_template_iterator(self):
+        # Try iterating the same queryset twice, nested, in a Django template.
+        names = ['A', 'B', 'C', 'D']
+
+        class User(Document):
+            name = StringField()
+            def __unicode__(self):
+                return self.name
+
+        User.drop_collection()
+
+        for name in names:
+            User(name=name).save()
+
+        users = User.objects.all().order_by('name')
+        template = Template("{% for user in users %}{{ user.name }}{% ifequal forloop.counter 2 %} {% for inner_user in users %}{{ inner_user.name }}{% endfor %} {% endifequal %}{% endfor %}")
+        rendered = template.render(Context({'users':users}))
+        self.assertEqual(rendered, 'AB ABCD CD') # expected result is AB ABCD CD, buggy result is AB ABCD ABCD (when it resets the outer loop)
+
 
 
 class MongoDBSessionTest(SessionTestsMixin, unittest.TestCase):


### PR DESCRIPTION
In Django, you can do this:

```
articles = Article.objects.all()
for article in articles:
    print article.title
    for article2 in articles:
        print('-', article2.title)
```

The above code prints out each article, and then also lists all articles underneath it. I use this myself in a Django template (with some additional looping conditions).

In MongoEngine, the same code results in an infinite loop, because the QuerySet does not create new iterator objects, but uses itself as the iterator. So each time the second-level loop finishes, it causes the shared iterator to rewind() itself.

Additionally, when evaluating template variables, Django invokes __call__ on the queryset, which currently resets the query even if it's already iterating. This also causes an infinite loop.

This fix attempts to cover these two issues and includes test cases for both of them. It should not affect top-level loops in any way (it only does things when _iter is already set by the parent iterator).
