### PR TITLE
Do not fail on delete() when blinker is not available

### DIFF
--- a/mongoengine/queryset/queryset.py
+++ b/mongoengine/queryset/queryset.py
@@ -366,7 +366,7 @@ class QuerySet(object):
         queryset = self.clone()
         doc = queryset._document
 
-        has_delete_signal = (
+        has_delete_signal = signals.signals_available and (
             signals.pre_delete.has_receivers_for(self._document) or
             signals.post_delete.has_receivers_for(self._document))
 


### PR DESCRIPTION
Using v0.8 without `blinker`, an error is raised when calling `QuerySet.delete()`: "signalling support is unavailable because the blinker library is not installed."
