### PR TITLE
Fix for pickle.loads

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -152,7 +152,8 @@ class BaseDocument(object):
         if isinstance(data["_data"], SON):
             data["_data"] = self.__class__._from_son(data["_data"])._data
         for k in ('_changed_fields', '_initialised', '_created', '_data'):
-            setattr(self, k, data[k])
+            if k in data:
+                setattr(self, k, data[k])
 
     def __iter__(self):
         if 'id' in self._fields and 'id' not in self._fields_ordered:


### PR DESCRIPTION
`pickle.loads` fails on documents without any changed fields:

```
    body = pickle.loads(base64.b64decode(task['body']))
  File "/usr/lib/python2.7/pickle.py", line 1382, in loads
    return Unpickler(file).load()
  File "/usr/lib/python2.7/pickle.py", line 858, in load
    dispatch[key](self)
  File "/usr/lib/python2.7/pickle.py", line 1217, in load_build
    setstate(state)
  File "/home/ubuntu/closeio/venv/src/mongoengine/mongoengine/base/document.py", line 155, in __setstate__
    setattr(self, k, data[k])
KeyError: '_changed_fields'
```

This PR fixes it.
