### PR TITLE
Patch to fix authentication support for Django 1.5 and later.

### DIFF
--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -164,7 +164,7 @@ class Document(BaseDocument):
 
     def save(self, safe=True, force_insert=False, validate=True,
              write_options=None,  cascade=None, cascade_kwargs=None,
-             _refs=None):
+             _refs=None, update_fields=None):
         """Save the :class:`~mongoengine.Document` to the database. If the
         document already exists, it will be updated, otherwise it will be
         created.
@@ -189,6 +189,7 @@ class Document(BaseDocument):
         :param cascade_kwargs: optional kwargs dictionary to be passed throw
             to cascading saves
         :param _refs: A list of processed references used in cascading saves
+        :param update_fields Specific fields to update
 
         .. versionchanged:: 0.5
             In existing documents it only saves changed fields using


### PR DESCRIPTION
When running MongoEngine as the database backend for Django 1.5 
and later, the django.contrib.auth.login and 
django.contrib.auth.authenticate methods fail here, since the 
`update_fields` keyword argument is not present in the `save()` 
method. This error is caused by Django [here](https://github.com/django/django/blob/master/django/contrib/auth/models.py#L244)
in the `check_password` method of the User object.
