### PR TITLE
Test to illustrate failure in changed attribute tracking

### DIFF
--- a/tests/document/delta.py
+++ b/tests/document/delta.py
@@ -735,5 +735,47 @@ class DeltaTest(unittest.TestCase):
         mydoc._clear_changed_fields()
         self.assertEqual([], mydoc._get_changed_fields())
 
+    def test_referenced_object_changed_attributes(self):
+        """Ensures that when you save a new reference to a field, the referenced object isn't altered"""
+
+        class Organization(Document):
+            name = StringField()
+
+        class User(Document):
+            name = StringField()
+            org = ReferenceField('Organization', required=True)
+
+        Organization.drop_collection()
+        User.drop_collection()
+
+        org1 = Organization(name='Org 1')
+        org1.save()
+
+        org2 = Organization(name='Org 2')
+        org2.save()
+
+        user = User(name='Fred', org=org1)
+        user.save()
+
+        org1.reload()
+        org2.reload()
+        user.reload()
+        self.assertEqual(org1.name, 'Org 1')
+        self.assertEqual(org2.name, 'Org 2')
+        self.assertEqual(user.name, 'Fred')
+
+        user.name = 'Harold'
+        user.org = org2
+
+        org2.name = 'New Org 2'
+        self.assertEqual(org2.name, 'New Org 2')
+
+        user.save()
+        org2.save()
+
+        self.assertEqual(org2.name, 'New Org 2')
+        org2.reload()
+        self.assertEqual(org2.name, 'New Org 2')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
It seems that commit d868cfdeb08ec2de046f0efac34ae735a4745b6f has introduced a bug.

When you alter a document, then use that document in a reference field of another document before saving it, the changed attributes metadata is reset, meaning when you **do** save, your changes aren't actually saved.

I used git bisect to find the commit indicated above (before that commit this test passes). This means that any version of mongoengine after v0.8.4 has this "bad" behaviour.

I'm not entirely sure how to go about fixing this bug (the code in the above commit looks like it requires some solid understanding of the internals) so I just made a pull request with this test which hopefully someone can use to fix the bug.
