### PR TITLE
class_prepared signal

### DIFF
--- a/mongoengine/base/metaclasses.py
+++ b/mongoengine/base/metaclasses.py
@@ -217,6 +217,7 @@ class DocumentMetaclass(type):
                        "field name" % field.name)
                 raise InvalidDocumentError(msg)
 
+        signals.class_prepared.send(new_class)
         return new_class
 
     def add_to_class(self, name, value):

--- a/mongoengine/signals.py
+++ b/mongoengine/signals.py
@@ -36,6 +36,7 @@ except ImportError:
 # not put signals in here.  Create your own namespace instead.
 _signals = Namespace()
 
+class_prepared = _signals.signal('class_prepared')
 pre_init = _signals.signal('pre_init')
 post_init = _signals.signal('post_init')
 pre_save = _signals.signal('pre_save')


### PR DESCRIPTION
Django-style class_prepared signal sent when document class is initialised. Useful for installing additional signals for document classes having specific properties (i.e. attributes or classmethods)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/768)

<!-- Reviewable:end -->
