### PR TITLE
let username and password be specified outside a uri

### DIFF
--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -56,7 +56,6 @@ def register_connection(alias, name, host=None, port=None,
             'name': uri_dict.get('database') or name,
             'username': uri_dict.get('username') or username,
             'password': uri_dict.get('password') or password,
-            'read_preference': read_preference,
         })
         if "replicaSet" in conn_settings['host']:
             conn_settings['replicaSet'] = True

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -54,8 +54,8 @@ def register_connection(alias, name, host=None, port=None,
         uri_dict = uri_parser.parse_uri(conn_settings['host'])
         conn_settings.update({
             'name': uri_dict.get('database') or name,
-            'username': uri_dict.get('username'),
-            'password': uri_dict.get('password'),
+            'username': uri_dict.get('username') or username,
+            'password': uri_dict.get('password') or password,
             'read_preference': read_preference,
         })
         if "replicaSet" in conn_settings['host']:

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -93,6 +93,7 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
             raise ConnectionError(msg)
         conn_settings = _connection_settings[alias].copy()
 
+        # These settings aren't used until we connect to a specific db
         conn_settings.pop('name', None)
         conn_settings.pop('username', None)
         conn_settings.pop('password', None)
@@ -112,6 +113,7 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
             connection = None
             connection_settings_iterator = ((alias, settings.copy()) for alias, settings in _connection_settings.iteritems())
             for alias, connection_settings in connection_settings_iterator:
+                # Need to pop these off as we did above so the dict comparison works
                 connection_settings.pop('name', None)
                 connection_settings.pop('username', None)
                 connection_settings.pop('password', None)

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -115,6 +115,7 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
                 connection_settings.pop('name', None)
                 connection_settings.pop('username', None)
                 connection_settings.pop('password', None)
+                connection_settings.pop('authentication_source', None)
                 if conn_settings == connection_settings and _connections.get(alias, None):
                     connection = _connections[alias]
                     break

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -111,6 +111,11 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
 
         try:
             connection = None
+            # This loop allows us to detect different alias' that connect to the same mongodb instance, and have them
+            # share a single pymongo object.
+            # Ie: alias 'production' and 'readOnly' connect to the same database, just with a different
+            # username/password. This would have both alias' use the same pymongo connection object, but still
+            # authenticate separately.
             connection_settings_iterator = ((alias, settings.copy()) for alias, settings in _connection_settings.iteritems())
             for alias, connection_settings in connection_settings_iterator:
                 # Need to pop these off as we did above so the dict comparison works

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -117,6 +117,11 @@ class ConnectionTest(unittest.TestCase):
         conn = connect(alias='test_uri_no_username', host='mongodb://localhost/mongoenginetest', username="username", password="password")
         self.assertTrue(isinstance(conn, pymongo.mongo_client.MongoClient))
 
+        # Since the mongodb instance used for testing doesn't require
+        # authentication (and turning that on breaks some 85 tests), and there
+        # doesn't appear to be any way to check to see if a connection has
+        # authenticated, I instead expose some internals of mongoengine to
+        # make sure the correct settings have been saved.
         self.assertEqual(me_connection._connection_settings['test_uri_no_username']['username'], 'username')
         self.assertEqual(me_connection._connection_settings['test_uri_no_username']['password'], 'password')
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -101,6 +101,29 @@ class ConnectionTest(unittest.TestCase):
         c.admin.system.users.remove({})
         c.mongoenginetest.system.users.remove({})
 
+    def test_connect_uri_without_username_password(self):
+        """Ensure that the connect() method works properly with a uri,
+        when the username/password is specified outside the uri
+        """
+        c = connect(db='mongoenginetest', alias='admin')
+        c.admin.system.users.remove({})
+        c.mongoenginetest.system.users.remove({})
+
+        c.admin.add_user("admin", "password")
+        c.admin.authenticate("admin", "password")
+        c.mongoenginetest.add_user("username", "password")
+
+        self.assertRaises(ConnectionError, connect, "testdb_uri_bad", host='mongodb://test:password@localhost')
+
+        conn = connect(alias='test_uri_no_username', host='mongodb://localhost/mongoenginetest', username="username", password="password")
+        self.assertTrue(isinstance(conn, pymongo.mongo_client.MongoClient))
+        db = get_db(alias='test_uri_no_username')
+        self.assertTrue(isinstance(db, pymongo.database.Database))
+        self.assertEqual(db.name, 'mongoenginetest')
+
+        c.admin.system.users.remove({})
+        c.mongoenginetest.system.users.remove({})
+
     def test_register_connection(self):
         """Ensure that connections with different aliases may be registered.
         """

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -14,6 +14,7 @@ from bson.tz_util import utc
 from mongoengine import *
 import mongoengine.connection
 from mongoengine.connection import get_db, get_connection, ConnectionError
+import mongoengine.connection as me_connection
 
 
 class ConnectionTest(unittest.TestCase):
@@ -115,6 +116,10 @@ class ConnectionTest(unittest.TestCase):
 
         conn = connect(alias='test_uri_no_username', host='mongodb://localhost/mongoenginetest', username="username", password="password")
         self.assertTrue(isinstance(conn, pymongo.mongo_client.MongoClient))
+
+        self.assertEqual(me_connection._connection_settings['test_uri_no_username']['username'], 'username')
+        self.assertEqual(me_connection._connection_settings['test_uri_no_username']['password'], 'password')
+
         db = get_db(alias='test_uri_no_username')
         self.assertTrue(isinstance(db, pymongo.database.Database))
         self.assertEqual(db.name, 'mongoenginetest')

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -122,6 +122,9 @@ class ConnectionTest(unittest.TestCase):
         # doesn't appear to be any way to check to see if a connection has
         # authenticated, I instead expose some internals of mongoengine to
         # make sure the correct settings have been saved.
+        # Without this, instead of the test failing everything would appear to
+        # work fine, but there would be no username/password on the
+        # connection.
         self.assertEqual(me_connection._connection_settings['test_uri_no_username']['username'], 'username')
         self.assertEqual(me_connection._connection_settings['test_uri_no_username']['password'], 'password')
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -113,8 +113,6 @@ class ConnectionTest(unittest.TestCase):
         c.admin.authenticate("admin", "password")
         c.mongoenginetest.add_user("username", "password")
 
-        self.assertRaises(ConnectionError, connect, "testdb_uri_bad", host='mongodb://test:password@localhost')
-
         conn = connect(alias='test_uri_no_username', host='mongodb://localhost/mongoenginetest', username="username", password="password")
         self.assertTrue(isinstance(conn, pymongo.mongo_client.MongoClient))
         db = get_db(alias='test_uri_no_username')


### PR DESCRIPTION
currently, if you use a uri without the username/password/db name inside it, ie:
`mongodb://host1.com:1337,host2.com:1337/`
it will pull the db name from the other args passed to connet():
`'name': uri_dict.get('database') or name,`
but the username and password specified in connect() will be overwritten with None:

```
'password': uri_dict.get('password'), # <---Returns None if no password was in the uri
'password': uri_dict.get('password'),
```

This forces anyone using a uri, say to make handling multiple nodes easier, to put their username and password into the uri. This isn't a huge problem, but forces some awkward manual string formatting in some setups, and there's no need for that.

I also removed a duplicate read_preference update.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/731)

<!-- Reviewable:end -->
