### PR TITLE
fix-#759: with_limit_and_skip for count should default like in pymongo

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 Changes in 0.9.X - DEV
 ======================
+- with_limit_and_skip for count should default like in pymongo #759
 - Querying by a field defined in a subclass raises InvalidQueryError #744
 - Add Support For MongoDB 2.6.X's maxTimeMS #778
 - abstract shouldn't be inherited in EmbeddedDocument # 789

--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -384,7 +384,7 @@ class BaseQuerySet(object):
             self._document, documents=results, loaded=True)
         return return_one and results[0] or results
 
-    def count(self, with_limit_and_skip=True):
+    def count(self, with_limit_and_skip=False):
         """Count the selected elements in the query.
 
         :param with_limit_and_skip (optional): take any :meth:`limit` or

--- a/mongoengine/queryset/queryset.py
+++ b/mongoengine/queryset/queryset.py
@@ -94,7 +94,7 @@ class QuerySet(BaseQuerySet):
             except StopIteration:
                 self._has_more = False
 
-    def count(self, with_limit_and_skip=True):
+    def count(self, with_limit_and_skip=False):
         """Count the selected elements in the query.
 
         :param with_limit_and_skip (optional): take any :meth:`limit` or

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -914,7 +914,7 @@ class QuerySetTest(unittest.TestCase):
         docs = docs[1:4]
         self.assertEqual('[<Doc: 1>, <Doc: 2>, <Doc: 3>]', "%s" % docs)
 
-        self.assertEqual(docs.count(), 3)
+        self.assertEqual(docs.count(with_limit_and_skip=True), 3)
         for doc in docs:
             self.assertEqual('.. queryset mid-iteration ..', repr(docs))
 
@@ -3244,7 +3244,7 @@ class QuerySetTest(unittest.TestCase):
         for i in xrange(10):
             Post(title="Post %s" % i).save()
 
-        self.assertEqual(5, Post.objects.limit(5).skip(5).count())
+        self.assertEqual(5, Post.objects.limit(5).skip(5).count(with_limit_and_skip=True))
 
         self.assertEqual(
             10, Post.objects.limit(5).skip(5).count(with_limit_and_skip=False))
@@ -4013,7 +4013,7 @@ class QuerySetTest(unittest.TestCase):
             self.assertEqual(100, people._len)  # Caused by list calling len
             self.assertEqual(q, 1)
 
-            people.count()  # count is cached
+            people.count(with_limit_and_skip=True)  # count is cached
             self.assertEqual(q, 1)
 
     def test_no_cached_queryset(self):
@@ -4109,7 +4109,7 @@ class QuerySetTest(unittest.TestCase):
         with query_counter() as q:
             self.assertEqual(q, 0)
 
-            self.assertEqual(users.count(), 7)
+            self.assertEqual(users.count(with_limit_and_skip=True), 7)
 
             for i, outer_user in enumerate(users):
                 self.assertEqual(outer_user.name, names[i])
@@ -4117,7 +4117,7 @@ class QuerySetTest(unittest.TestCase):
                 inner_count = 0
 
                 # Calling len might disrupt the inner loop if there are bugs
-                self.assertEqual(users.count(), 7)
+                self.assertEqual(users.count(with_limit_and_skip=True), 7)
 
                 for j, inner_user in enumerate(users):
                     self.assertEqual(inner_user.name, names[j])

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -170,7 +170,12 @@ class QuerySetTest(unittest.TestCase):
         """Ensure that a queryset and filters work as expected
         """
 
+        class LimitCountQuerySet(QuerySet):
+            def count(self, with_limit_and_skip=True):
+                return super(LimitCountQuerySet, self).count(with_limit_and_skip)
+
         class Note(Document):
+            meta = dict(queryset_class=LimitCountQuerySet)
             text = StringField()
 
         Note.drop_collection()


### PR DESCRIPTION
fixes #759 
