### PR TITLE
MongoTestCase relies on "nose"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pymongo>=2.7.1
+nose


### PR DESCRIPTION
Otherwise you get;

```
ImportError: Failed to import test module: gleem.tests.test_booking
Traceback (most recent call last):
  File "/usr/lib/python2.7/unittest/loader.py", line 254, in _find_tests
    module = self._get_module_from_name(name)
  File "/usr/lib/python2.7/unittest/loader.py", line 232, in _get_module_from_name
    __import__(name)
  File "/mnt/ellie/ellie/gleem/tests/test_booking.py", line 2, in <module>
    from helpers import CommonTestCase
  File "/mnt/ellie/ellie/gleem/tests/helpers.py", line 3, in <module>
    from mongoengine.django.tests import MongoTestCase
  File "/home/vagrant/.virtualenvs/ellie/local/lib/python2.7/site-packages/mongoengine/django/tests.py", line 2, in <module>
    from nose.plugins.skip import SkipTest
ImportError: No module named nose.plugins.skip
```
