### PR TITLE
Fix multiple connections aliases being rewritten

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -53,6 +53,7 @@ Changes in 0.9.X - DEV
 - Make 'db' argument to connection optional #737
 - Allow atomic update for the entire `DictField` #742
 - Added MultiPointField, MultiLineField, MultiPolygonField
+- Fix multiple connections aliases being rewritten #748
 
 Changes in 0.8.7
 ================

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -111,13 +111,14 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
 
         try:
             connection = None
-            connection_settings_iterator = ((alias, settings.copy()) for alias, settings in _connection_settings.iteritems())
-            for alias, connection_settings in connection_settings_iterator:
+            # check for shared connections
+            connection_settings_iterator = ((db_alias, settings.copy()) for db_alias, settings in _connection_settings.iteritems())
+            for db_alias, connection_settings in connection_settings_iterator:
                 connection_settings.pop('name', None)
                 connection_settings.pop('username', None)
                 connection_settings.pop('password', None)
-                if conn_settings == connection_settings and _connections.get(alias, None):
-                    connection = _connections[alias]
+                if conn_settings == connection_settings and _connections.get(db_alias, None):
+                    connection = _connections[db_alias]
                     break
 
             _connections[alias] = connection if connection else connection_class(**conn_settings)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -147,6 +147,18 @@ class ConnectionTest(unittest.TestCase):
         date_doc = DateDoc.objects.first()
         self.assertEqual(d, date_doc.the_date)
 
+    def test_multiple_connection_settings(self):
+        connect('mongoenginetest', alias='t1', host="localhost")
+
+        connect('mongoenginetest2', alias='t2', host="127.0.0.1")
+
+        mongo_connections = mongoengine.connection._connections
+        self.assertEqual(len(mongo_connections.items()), 2)
+        self.assertTrue('t1' in mongo_connections.keys())
+        self.assertTrue('t2' in mongo_connections.keys())
+        self.assertEqual(mongo_connections['t1'].host, 'localhost')
+        self.assertEqual(mongo_connections['t2'].host, '127.0.0.1')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Multiple connections get overwritten with the most recent.
