### PR TITLE
allow a QuerySetManager to come from a parent class

### DIFF
--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -804,8 +804,10 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
             new_class._meta['collection'] = collection(new_class)
 
         # Provide a default queryset unless one has been set
-        manager = attrs.get('objects', QuerySetManager())
-        new_class.objects = manager
+        manager = getattr(new_class, 'objects', None)
+        if manager is None:
+            manager = attrs.get('objects', QuerySetManager())
+            new_class.objects = manager
 
         # Validate the fields and set primary key if needed
         for field_name, field in new_class._fields.iteritems():


### PR DESCRIPTION
Example:

``` python
import mongoengine as me

class Base(me.Document):
    active = me.BooleanField(default=True)

    @me.queryset_manager
    def objects(klass, queryset):
        return queryset(active=True)



class Child(Base):
    pass

Child.objects.create(active=False)
assert Child.objects.count() == 0
```
