### PR TITLE
Make `in_bulk()` respect `no_dereference()`

### DIFF
--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -619,7 +619,9 @@ class BaseQuerySet(object):
                 doc_map[doc['_id']] = self._get_as_pymongo(doc)
         else:
             for doc in docs:
-                doc_map[doc['_id']] = self._document._from_son(doc, only_fields=self.only_fields)
+                doc_map[doc['_id']] = self._document._from_son(doc,
+                        only_fields=self.only_fields,
+                        _auto_dereference=self._auto_dereference)
 
         return doc_map
 


### PR DESCRIPTION
The issue here is that the `in_bulk()` query set method does not honor `no_dereference()`, such that accessing attributes on items fetched in bulk always triggers a dereference, even if the programmer has asked for no dereferencing.

I'll write a test case if this looks like the way to fix this.

Possibly related to #372 and #517.
