### PR TITLE
Fix for issue #260, distinct() does not resolve to db_field automatically

### DIFF
--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -1214,6 +1214,8 @@ class QuerySet(object):
         .. versionchanged:: 0.5 - Fixed handling references
         .. versionchanged:: 0.6 - Improved db_field refrence handling
         """
+        field = [field]
+        field = self._fields_to_dbfields(field).pop()
         return self._dereference(self._cursor.distinct(field), 1,
                                  name=field, instance=self._document)
 

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -2481,6 +2481,23 @@ class QuerySetTest(unittest.TestCase):
 
         self.assertEqual(Foo.objects.distinct("bar"), [bar])
 
+    def test_distinct_handles_db_field(self):
+        """Ensure that distinct resolves field name to db_field as expected.
+        """
+        class Product(Document):
+            product_id=IntField(db_field='pid')
+
+        Product.drop_collection()
+
+        product_one = Product(product_id=1).save()
+        product_two = Product(product_id=2).save()
+        product_one_dup = Product(product_id=1).save()
+
+        self.assertEqual(set(Product.objects.distinct('product_id')),
+                         set([1, 2]))
+
+        Product.drop_collection()
+
     def test_custom_manager(self):
         """Ensure that custom QuerySetManager instances work as expected.
         """


### PR DESCRIPTION
I'm not sure if this would be the best way to do this, but in any case here's a solution for [#260](https://github.com/MongoEngine/mongoengine/issues/260)
