### PR TITLE
Add authentication_source option to register_connection (#573) (#580)

### DIFF
--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -20,7 +20,8 @@ _dbs = {}
 
 def register_connection(alias, name, host=None, port=None,
                         is_slave=False, read_preference=False, slaves=None,
-                        username=None, password=None, **kwargs):
+                        username=None, password=None, authentication_source=None,
+                        **kwargs):
     """Add a connection.
 
     :param alias: the name that will be used to refer to this connection
@@ -36,6 +37,7 @@ def register_connection(alias, name, host=None, port=None,
         be a registered connection that has :attr:`is_slave` set to ``True``
     :param username: username to authenticate with
     :param password: password to authenticate with
+    :param authentication_source: database to authenticate against
     :param kwargs: allow ad-hoc parameters to be passed into the pymongo driver
 
     """
@@ -46,10 +48,11 @@ def register_connection(alias, name, host=None, port=None,
         'host': host or 'localhost',
         'port': port or 27017,
         'is_slave': is_slave,
+        'read_preference': read_preference,
         'slaves': slaves or [],
         'username': username,
         'password': password,
-        'read_preference': read_preference
+        'authentication_source': authentication_source
     }
 
     # Handle uri style connections
@@ -99,6 +102,7 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
             conn_settings.pop('is_slave', None)
             conn_settings.pop('username', None)
             conn_settings.pop('password', None)
+            conn_settings.pop('authentication_source', None)
         else:
             # Get all the slave connections
             if 'slaves' in conn_settings:
@@ -137,7 +141,8 @@ def get_db(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
         # Authenticate if necessary
         if conn_settings['username'] and conn_settings['password']:
             db.authenticate(conn_settings['username'],
-                            conn_settings['password'])
+                            conn_settings['password'],
+                            source=conn_settings['authentication_source'])
         _dbs[alias] = db
     return _dbs[alias]
 


### PR DESCRIPTION
Since v2.5, PyMongo has supported a "source" option, to specify a
particular database to authenticate against. This adds support for that
option, in the form of a "authentication_source" option to
register_connection.
