### PR TITLE
Ability to clear the ordering

### DIFF
--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -50,7 +50,7 @@ class BaseQuerySet(object):
         self._initial_query = {}
         self._where_clause = None
         self._loaded_fields = QueryFieldList()
-        self._ordering = []
+        self._ordering = None
         self._snapshot = False
         self._timeout = True
         self._class_check = True
@@ -1189,8 +1189,9 @@ class BaseQuerySet(object):
             if self._ordering:
                 # Apply query ordering
                 self._cursor_obj.sort(self._ordering)
-            elif self._document._meta['ordering']:
-                # Otherwise, apply the ordering from the document model
+            elif self._ordering is None and self._document._meta['ordering']:
+                # Otherwise, apply the ordering from the document model, unless
+                # it's been explicitly cleared via order_by with no arguments
                 order = self._get_order_by(self._document._meta['ordering'])
                 self._cursor_obj.sort(order)
 


### PR DESCRIPTION
This PR adds the capability to clear the ordering - both the explicitly set one, and the default inherited from `_meta['ordering']`.
