### PR TITLE
Fix problem with db_field in distinct()

### DIFF
--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -1214,8 +1214,14 @@ class QuerySet(object):
         .. versionchanged:: 0.5 - Fixed handling references
         .. versionchanged:: 0.6 - Improved db_field refrence handling
         """
-        return self._dereference(self._cursor.distinct(field), 1,
-                                 name=field, instance=self._document)
+
+        try:
+            field_document = QuerySet._lookup_field(self._document, field) 
+            if field_document:
+                field = field_document[0].db_field
+        finally:
+            return self._dereference(self._cursor.distinct(field), 1,
+                                     name=field, instance=self._document)
 
     def only(self, *fields):
         """Load only a subset of this document's fields. ::


### PR DESCRIPTION
Hello,

I Fixed problem with db_field in distinct(), Issue: https://github.com/MongoEngine/mongoengine/issues/260

mongoengine/queryset.py 

<pre lang="python"><code>
(-)        return self._dereference(self._cursor.distinct(field), 1,
(-)                                 name=field, instance=self._document)
(+)
(+)        try:
(+)            field_document = QuerySet._lookup_field(self._document, field) 
(+)            if field_document:
(+)                field = field_document[0].db_field
(+)        finally:
(+)            return self._dereference(self._cursor.distinct(field), 1,
(+)                                     name=field, instance=self._document) 
</code></pre>
