### PR TITLE
permit the establishment of a field with the name of size or other

### DIFF
--- a/mongoengine/queryset/transform.py
+++ b/mongoengine/queryset/transform.py
@@ -43,11 +43,11 @@ def query(_doc_cls=None, _field_operation=False, **query):
         parts = [part for part in parts if not part.isdigit()]
         # Check for an operator and transform to mongo-style if there is
         op = None
-        if parts[-1] in MATCH_OPERATORS:
+        if len(parts) > 1 and parts[-1] in MATCH_OPERATORS:
             op = parts.pop()
 
         negate = False
-        if parts[-1] == 'not':
+        if len(parts) > 1 and parts[-1] == 'not':
             parts.pop()
             negate = True
 


### PR DESCRIPTION
## Example:
### model

```
class Example(Document):
    size = ReferenceField(Size, verbose_name='Size')
```
### query

```
examples = Example.objects(size=instance_size)
```
### caused an error

```
File ".../mongoengine/queryset/transform.py", line 50, in query
if parts[-1] == 'not':
IndexError: list index out of range
```
