### PR TITLE
Avoid crash when an old instance of an object is unpickled after a field...

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -254,7 +254,7 @@ class BaseDocument(object):
                 value = field.to_mongo(value)
 
             # Handle self generating fields
-            if value is None and field._auto_gen:
+            if value is None and getattr(field, '_auto_gen', False):
                 value = field.generate()
                 self._data[field_name] = value
 


### PR DESCRIPTION
... has been removed from the model

This bug is quite convoluted, and I'm not sure that the solution is 100% complete. 

You've got a full stackstrace here: http://dev.1flow.net/development/1flow-dev/group/4688/

The problem occurs when a `Document` is unpickled from a celery task that was in the retry state for a while, and the `Document` attributes changed during the time (here, the `google_reader_original_data` was removed from the model). 

I totally understand that it is kind of a "non-standard" behavior, and that doing such things can make anything crash in many ways.

But in turn, I obviously cannot purge the worker queues nor stop all the workers to upload new code on my production machines. This is a live and streaming system.

So perhaps this small change can make it's way into `mongoengine` and make the whole thing more robust?

Any thought will be greatly apreciated.

regards,
