### PR TITLE
Document Traits and alternative to inheritence

### DIFF
--- a/mongoengine/base/common.py
+++ b/mongoengine/base/common.py
@@ -1,11 +1,11 @@
 from mongoengine.errors import NotRegistered
 
-__all__ = ('ALLOW_INHERITANCE', 'get_document', '_document_registry')
+__all__ = ('ALLOW_INHERITANCE', 'get_document', '_document_registry', '_trait_registry')
 
 ALLOW_INHERITANCE = False
 
 _document_registry = {}
-
+_trait_registry = {}
 
 def get_document(name):
     doc = _document_registry.get(name, None)
@@ -24,3 +24,22 @@ def get_document(name):
             been imported?
         """.strip() % name)
     return doc
+
+def apply_traits(doc, names):
+    """Apply traits to a document"""
+    traits = set()
+    for name in sorted(names):
+        if name not in _trait_registry:
+            raise NotRegistered("""
+            `%s` is not a known Trait in the trait registry.
+            Importing the Trait class automatically registers it, has it 
+            been imported?
+            """.strip() % name)
+        traits.add(_trait_registry[name])
+    bases =  tuple([base for base in doc.__bases__ 
+                    if base.__name__ not in _trait_registry])
+    dic = {k: v for k, v in doc.__dict__.iteritems() if not k.startswith("__")}
+    dic['_traits'] = tuple(traits)
+    dic['_traitnames'] = set(names)
+    return type(doc.__name__, tuple(traits) + bases, dic)
+

--- a/mongoengine/common.py
+++ b/mongoengine/common.py
@@ -7,7 +7,7 @@ def _import_class(cls_name):
         return _class_registry_cache.get(cls_name)
 
     doc_classes = ('Document', 'DynamicEmbeddedDocument', 'EmbeddedDocument',
-                   'MapReduceDocument')
+                   'MapReduceDocument', 'Trait')
     field_classes = ('DictField', 'DynamicField', 'EmbeddedDocumentField',
                      'FileField', 'GenericReferenceField',
                      'GenericEmbeddedDocumentField', 'GeoPointField',


### PR DESCRIPTION
I have a test case https://gist.github.com/fried/5711229

This allows Document Fields to be build by Trait, so you can build your classes by composition instead of by ridged single inheritance. 

It seems to work.  
