### PR TITLE
fix-#746: Stop ensure_indexes running on a secondaries unless connection...

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 Changes in 0.9.X - DEV
 ======================
+- Stop ensure_indexes running on a secondaries unless connection is through mongos #746
 - Not overriding default values when loading a subset of fields #399
 - Saving document doesn't create new fields in existing collection #620
 - Added `Queryset.aggregate` wrapper to aggregation framework #703

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -594,7 +594,9 @@ class Document(BaseDocument):
         index_cls = cls._meta.get('index_cls', True)
 
         collection = cls._get_collection()
-        if collection.read_preference > 1:
+        # 746: when connection is via mongos, the read preference is not necessarily an indication that
+        # this code runs on a secondary
+        if not collection.is_mongos and collection.read_preference > 1:
             return
 
         # determine if an index which we are creating includes


### PR DESCRIPTION
... is through mongos
