### PR TITLE
Fix for issue #425

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -792,8 +792,17 @@ class BaseDocument(object):
                    # Look up subfield on the previous field
                     new_field = field.lookup_member(field_name)
                 if not new_field and isinstance(field, ComplexBaseField):
-                    fields.append(field_name)
-                    continue
+                    if hasattr(field.field, 'document_type') and cls._dynamic \
+                            and field.field.document_type._dynamic:
+                        DynamicField = _import_class('DynamicField')
+                        new_field = DynamicField(db_field=field_name)
+                    else:
+                        fields.append(field_name)
+                        continue
+                elif not new_field and hasattr(field, 'document_type') and cls._dynamic \
+                        and field.document_type._dynamic:
+                    DynamicField = _import_class('DynamicField')
+                    new_field = DynamicField(db_field=field_name)
                 elif not new_field:
                     raise LookUpError('Cannot resolve field "%s"'
                                       % field_name)

--- a/tests/document/dynamic.py
+++ b/tests/document/dynamic.py
@@ -292,6 +292,21 @@ class DynamicTest(unittest.TestCase):
         person.save()
         self.assertEqual(Person.objects.first().age, 35)
 
+    def test_dynamic_embedded_works_with_only(self):
+        """Ensure custom fieldnames on a dynamic embedded document are found by qs.only()"""
+
+        class Address(DynamicEmbeddedDocument):
+            city = StringField()
+
+        class Person(DynamicDocument):
+            address = EmbeddedDocumentField(Address)
+
+        Person.drop_collection()
+
+        Person(name="Eric", address=Address(city="San Francisco", street_number="1337")).save()
+
+        self.assertEqual(Person.objects.first().address.street_number, '1337')
+        self.assertEqual(Person.objects.only('address.street_number').first().address.street_number, '1337')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
 Allow undeclared fields in an embedded dynamic document to be seen by queryset methods.  Fix for issue #425.  (Per Ross's recommendation I required that the parent document also be dynamic for this to work; reversing this requirement is simple.)
