### PR TITLE
Fixed bug for count method when _none is True

### DIFF
--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -331,7 +331,7 @@ class BaseQuerySet(object):
             :meth:`skip` that has been applied to this cursor into account when
             getting the count
         """
-        if self._limit == 0 and with_limit_and_skip:
+        if self._limit == 0 and with_limit_and_skip or self._none:
             return 0
         return self._cursor.count(with_limit_and_skip=with_limit_and_skip)
 


### PR DESCRIPTION
If my queryset have elements example:

qs.all().count() => 10
q = qs.all().none()

the count in queryset "q" must be 0
q.count() => 0
