### PR TITLE
Fix KeyError on reload() from a DynamicDocument

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -212,3 +212,4 @@ that much better:
  * Axel Haustant (https://github.com/noirbizarre)
  * David Czarnecki (https://github.com/czarneckid)
  * Vyacheslav Murashkin (https://github.com/a4tunado)
+ * André Ericson (https://github.com/aericson)

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -543,7 +543,13 @@ class Document(BaseDocument):
 
         for field in self._fields_ordered:
             if not fields or field in fields:
-                setattr(self, field, self._reload(field, obj[field]))
+                try:
+                    setattr(self, field, self._reload(field, obj[field]))
+                except KeyError:
+                    # If field is removed from the database while the object
+                    # is in memory, a reload would cause a KeyError
+                    # i.e. obj.update(unset__field=1) followed by obj.reload()
+                    delattr(self, field)
 
         self._changed_fields = obj._changed_fields
         self._created = False

--- a/tests/document/dynamic.py
+++ b/tests/document/dynamic.py
@@ -81,6 +81,13 @@ class DynamicTest(unittest.TestCase):
         obj = collection.find_one()
         self.assertEqual(sorted(obj.keys()), ['_cls', '_id', 'name'])
 
+    def test_reload_after_unsetting(self):
+        p = self.Person()
+        p.misc = 22
+        p.save()
+        p.update(unset__misc=1)
+        p.reload()
+
     def test_dynamic_document_queries(self):
         """Ensure we can query dynamic fields"""
         p = self.Person()


### PR DESCRIPTION
If the document is in memory and a field is deleted from the db,
calling reload() would raise a KeyError.
