### PR TITLE
dereference instance not thread-safe

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -172,3 +172,4 @@ that much better:
  * Alon Horev (https://github.com/alonho)
  * Kelvin Hammond (https://github.com/kelvinhammond)
  * Jatin- (https://github.com/jatin-)
+ * Thom Knowles (https://github.com/fleat)

--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -186,7 +186,6 @@ class ComplexBaseField(BaseField):
     """
 
     field = None
-    __dereference = False
 
     def __get__(self, instance, owner):
         """Descriptor to automatically dereference references.
@@ -201,9 +200,11 @@ class ComplexBaseField(BaseField):
                        (self.field is None or isinstance(self.field,
                         (GenericReferenceField, ReferenceField))))
 
+        _dereference = _import_class("DeReference")()
+
         self._auto_dereference = instance._fields[self.name]._auto_dereference
-        if not self.__dereference and instance._initialised and dereference:
-            instance._data[self.name] = self._dereference(
+        if instance._initialised and dereference:
+            instance._data[self.name] = _dereference(
                 instance._data.get(self.name), max_depth=1, instance=instance,
                 name=self.name
             )
@@ -222,7 +223,7 @@ class ComplexBaseField(BaseField):
         if (self._auto_dereference and instance._initialised and
            isinstance(value, (BaseList, BaseDict))
            and not value._dereferenced):
-            value = self._dereference(
+            value = _dereference(
                 value, max_depth=1, instance=instance, name=self.name
             )
             value._dereferenced = True
@@ -381,13 +382,6 @@ class ComplexBaseField(BaseField):
         self._owner_document = owner_document
 
     owner_document = property(_get_owner_document, _set_owner_document)
-
-    @property
-    def _dereference(self,):
-        if not self.__dereference:
-            DeReference = _import_class("DeReference")
-            self.__dereference = DeReference()  # Cached
-        return self.__dereference
 
 
 class ObjectIdField(BaseField):


### PR DESCRIPTION
This is sort of a sequel to hmarr/mongoengine#399 I think. The problem I noticed was in a threaded environment where multiple threads are pulling the same type of document from the database, and the type has a ListField of ReferenceFields defined. When those threads dereferenced the fields on the documents at roughly the same time, sometimes the resulting list would contain some items that were properly dereferenced and some items that were still pymongo DBRefs.

I tracked it down to the ListField's <code>_dereference</code> instance, which itself is not thread safe as it saves state during <code>__call__</code> and then references the state later in the execution path. Since all threads would use the same ListField instance on a given type this causes problems.

I believe the simplest example showing the problem is this:

``` python
import threading
import time
from mongoengine import Document, StringField, ReferenceField, ListField

class Sibling(Document):
    name = StringField()

class Person(Document):
    name = StringField()
    siblings = ListField(ReferenceField(Sibling))

def traverse(thread_num):
    if thread_num > 0:  # let 1st thread get through, avoids race condition
        time.sleep(1)
    deref = Person.siblings._dereference
    print "Thread num %d, siblings dereferencer: %s" % (thread_num, deref)

threads = [
    threading.Thread(target=traverse, args=(thread_nr,))
    for thread_nr in xrange(2)
]

for thread in threads:
    thread.start()
for thread in threads:
    thread.join()
```

Note in the print output both threads are holding on to the same <code>_dereference</code> instance.

Fix attached, just instantiates a DeReference instance during execution of <code>__get__</code> which I don't think incurs very much of a penalty as a DeReference is just a basic object. With this I no longer see the behavior I observed previously.

I'm happy to write a test for this but it's not straightforward. The existing tests all still work at least.
