### PR TITLE
Use defaults when host and port are passed as None

### DIFF
--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -18,7 +18,7 @@ _connections = {}
 _dbs = {}
 
 
-def register_connection(alias, name, host='localhost', port=27017,
+def register_connection(alias, name, host=None, port=None,
                         is_slave=False, read_preference=False, slaves=None,
                         username=None, password=None, **kwargs):
     """Add a connection.
@@ -43,8 +43,8 @@ def register_connection(alias, name, host='localhost', port=27017,
 
     conn_settings = {
         'name': name,
-        'host': host,
-        'port': port,
+        'host': host or 'localhost',
+        'port': port or 27017,
         'is_slave': is_slave,
         'slaves': slaves or [],
         'username': username,
@@ -53,16 +53,15 @@ def register_connection(alias, name, host='localhost', port=27017,
     }
 
     # Handle uri style connections
-    if "://" in host:
-        uri_dict = uri_parser.parse_uri(host)
+    if "://" in conn_settings['host']:
+        uri_dict = uri_parser.parse_uri(conn_settings['host'])
         conn_settings.update({
-            'host': host,
             'name': uri_dict.get('database') or name,
             'username': uri_dict.get('username'),
             'password': uri_dict.get('password'),
             'read_preference': read_preference,
         })
-        if "replicaSet" in host:
+        if "replicaSet" in conn_settings['host']:
             conn_settings['replicaSet'] = True
 
     conn_settings.update(kwargs)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -98,6 +98,14 @@ class ConnectionTest(unittest.TestCase):
         self.assertTrue(isinstance(db, pymongo.database.Database))
         self.assertEqual(db.name, 'mongoenginetest2')
 
+    def test_register_connection_defaults(self):
+        """Ensure that defaults are used when the host and port are None.
+        """
+        register_connection('testdb', 'mongoenginetest', host=None, port=None)
+
+        conn = get_connection('testdb')
+        self.assertTrue(isinstance(conn, pymongo.mongo_client.MongoClient))
+
     def test_connection_kwargs(self):
         """Ensure that connection kwargs get passed to pymongo.
         """


### PR DESCRIPTION
Currently, there are a few alternatives for specifying the host and port when connecting. Because of the way the defaults are given in `register_connection`, none of them are very nice.

You can always use the internal defaults. This should only work for development environments:

``` python
mongoengine.connect('connection_alias', 'db_name')
```

You can override the defaults explicitly, in which case you have to provide your own (redundant) defaults:

``` python
host = os.environ.get('MONGO_HOST', 'localhost')
port = os.environ.get('MONGO_PORT', 27017)
mongoengine.connect('connection_alias', 'db_name', host=host, port=port)
```

This one's really ugly, but you _could_ use an if statement:

``` python
host = os.environ.get('MONGO_HOST')
port = os.environ.get('MONGO_PORT')
if host and port:
    mongoengine.connect('connection_alias', 'db_name', host=host, port=port)
else:
    mongoengine.connect('connection_alias', 'db_name')
```

To make this nicer, this pull request adds the ability to pass `None` for `host` and `port` to fall back to MongoEngine's internal defaults:

``` python
host = os.environ.get('MONGO_HOST')
port = os.environ.get('MONGO_PORT')
mongoengine.connect('connection_alias', 'db_name', host=host, port=port)
```

:tada:
