### PR TITLE
importlib does not exist on Python 2.6. Use Django version.

### DIFF
--- a/mongoengine/django/mongo_auth/models.py
+++ b/mongoengine/django/mongo_auth/models.py
@@ -1,9 +1,8 @@
-from importlib import import_module
-
 from django.conf import settings
 from django.contrib.auth.models import UserManager
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
+from django.utils.importlib import import_module
 from django.utils.translation import ugettext_lazy as _
 
 


### PR DESCRIPTION
Fixed support for Django on Python 2.6.
