### PR TITLE
Don't run unset on IntField if the value is 0 (zero).

### DIFF
--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -1207,7 +1207,7 @@ class BaseDocument(object):
 
         # Determine if any changed items were actually unset.
         for path, value in set_data.items():
-            if value or type(value) in [bool, int]:
+            if value or isinstance(value, (bool, int)):
                 continue
 
             # If we've set a value that ain't the default value dont unset it.


### PR DESCRIPTION
Here is a lot more info about this specific issue (especially if you click the referenced issue). https://github.com/MongoEngine/mongoengine/issues/271

However, this change only makes sure that users are able to set IntField values to 0 without losing them (triggering unset). This only happens if the field in the model has the default value set to 0 (default=0).

Maybe this should be changed in a more generic way for other datatypes as well. However, MongoEngine does trigger unset on many field types if they get an empty value in the field's data type. Therefore, you can't do this in a more generic way without breaking things.

The tests do succeed after this patch has been applied to the current master tree of MongoEngine.
