### PR TITLE
Case insensitive uniqueness

### DIFF
--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -548,7 +548,7 @@ class DocumentMetaclass(type):
             if getattr(attr_value, '_unique_case_insensitive', None):
                 from fields import StringField
 
-                lower_field = StringField(unique=True)
+                lower_field = StringField(unique=attr_value.unique, unique_with=attr_value.unique_with)
                 lower_field.name = '_%s_lower' % attr_name
                 lower_field.db_field = lower_field.name
 

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -101,7 +101,8 @@ class StringField(BaseField):
 class IUniqueStringField(StringField):
 
     def __init__(self, *args, **kwargs):
-        kwargs['unique'] = True
+        if not kwargs.get('unique') and not kwargs.get('unique_with'):
+            raise StandardError('IUniqueStringField requires a unique or unique_with parameter')
         super(IUniqueStringField, self).__init__(*args, **kwargs)
         self._unique_case_insensitive = True
 
@@ -168,7 +169,8 @@ class EmailField(StringField):
 class IUniqueEmailField(EmailField):
 
     def __init__(self, *args, **kwargs):
-        kwargs['unique'] = True
+        if not kwargs.get('unique') and not kwargs.get('unique_with'):
+            raise StandardError('IUniqueStringField requires a unique or unique_with parameter')
         super(IUniqueEmailField, self).__init__(*args, **kwargs)
         self._unique_case_insensitive = True
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1168,7 +1168,7 @@ class DocumentTest(unittest.TestCase):
         """
         class BlogPost(Document):
             title = StringField()
-            slug = IUniqueStringField()
+            slug = IUniqueStringField(unique=True)
 
         BlogPost.drop_collection()
 
@@ -1179,13 +1179,33 @@ class DocumentTest(unittest.TestCase):
         post2 = BlogPost(title='test2', slug='TEST')
         self.assertRaises(NotUniqueError, post2.save)
 
+    def test_case_insensitive_string_unique_with(self):
+        """Ensure that case insensitive uniqueness constraints are applied to
+        emails.
+        """
+        class BlogPost(Document):
+            title = StringField()
+            slug = IUniqueStringField(unique_with='title')
+
+        post1 = BlogPost(title='test1', slug='test')
+        post1.save()
+
+        post2 = BlogPost(title='test2', slug='test')
+        post2.save()
+
+        post3 = BlogPost(title='test1', slug='test')
+        self.assertRaises(NotUniqueError, post3.save)
+
+        post4 = BlogPost(title='test1', slug='TEST')
+        self.assertRaises(NotUniqueError, post4.save)
+
     def test_unique_case_insensitive_email(self):
         """Ensure that case insensitive uniqueness constraints are applied to
         emails.
         """
         class BlogPost(Document):
             title = StringField()
-            author_email = IUniqueEmailField()
+            author_email = IUniqueEmailField(unique=True)
 
         BlogPost.drop_collection()
 
@@ -1232,7 +1252,7 @@ class DocumentTest(unittest.TestCase):
         """
         class SubDocument(EmbeddedDocument):
             year = IntField(db_field='yr')
-            slug = IUniqueStringField()
+            slug = IUniqueStringField(unique=True)
 
         class BlogPost(Document):
             title = StringField()


### PR DESCRIPTION
```
from mongoengine import *

connect('dbname')

class A(Document):
    b = IUniqueStringField()

c = A()
c.b = 'whatever'
c.save()

d = A()
d.b = 'WhatEVER'
d.save()
```

results in:

```
(env)[mongoengine] python test.py                                                                                                                             19:00:59 git:(master*)
Traceback (most recent call last):
  File "test.py", line 11, in <module>
    c.save()
  File "/Users/wojcikstefan/Repos/mongoengine/mongoengine/document.py", line 266, in save
    raise NotUniqueError(message % unicode(err))
mongoengine.queryset.NotUniqueError: Tried to save duplicate unique keys (E11000 duplicate key error index: tumblelog.a.$_b_lower_1  dup key: { : "whatever" })
```
