### PR TITLE
Fixes #458, DecimalField now ignores incorrect values until validate is called just like FloatField

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -304,7 +304,10 @@ class DecimalField(BaseField):
             return value
 
         # Convert to string for python 2.6 before casting to Decimal
-        value = decimal.Decimal("%s" % value)
+        try:
+            value = decimal.Decimal("%s" % value)
+        except decimal.InvalidOperation:
+            return value
         return value.quantize(self.precision, rounding=self.rounding)
 
     def to_mongo(self, value):

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -384,6 +384,9 @@ class FieldTest(unittest.TestCase):
         person.height = 4.0
         self.assertRaises(ValidationError, person.validate)
 
+        person_2 = Person(height='something invalid')
+        self.assertRaises(ValidationError, person_2.validate)
+
     def test_decimal_validation(self):
         """Ensure that invalid values cannot be assigned to decimal fields.
         """
@@ -405,6 +408,11 @@ class FieldTest(unittest.TestCase):
         self.assertRaises(ValidationError, person.validate)
         person.height = Decimal('4.0')
         self.assertRaises(ValidationError, person.validate)
+        person.height = 'something invalid'
+        self.assertRaises(ValidationError, person.validate)
+
+        person_2 = Person(height='something invalid')
+        self.assertRaises(ValidationError, person_2.validate)
 
         Person.drop_collection()
 


### PR DESCRIPTION
As pointed out in issue #458, while creating a document with kwargs, incorrect values for FloatFields are ignored until `doc.validate()` is called, but the same was not the case with DecimalFields, where a `decimal.InvalidOperation` exception is raised immediately.
This commit fixes that and brings the 2 fields closer. Although I'm not sure if this is the desired direction of MongoEngine.
