### PR TITLE
Give the choice to create a copy or dbref from a document in a dynamic Field

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -638,6 +638,9 @@ class DynamicField(BaseField):
                         val = {"_ref": value.to_dbref(), "_cls": cls.__name__}
                 else:
                         val['_cls'] = cls.__name__
+                        if "_id" in val: #Do not modify the original document for copying, but creates a new one.
+                                del( val['_id'] )
+
             if (isinstance(value, EmbeddedDocument)):
                 val['_cls'] = cls.__name__
             return val


### PR DESCRIPTION
### Use a copy if value is a document

myField = DynamicField(use_dbref=False)
### Use a DBRef if value is a Document

myField = DynamicField()
# or

myField = DynamicField(use_dbref=True)
### Example:

```
class Doc3(EmbeddedDocument):
    field_2 = StringField()

class Doc2(Document):
    field_1 = StringField()

class Doc(Document):
    my_id = IntField(required=True, unique=True, primary_key=True)
    embed_me = DynamicField()
    embed_me_nodbref = DynamicField(use_dbref=False)

    embed_me_ed = DynamicField()
    embed_me_ed_nodbref = DynamicField(use_dbref=False)

    field_x = StringField(db_field='x')

Doc.drop_collection()
Doc2.drop_collection()

doc3 = Doc3(field_2="hello2")
doc2 = Doc2(field_1="hello")
doc = Doc(my_id=1, 
    embed_me=doc2, 
    embed_me_nodbref=doc2, 
    embed_me_ed=doc3, 
    embed_me_ed_nodbref=doc3, 
    field_x="x")

doc2.save()
doc.save()

doc = Doc.objects.get()

print doc.embed_me_nodbref.field_1 == doc.embed_me.field_1 # True : hello = hello

doc.update(set__embed_me_nodbref__field_1 = "world")
doc.reload()

print doc.embed_me_nodbref.field_1 == doc.embed_me.field_1 # False : world = hello

print doc.embed_me_ed_nodbref.field_2 == doc.embed_me_ed.field_2# True hello2 = hello2
```
