### PR TITLE
Test for testing invalid dict field value

### DIFF
--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -2560,6 +2560,20 @@ class FieldTest(unittest.TestCase):
         doc = Doc.objects.get()
         self.assertEqual(doc.embed_me.field_1, "hello")
 
+    def test_invalid_dict_value(self):
+        class DictFieldTest(Document):
+            dictionary = DictField(required=True)
+        
+        DictFieldTest.drop_collection()
+
+        test = DictFieldTest(dictionary=None)
+        test.dictionary # Just access to test getter
+        self.assertRaises(ValidationError, test.validate)
+        
+        test = DictFieldTest(dictionary=False)
+        test.dictionary # Just access to test getter
+        self.assertRaises(ValidationError, test.validate)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added a test which fails for me in strange way. I would suspect that the test succeeds but it fails with:

```
TypeError: 'bool' object is not iterable
```
