### PR TITLE
Expanded example of using ListFields for one-to-many relationships.

### DIFF
--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -287,6 +287,12 @@ instance of the object to the query::
     # Find all pages that both Bob and John have authored
     Page.objects(authors__all=[bob, john])
 
+    # Remove Bob from the authors for a page.
+    Page.objects(id='...').update_one(pull__authors=bob)
+
+    # Add John to the authors for a page.
+    Page.objects(id='...').update_one(push__authors=john)
+
 
 Dealing with deletion of referred documents
 '''''''''''''''''''''''''''''''''''''''''''


### PR DESCRIPTION
- Added an example of how to use the atomic update operations to `pull` and `push` to a `ListField` containing `ReferenceField`s.
- I personally found it surprising there wasn't an example of any basic way to `push` or `pull` from a `ListField` in this section of the documentation. I think it would be good for users to get an example of how to use it right there, so they don't have to go searching for it.
