### PR TITLE
_auto_id_field check on document update

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -46,8 +46,9 @@ class BaseDocument(object):
             # We only want named arguments.
             field = iter(self._fields_ordered)
             # If its an automatic id field then skip to the first defined field
-            if self._auto_id_field:
-                next(field)
+            if hasattr(self, '_auto_id_field'):
+                if self._auto_id_field:
+                    next(field)
             for value in args:
                 name = next(field)
                 if name in values:


### PR DESCRIPTION
First, I could have missed a config item in my class. If I did, just point me to the docs for it.

Now for my issue. For me I had a EmbeddedDocument class
```
class EventRaw(mongodb.EmbeddedDocument):
    timestamp = mongodb.DateTimeField(default=datetime.now)
    data = mongodb.ListField()
```

Which a document class is using.

```

class Events(mongodb.Document):
    events = mongodb.ListField(mongodb.EmbeddedDocumentField(EventRaw))
    date = mongodb.DateTimeField(default=datetime.now)
    ....
```
Which was giving me an error.
```
File "/usr/local/lib/python2.7/dist-packages/mongoengine/document.py", line 65, in __init__
    super(EmbeddedDocument, self).__init__(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/mongoengine/base/document.py", line 47, in __init__
    if self._auto_id_field:
AttributeError: 'EventRaw' object has no attribute '_auto_id_field'
```
My fix checks that the attribute is set before using it. An alternative is to fix instead in the EmbeddedDocument class.

My temporary fix was to set the auto id of the EventRaw class.
```
class EventRaw(mongodb.EmbeddedDocument):
    timestamp = mongodb.DateTimeField(default=datetime.now)
    data = mongodb.ListField()

    _auto_id_field = False
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/777)
<!-- Reviewable:end -->
