### PR TITLE
Raise the generated error

### DIFF
--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -252,7 +252,7 @@ class BaseField(object):
             elif value_to_check not in self.choices:
                 msg = ('Value must be %s of %s' %
                        (err_msg, unicode(self.choices)))
-                self.error()
+                self.error(msg)
 
         # check validation argument
         if self.validation is not None:


### PR DESCRIPTION
document validation was throwing empty validation errors with just the field name.

The error message is made, but never thrown.
