### PR TITLE
Mongoengine fails when using pickle with signal hooks

### DIFF
--- a/tests/document/instance.py
+++ b/tests/document/instance.py
@@ -9,7 +9,7 @@ import unittest
 import uuid
 
 from datetime import datetime
-from tests.fixtures import PickleEmbedded, PickleTest
+from tests.fixtures import PickleEmbedded, PickleTest, PickleSignalsTest
 
 from mongoengine import *
 from mongoengine.errors import (NotRegistered, InvalidDocumentError,
@@ -1729,6 +1729,12 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(resurrected, pickle_doc)
         self.assertEqual(pickle_doc.string, "Two")
         self.assertEqual(pickle_doc.lists, ["1", "2", "3"])
+
+    def test_picklable_on_signals(self):
+        pickle_doc = PickleSignalsTest(number=1, string="One", lists=['1', '2'])
+        pickle_doc.embedded = PickleEmbedded()
+        pickle_doc.save()
+        pickle_doc.delete()
 
     def test_throw_invalid_document_error(self):
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,6 +1,8 @@
+import pickle
 from datetime import datetime
 
 from mongoengine import *
+from mongoengine import signals
 
 
 class PickleEmbedded(EmbeddedDocument):
@@ -13,6 +15,24 @@ class PickleTest(Document):
     embedded = EmbeddedDocumentField(PickleEmbedded)
     lists = ListField(StringField())
     photo = FileField()
+
+
+class PickleSignalsTest(Document):
+    number = IntField()
+    string = StringField(choices=(('One', '1'), ('Two', '2')))
+    embedded = EmbeddedDocumentField(PickleEmbedded)
+    lists = ListField(StringField())
+
+    @classmethod
+    def post_save(self, sender, document, created, **kwargs):
+    	pickled = pickle.dumps(document)
+
+    @classmethod
+    def post_delete(self, sender, document, **kwargs):
+    	pickled = pickle.dumps(document)
+
+signals.post_save.connect(PickleSignalsTest.post_save, sender=PickleSignalsTest)
+signals.post_delete.connect(PickleSignalsTest.post_delete, sender=PickleSignalsTest)
 
 
 class Mixin(object):


### PR DESCRIPTION
This test fails with mongoengine 0.8.0RC4 when using pickle inside signal hooks (maybe related to hmarr/mongoengine#135).
Only occurs on `post_delete` in this test but also on `post_save` in my case, haven't figured out why...
