### PR TITLE
Better handling of FileFields stored in containers

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -1190,9 +1190,7 @@ class FileField(BaseField):
         # Check if a file already exists for this model
         grid_file = instance._data.get(self.name)
         if not isinstance(grid_file, self.proxy_class):
-            grid_file = self.proxy_class(key=self.name, instance=instance,
-                                         db_alias=self.db_alias,
-                                         collection_name=self.collection_name)
+            grid_file = self.get_proxy_obj(key=key, instance=instance)
             instance._data[self.name] = grid_file
 
         if not grid_file.key:
@@ -1214,14 +1212,22 @@ class FileField(BaseField):
                     pass
 
             # Create a new proxy object as we don't already have one
-            instance._data[key] = self.proxy_class(key=key, instance=instance,
-                                                   db_alias=self.db_alias,
-                                                   collection_name=self.collection_name)
+            instance._data[key] = self.get_proxy_obj(key=key, instance=instance)
             instance._data[key].put(value)
         else:
             instance._data[key] = value
 
         instance._mark_as_changed(key)
+        
+    def get_proxy_obj(self, key, instance, db_alias=None, collection_name=None):
+        if db_alias is None:
+            db_alias = self.db_alias
+        if collection_name is None:
+            collection_name = self.collection_name
+            
+        return  self.proxy_class(key=key, instance=instance,
+                                 db_alias=db_alias,
+                                 collection_name=collection_name)
 
     def to_mongo(self, value):
         # Store the GridFS file id in MongoDB
@@ -1255,6 +1261,11 @@ class ImageGridFsProxy(GridFSProxy):
         applying field properties (size, thumbnail_size)
         """
         field = self.instance._fields[self.key]
+        # if the field from the instance has an attribute field
+        # we use that one and hope for the best. Usually only container
+        # fields have a field attribute.
+        if hasattr(field, 'field'):
+            field = field.field
 
         try:
             img = Image.open(file_obj)


### PR DESCRIPTION
Adds a `get_proxy_obj` method to FileFields to make adding files to a container a bit more convenient. Also `ImageField.put()` should now figure out correctly if it's stored in a container field and get the ImageField if it is.
