### PR TITLE
Remove database name necessity in uri connection schema

### DIFF
--- a/docs/guide/connecting.rst
+++ b/docs/guide/connecting.rst
@@ -23,11 +23,14 @@ arguments should be provided::
 
     connect('project1', username='webapp', password='pwd123')
 
-Uri style connections are also supported as long as you include the database
-name - just supply the uri as the :attr:`host` to
+Uri style connections are also supported - just supply the uri as
+the :attr:`host` to
 :func:`~mongoengine.connect`::
 
     connect('project1', host='mongodb://localhost/database_name')
+
+Note that database name from uri has priority over name
+in ::func:`~mongoengine.connect`
 
 ReplicaSets
 ===========

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -55,12 +55,9 @@ def register_connection(alias, name, host='localhost', port=27017,
     # Handle uri style connections
     if "://" in host:
         uri_dict = uri_parser.parse_uri(host)
-        if uri_dict.get('database') is None:
-            raise ConnectionError("If using URI style connection include "\
-                                  "database name in string")
         conn_settings.update({
             'host': host,
-            'name': uri_dict.get('database'),
+            'name': uri_dict.get('database') or name,
             'username': uri_dict.get('username'),
             'password': uri_dict.get('password'),
             'read_preference': read_preference,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -59,6 +59,32 @@ class ConnectionTest(unittest.TestCase):
         c.admin.system.users.remove({})
         c.mongoenginetest.system.users.remove({})
 
+    def test_connect_uri_without_db(self):
+        """Ensure that the connect() method works properly with uri's
+        without database_name
+        """
+        c = connect(db='mongoenginetest', alias='admin')
+        c.admin.system.users.remove({})
+        c.mongoenginetest.system.users.remove({})
+
+        c.admin.add_user("admin", "password")
+        c.admin.authenticate("admin", "password")
+        c.mongoenginetest.add_user("username", "password")
+
+        self.assertRaises(ConnectionError, connect, "testdb_uri_bad", host='mongodb://test:password@localhost')
+
+        connect("mongoenginetest", host='mongodb://localhost/')
+
+        conn = get_connection()
+        self.assertTrue(isinstance(conn, pymongo.mongo_client.MongoClient))
+
+        db = get_db()
+        self.assertTrue(isinstance(db, pymongo.database.Database))
+        self.assertEqual(db.name, 'mongoenginetest')
+
+        c.admin.system.users.remove({})
+        c.mongoenginetest.system.users.remove({})
+
     def test_register_connection(self):
         """Ensure that connections with different aliases may be registered.
         """


### PR DESCRIPTION
When I`m using URI connection schema without user and password, I get warnings from pymongo:

```
UserWarning: database name or authSource in URI is being ignored. If you wish to authenticate to ugc_development, you must provide a username and password.
  "must provide a username and password." % (db_name,))
```

So, why we can`t get database name from connect parameters if we don`t need auth on database?
