### PR TITLE
Include preliminary support for text indexes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 Changes in 0.9.X - DEV
 ======================
 
+- Added preliminary support for text indexes #680
 - Added `elemMatch` operator as well - `match` is too obscure #653
 - Added support for progressive JPEG #486 #548
 - Allow strings to be used in index creation #675

--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -459,7 +459,8 @@ by creating a list of index specifications called :attr:`indexes` in the
 either be a single field name, a tuple containing multiple field names, or a
 dictionary containing a full index definition. A direction may be specified on
 fields by prefixing the field name with a **+** (for ascending) or a **-** sign
-(for descending). Note that direction only matters on multi-field indexes. ::
+(for descending). Note that direction only matters on multi-field indexes.
+Text indexes may be specified by prefixing the field name with a **$**. ::
 
     class Page(Document):
         title = StringField()

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -680,15 +680,18 @@ class BaseDocument(object):
             if isinstance(key, (list, tuple)):
                 continue
 
-            # ASCENDING from +,
+            # ASCENDING from +
             # DESCENDING from -
             # GEO2D from *
+            # TEXT from $
             direction = pymongo.ASCENDING
             if key.startswith("-"):
                 direction = pymongo.DESCENDING
             elif key.startswith("*"):
                 direction = pymongo.GEO2D
-            if key.startswith(("+", "-", "*")):
+            elif key.startswith("$"):
+                direction = pymongo.TEXT
+            if key.startswith(("+", "-", "*", "$")):
                 key = key[1:]
 
             # Use real field name, do it manually because we need field

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(name='mongoengine',
       long_description=LONG_DESCRIPTION,
       platforms=['any'],
       classifiers=CLASSIFIERS,
-      install_requires=['pymongo>=2.7'],
+      install_requires=['pymongo>=2.7.1'],
       test_suite='nose.collector',
       **extra_opts
 )

--- a/tests/document/indexes.py
+++ b/tests/document/indexes.py
@@ -727,7 +727,6 @@ class IndexesTest(unittest.TestCase):
                          report.to_mongo())
         self.assertEqual(report, Report.objects.get(pk=my_key))
 
-
     def test_string_indexes(self):
 
         class MyDoc(Document):
@@ -740,6 +739,19 @@ class IndexesTest(unittest.TestCase):
         info = [value['key'] for key, value in info.iteritems()]
         self.assertTrue([('provider_ids.foo', 1)] in info)
         self.assertTrue([('provider_ids.bar', 1)] in info)
+
+    def test_text_indexes(self):
+
+        class Book(Document):
+            title = DictField()
+            meta = {
+                "indexes": ["$title"],
+            }
+
+        indexes = Book.objects._collection.index_information()
+        self.assertTrue("title_text" in indexes)
+        key = indexes["title_text"]["key"]
+        self.assertTrue(('_fts', 'text') in key)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As the first pass at adding text index support to MongoEngine, here's a patch that lets you specify text indexes in the `Document.meta.indexes` field. To index a text field, prefix the field name with `$`, as in `$title`:

```
class Book(Document):
    title = StringField()
    meta = {
        "indexes": ["$title"],
    }
```
