### PR TITLE
test_validation_after_reload unittest

### DIFF
--- a/tests/document/validation.py
+++ b/tests/document/validation.py
@@ -141,6 +141,31 @@ class ValidatorErrorTest(unittest.TestCase):
             self.assertEqual(e.to_dict(), {
                 "e": {'val': 'OK could not be converted to int'}})
 
+    def test_validation_after_reload(self):
+        CHOICES = (
+                (0, 'zero'),
+                (1, 'one'),
+            )
+
+        class SubDoc(EmbeddedDocument):
+            val = IntField(required=True, choices=CHOICES)
+
+        class Doc(Document):
+            e = EmbeddedDocumentField(SubDoc, default=SubDoc)
+
+        doc = Doc()
+        doc.e.val = 0
+        doc.save()
+        doc.reload()
+        self.assertEqual(doc.e.val, 0)
+        doc.e.val = 1
+        doc.save()
+        doc.reload()
+        self.assertEqual(doc.e.val, 1)
+        doc.e.val = None
+        with self.assertRaises(ValidationError):
+            doc.save()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi, I fell on a `ReferenceError: weakly-referenced object no longer exists` Bug in mongoengine 0.8.2

Rather than giving a long explanation to reproduce the bug, I found it easier to add a unittest which reproduces the bug (in order to help you fixing).
So indeed the unittest fails (on 0.8.2), so don't feel obliged to merge it, but I hope it helps you pinpoint the issue more easily than with a long bug description:

```
$ python setup.py test --test-suite tests.document.validation.ValidatorErrorTest.test_validation_after_reload
0.8.2
running test
running egg_info
writing requirements to mongoengine.egg-info/requires.txt
writing mongoengine.egg-info/PKG-INFO
writing top-level names to mongoengine.egg-info/top_level.txt
writing dependency_links to mongoengine.egg-info/dependency_links.txt
reading manifest file 'mongoengine.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
no previously-included directories found matching 'docs/_build'
writing manifest file 'mongoengine.egg-info/SOURCES.txt'
running build_ext
test_validation_after_reload (tests.document.validation.ValidatorErrorTest) ... ERROR

======================================================================
ERROR: test_validation_after_reload (tests.document.validation.ValidatorErrorTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ygbourhis/Dev/ygbourhis/mongoengine/tests/document/validation.py", line 168, in test_validation_after_reload
    doc.save()
  File "mongoengine/document.py", line 223, in save
    self.validate(clean=clean)
  File "mongoengine/base/document.py", line 306, in validate
    field._validate(value, clean=clean)
  File "mongoengine/base/fields.py", line 175, in _validate
    self.validate(value, **kwargs)
  File "mongoengine/fields.py", line 563, in validate
    self.document_type.validate(value, clean)
  File "mongoengine/base/document.py", line 321, in validate
    elif self._instance:
ReferenceError: weakly-referenced object no longer exists

----------------------------------------------------------------------
Ran 1 test in 0.007s

FAILED (errors=1)
```

If you remove the calls to `doc.reload()` the test passes. But if we `reload` we get a ReferenceError when validation occurs before saving.

Thanks.
