### PR TITLE
Follow ReferenceFields in EmbeddedDocuments with select_related

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 Changes in 0.9.X - DEV
 ======================
 
+- Follow ReferenceFields in EmbeddedDocuments with select_related #690
 - Added preliminary support for text indexes #680
 - Added `elemMatch` operator as well - `match` is too obscure #653
 - Added support for progressive JPEG #486 #548

--- a/mongoengine/dereference.py
+++ b/mongoengine/dereference.py
@@ -95,7 +95,7 @@ class DeReference(object):
         # Recursively find dbreferences
         depth += 1
         for k, item in iterator:
-            if isinstance(item, Document):
+            if isinstance(item, (Document, EmbeddedDocument)):
                 for field_name, field in item._fields.iteritems():
                     v = item._data.get(field_name, None)
                     if isinstance(v, (DBRef)):
@@ -202,7 +202,7 @@ class DeReference(object):
 
             if k in self.object_map and not is_list:
                 data[k] = self.object_map[k]
-            elif isinstance(v, Document):
+            elif isinstance(v, (Document, EmbeddedDocument)):
                 for field_name, field in v._fields.iteritems():
                     v = data[k]._data.get(field_name, None)
                     if isinstance(v, (DBRef)):


### PR DESCRIPTION
For the following structure:

```
class Playlist(Document):
    items = ListField(EmbeddedDocumentField("PlaylistItem"))

class PlaylistItem(EmbeddedDocument):
    song = ReferenceField("Song")

class Song(Document):
    title = StringField()
```

this patch prevents the N+1 queries otherwise required to fetch all
the `Song` instances referenced by all the `PlaylistItem`s.
