### PR TITLE
Fix datetime call in UserManager

### DIFF
--- a/mongoengine/django/auth.py
+++ b/mongoengine/django/auth.py
@@ -142,7 +142,7 @@ class UserManager(models.Manager):
         """
         Creates and saves a User with the given username, e-mail and password.
         """
-        now = datetime.datetime.now()
+        now = datetime_now()
 
         # Normalize the address by lowercasing the domain part of the email
         # address.


### PR DESCRIPTION
Replaced a leftover call to `datetime.datetime.now()` with `datetime_now()`.
