### PR TITLE
Possible bug with only and to_json/as_pymongo

### DIFF
--- a/mongoengine/queryset/queryset.py
+++ b/mongoengine/queryset/queryset.py
@@ -1423,7 +1423,13 @@ class QuerySet(object):
         # used. If not, handle all fields.
         if not getattr(self, '__as_pymongo_fields', None):
             self.__as_pymongo_fields = []
-            for field in self._loaded_fields.fields - set(['_cls', '_id']):
+            fields = self._loaded_fields.fields - set(['_cls'])
+            
+            # if id was not in the list of fields, we ignore it
+            if not '_id' in fields:
+                fields -= set(['_id'])
+
+            for field in fields:
                 self.__as_pymongo_fields.append(field)
                 while '.' in field:
                     field, _ = field.rsplit('.', 1)

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -3246,6 +3246,21 @@ class QuerySetTest(unittest.TestCase):
         self.assertEqual(results[1]['name'], 'Barack Obama')
         self.assertEqual(results[1]['price'], Decimal('2.22'))
 
+        # assure name and price are the only keys in the result
+        self.assertTrue(
+            set(results[0].keys()).difference(('name', 'price')) == set()
+        )
+
+        # Test requiring id
+        results = list(
+            User.objects.only('id', 'name').as_pymongo(coerce_types=True)
+        )
+        self.assertTrue('_id' in results[0])
+        self.assertTrue(isinstance(results[0]['_id'], ObjectId))
+        self.assertTrue(
+            set(results[0].keys()).difference(('name', '_id')) == set()
+        )
+
     def test_as_pymongo_json_limit_fields(self):
 
         class User(Document):


### PR DESCRIPTION
Taking this example:

```
>>> class Doc(Document):
...    foo = StringField()
...    bar = StringField()
```

If I want the "bar" field:

```
>>> Doc(foo='foo', bar='bar').save()
>>> Doc.objects.only('bar').to_json()
'[{"bar": "bar"}]'
```

If I want the "id":

```
>>> Doc.objects.only('id').to_json()
'[{"_id": {"$oid": "51cda...bd8a0"}}]'
```

If I want the "id" field and "bar":

```
>>> Doc.objects.only('id', 'bar').to_json()
'[{"bar": "bar"}]'
```

Is this intentional or a bug?
