### PR TITLE
Allow index specs to be composed from raw strings

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -666,8 +666,14 @@ class BaseDocument(object):
                 fields = []
             else:
                 fields = cls._lookup_field(parts)
-                parts = [field if field == '_id' else field.db_field
-                         for field in fields]
+                parts = []
+                for field in fields:
+                    try:
+                        if field != "_id":
+                            field = field.db_field
+                    except AttributeError:
+                        pass
+                    parts.append(field)
                 key = '.'.join(parts)
             index_list.append((key, direction))
 


### PR DESCRIPTION
I'd like to be able to use MongoEngine to create an index on arbitrary keys of a `DictField`, _e.g._:

```
class MyDoc(Document):
    provider_ids = DictField()
    meta = {
        "indexes": ["provider_ids.foo", "provider_ids.bar"],
    }
```

The use case is that I'm ingesting data from various providers and want to be able to track the id that each provider has assigned to the data in a `DictField`. I _could_ track the ids in separate top-level fields (`foo_id`, `bar_id`), but grouping them under a single `DictField` feels cleaner to me and makes it easier to `.exclude()` the ids when I don't need them.

Before this patch, attempting to specify an index with arbitrary keys fails with `AttributeError: 'str' object has no attribute 'db_field'`. If this patch looks like the right approach, I'll write up a test case and resubmit.
