### PR TITLE
Implement support for abstract fields (Fixes #427)

### DIFF
--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -689,6 +689,35 @@ document.::
 .. note:: From 0.8 onwards you must declare :attr:`allow_inheritance` defaults
           to False, meaning you must set it to True to use inheritance.
 
+Sometimes it is useful to put a field in a subclass, but define an index
+on that field in the superclass, e.g. when defining a compound index on two
+fields in different subclasses. In order to do this, you must specify those
+"abstract" fields in the superclass by setting :attr:`abstract_fields` in the
+:attr:`meta` data for a document to be a dictionary mapping abstract field
+names to field instances, for example::
+
+    class Super(Document):
+        key = StringField()
+
+        meta = {
+	    'allow_inheritance': True,
+	    'abstract_fields': {
+	        'value1': StringField(),
+		'value2': StringField()
+	    },
+	    'indexes': [('key', 'value1', 'value2')]
+	}
+
+    class Sub1(Super):
+        value1 = StringField()
+
+    class Sub2(Super):
+        value2 = StringField()
+
+Using the correct type for the abstract field value allows the indexing to
+know the structure of the field and, for example, support indexing fields
+within an :class:`~mongoengine.fields.EmbeddedDocumentField`. You can always use
+:class:`~mongoengine.fields.DynamicField` if the field type is dynamic or unknown.
 
 Working with existing data
 --------------------------

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -774,6 +774,8 @@ class BaseDocument(object):
                     field_name = cls._meta['id_field']
                 if field_name in cls._fields:
                     field = cls._fields[field_name]
+                elif field_name in cls._abstract_fields:
+                    field = cls._abstract_fields[field_name]
                 elif cls._dynamic:
                     DynamicField = _import_class('DynamicField')
                     field = DynamicField(db_field=field_name)

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -117,6 +117,14 @@ class Document(BaseDocument):
     doesn't contain a list) if allow_inheritance is True. This can be
     disabled by either setting cls to False on the specific index or
     by setting index_cls to False on the meta dictionary for the document.
+
+    By default, indexes can only refer to fields accessible in the current
+    class hierarchy, meaning that an index cannot span fields in two
+    different sub-classes. To be able to create such indexes, set
+    :attr:`abstract_fields` in the :attr:`meta` dictionary to be a dictionary
+    mapping field names to field instances. This will allow index creation
+    to be aware of fields on subclasses without the base class actually
+    containing those fields.
     """
 
     # The __metaclass__ attribute is removed by 2to3 when running with Python3

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -563,7 +563,8 @@ class EmbeddedDocumentField(BaseField):
         self.document_type.validate(value, clean)
 
     def lookup_member(self, member_name):
-        return self.document_type._fields.get(member_name)
+        return (self.document_type._fields.get(member_name) or
+                self.document_type._abstract_fields.get(member_name))
 
     def prepare_query_value(self, op, value):
         return self.to_mongo(value)
@@ -918,7 +919,8 @@ class ReferenceField(BaseField):
                        'saved to the database')
 
     def lookup_member(self, member_name):
-        return self.document_type._fields.get(member_name)
+        return (self.document_type._fields.get(member_name) or
+                self.document_type._abstract_fields.get(member_name))
 
 
 class GenericReferenceField(BaseField):

--- a/tests/document/__init__.py
+++ b/tests/document/__init__.py
@@ -2,6 +2,7 @@ import sys
 sys.path[0:0] = [""]
 import unittest
 
+from abstract_fields import *
 from class_methods import *
 from delta import *
 from dynamic import *

--- a/tests/document/abstract_fields.py
+++ b/tests/document/abstract_fields.py
@@ -1,0 +1,219 @@
+# -*- coding: utf-8 -*-
+import sys
+sys.path[0:0] = [""]
+import unittest
+
+from mongoengine import Document, EmbeddedDocument, connect
+from mongoengine.connection import get_db
+from mongoengine.fields import IntField, StringField, EmbeddedDocumentField, \
+    ListField, DictField, MapField
+
+__all__ = ('AbstractFieldsTest', )
+
+
+class AbstractFieldsTest(unittest.TestCase):
+
+    def setUp(self):
+        connect(db='mongoenginetest')
+        self.db = get_db()
+
+    def tearDown(self):
+        for collection in self.db.collection_names():
+            if 'system.' in collection:
+                continue
+            self.db.drop_collection(collection)
+
+    def test_simple(self):
+        "Index on a simple abstract field"
+        class Animal(Document):
+            meta = {
+                'abstract_fields': {
+                    'wings': IntField()
+                },
+                'indexes': [('wings',)]
+            }
+
+        expected_specs = [{'fields': [('wings', 1)]}]
+        self.assertEqual(expected_specs, Animal._meta['index_specs'])
+
+    def test_compound(self):
+        "Compound index on a non-abstract and an abstract field"
+        class Animal(Document):
+            name = StringField()
+
+            meta = {
+                'abstract_fields': {
+                    'wings': IntField()
+                },
+                'indexes': [('name', 'wings')]
+            }
+
+        expected_specs = [{'fields': [('name', 1), ('wings', 1)]}]
+        self.assertEqual(expected_specs, Animal._meta['index_specs'])
+
+    def test_embedded(self):
+        "Index on an abstract EmbeddedDocumentField and one of its fields"
+        class Species(EmbeddedDocument):
+            name = StringField()
+
+        class Animal(Document):
+            meta = {
+                'abstract_fields': {
+                    'species': EmbeddedDocumentField(Species)
+                },
+                'indexes': [('species',), ('species.name',)]
+            }
+
+        expected_specs = [
+            {'fields': [('species', 1)]},
+            {'fields': [('species.name', 1)]}
+        ]
+        self.assertEqual(expected_specs, Animal._meta['index_specs'])
+
+    def test_embedded_abstract(self):
+        "Index on a abstract field of an EmbeddedDocumentField"
+        class Species(EmbeddedDocument):
+            meta = {
+                'abstract_fields': {
+                    'genus': StringField()
+                }
+            }
+
+        class Animal(Document):
+            species = EmbeddedDocumentField(Species)
+
+            meta = {
+                'indexes': [('species.genus',)]
+            }
+
+        expected_specs = [{'fields': [('species.genus', 1)]}]
+        self.assertEqual(expected_specs, Animal._meta['index_specs'])
+
+    def test_embedded_abstract_embedded(self):
+        "Index on a abstract field of an abstract EmbeddedDocumentField"
+        class Species(EmbeddedDocument):
+            meta = {
+                'abstract_fields': {
+                    'genus': StringField()
+                }
+            }
+
+        class Animal(Document):
+            meta = {
+                'abstract_fields': {
+                    'species': EmbeddedDocumentField(Species)
+                },
+                'indexes': [('species.genus',)]
+            }
+
+        expected_specs = [{'fields': [('species.genus', 1)]}]
+        self.assertEqual(expected_specs, Animal._meta['index_specs'])
+
+    def test_list(self):
+        "Index on an abstract ListField"
+        class Animal(Document):
+            meta = {
+                'abstract_fields': {'habitats': ListField(StringField())},
+                'indexes': ['habitats']
+            }
+
+        expected_specs = [{'fields': [('habitats', 1)]}]
+        self.assertEqual(expected_specs, Animal._meta['index_specs'])
+
+    def test_list_embedded(self):
+        "Index on a field of an EmbeddedDocumentField in an abstract ListField"
+        class Habitat(EmbeddedDocument):
+            name = StringField()
+
+        class Animal(Document):
+            meta = {
+                'abstract_fields': {'habitats': ListField(EmbeddedDocumentField(Habitat))},
+                'indexes': ['habitats.name']
+            }
+
+        expected_specs = [{'fields': [('habitats.name', 1)]}]
+        self.assertEqual(expected_specs, Animal._meta['index_specs'])
+
+    def test_list_embedded_abstract(self):
+        """
+        Index on an abstract field of an EmbeddedDocumentField in an
+        abstract ListField
+        """
+        class Habitat(EmbeddedDocument):
+            meta = {
+                'abstract_fields': {'name': StringField()}
+            }
+
+        class Animal(Document):
+            meta = {
+                'abstract_fields': {'habitats': ListField(EmbeddedDocumentField(Habitat))},
+                'indexes': ['habitats.name']
+            }
+
+        expected_specs = [{'fields': [('habitats.name', 1)]}]
+        self.assertEqual(expected_specs, Animal._meta['index_specs'])
+
+    def test_dict(self):
+        "Index on an abstract DictField, and on a sub-field"
+        class Animal(Document):
+            meta = {
+                'abstract_fields': {'properties': DictField()},
+                'indexes': [('properties', 'properties.species')]
+            }
+
+        expected_specs = [{'fields': [('properties', 1), ('properties.species', 1)]}]
+        self.assertEqual(expected_specs, Animal._meta['index_specs'])
+
+    def test_abstract_dict(self):
+        "Index on a field of an EmbeddedDocumentField in an abstract DictField"
+        class Value(EmbeddedDocument):
+            name = StringField()
+
+        class Animal(Document):
+            meta = {
+                'abstract_fields': {'properties': DictField(field=EmbeddedDocumentField(Value))},
+                'indexes': [('properties.name')]
+            }
+
+        expected_specs = [{'fields': [('properties.name', 1)]}]
+        self.assertEqual(expected_specs, Animal._meta['index_specs'])
+
+    def test_dict_abstract(self):
+        "Index on an abstract field in an EmbeddedDocumentField in a DictField"
+        class Value(EmbeddedDocument):
+            meta = {
+                'abstract_fields': {'name': StringField()}
+            }
+
+        class Animal(Document):
+            properties = DictField(field=EmbeddedDocumentField(Value))
+
+            meta = {
+                'indexes': [('properties.name')]
+            }
+
+        expected_specs = [{'fields': [('properties.name', 1)]}]
+        self.assertEqual(expected_specs, Animal._meta['index_specs'])
+
+    def test_abstract_dict_abstract(self):
+        """
+        Index on an abstract field in an EmbeddedDocumentField in an
+        abstract DictField
+        """
+        class Value(EmbeddedDocument):
+            meta = {
+                'abstract_fields': {'name': StringField()}
+            }
+
+        class Animal(Document):
+            meta = {
+                'abstract_fields': {'properties': DictField(field=EmbeddedDocumentField(Value))},
+                'indexes': [('properties.name')]
+            }
+
+        expected_specs = [{'fields': [('properties.name', 1)]}]
+        self.assertEqual(expected_specs, Animal._meta['index_specs'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The basic problem I'm solving here is to define indexes on fields that aren't all available in one class within a Document class hierarchy. One approach would be to simply allow this to occur -- allow indexes on fields that the Document class is not aware of and bypass the validation that is currently done. Defining abstract fields seems like a good middle-ground, though, as it still allows for validation of the indexes, but creates the desired flexibility (and abstract fields can be specified as DynamicFields to trade validation for further flexibility).

I considered an alternative approach of adding an abstract flag to the Field classes, and then sorting them in the meta class when generating self._fields and self._abstract_fields, but the abstract fields really seem more like metadata about the class, not actual members of the class, and I think the Document classes are more expressive if they only include the fields that can actually be used via the ORM methods. However, I'm not certain this is the best approach, and definitely welcome other suggestions :)
