### PR TITLE
Fix #756, added has_perms method to mongoengine.django.auth.User.

### DIFF
--- a/mongoengine/django/auth.py
+++ b/mongoengine/django/auth.py
@@ -328,6 +328,18 @@ class User(Document):
         # Otherwise we need to check the backends.
         return _user_has_perm(self, perm, obj)
 
+
+    def has_perms(self, perm_list, obj=None):
+        """
+        Returns True if the user has each of the specified permissions. If
+        object is passed, it checks if the user has all required perms for this
+        object.
+        """
+        for perm in perm_list:
+            if not self.has_perm(perm, obj):
+                return False
+        return True
+
     def has_module_perms(self, app_label):
         """
         Returns True if the user has any permissions in the given app label.


### PR DESCRIPTION
mongoengine.django.auth.User is supposed to mirror django. contrib.auth. models.User but is missing the has_perms method and this interferes with user authentication in django-rest-framework.


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/757)
<!-- Reviewable:end -->
