### PR TITLE
Minor documentation fix: switch_collection -> switch_db for changing database

### DIFF
--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -388,7 +388,7 @@ class Document(BaseDocument):
             user.save()
 
         If you need to read from another database see
-        :class:`~mongoengine.context_managers.switch_collection`
+        :class:`~mongoengine.context_managers.switch_db`
 
         :param collection_name: The database alias to use for saving the
             document


### PR DESCRIPTION
Update docs of switch_collection to indicate that if you need to read from another database, you should use switch_db (not switch_collection).
