### PR TITLE
Fixes AttributeError when using storage.exists() on a non-existing file.

### DIFF
--- a/mongoengine/django/storage.py
+++ b/mongoengine/django/storage.py
@@ -76,7 +76,7 @@ class GridFSStorage(Storage):
         """Find the documents in the store with the given name
         """
         docs = self.document.objects
-        doc = [d for d in docs if getattr(d, self.field).name == name]
+        doc = [d for d in docs if hasattr(getattr(d, self.field), 'name') and getattr(d, self.field).name == name]
         if doc:
             return doc[0]
         else:


### PR DESCRIPTION
This bit of code has caused a lot of trouble for me. It causes an attribute error when calling GridFSStorage.exists() on an file name that does not currently exist when it should return False.
