### PR TITLE
fields: fix embedded document within embedded map field

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -489,7 +489,7 @@ class EmbeddedDocumentField(BaseField):
         return self.document_type_obj
 
     def to_python(self, value):
-        if not isinstance(value, self.document_type):
+        if value and not isinstance(value, self.document_type):
             return self.document_type._from_son(value)
         return value
 


### PR DESCRIPTION
When you have an object schema as so:

```
 class Embedded(EmbeddedDocument):
     foo = StringField()

 class TopLevel(Document):
      stuff = MapField(MapField(EmbeddedDocumentField(Embedded)))
```

If the top level object you fetch doesn't contain all the dictionaries
required to get to the EmbeddedDocumentField then an AttributeError is
thrown, which is of course incorrect if all the fields are optional.
This commit seems to fix the behaviour for me.
