### PR TITLE
Better BaseDocument equality check when not saved

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -241,10 +241,12 @@ class BaseDocument(object):
         return txt_type('%s object' % self.__class__.__name__)
 
     def __eq__(self, other):
-        if isinstance(other, self.__class__) and hasattr(other, 'id'):
+        if isinstance(other, self.__class__) and hasattr(other, 'id') and other.id is not None:
             return self.id == other.id
         if isinstance(other, DBRef):
             return self._get_collection_name() == other.collection and self.id == other.id
+        if self.id is None:
+            return self is other
         return False
 
     def __ne__(self, other):

--- a/tests/document/instance.py
+++ b/tests/document/instance.py
@@ -2503,6 +2503,10 @@ class InstanceTest(unittest.TestCase):
             doc_name = StringField()
             doc = EmbeddedDocumentField(Embedded)
 
+            def __eq__(self, other):
+                return (self.doc_name == other.doc_name and
+                        self.doc == other.doc)
+
         classic_doc = Doc(doc_name="my doc", doc=Embedded(name="embedded doc"))
         dict_doc = Doc(**{"doc_name": "my doc",
                           "doc": {"name": "embedded doc"}})
@@ -2518,6 +2522,10 @@ class InstanceTest(unittest.TestCase):
         class Doc(Document):
             doc_name = StringField()
             docs = ListField(EmbeddedDocumentField(Embedded))
+
+            def __eq__(self, other):
+                return (self.doc_name == other.doc_name and
+                        self.docs == other.docs)
 
         classic_doc = Doc(doc_name="my doc", docs=[
                           Embedded(name="embedded doc1"),
@@ -2718,6 +2726,17 @@ class InstanceTest(unittest.TestCase):
         p4.save()
         self.assertEquals(p4.height, 189)
         self.assertEquals(Person.objects(height=189).count(), 1)
+
+    def test_not_saved_eq(self):
+        """Ensure we can compare documents not saved.
+        """
+        class Person(Document):
+            pass
+
+        p = Person()
+        p1 = Person()
+        self.assertNotEqual(p, p1)
+        self.assertEqual(p, p)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/document/json_serialisation.py
+++ b/tests/document/json_serialisation.py
@@ -51,6 +51,10 @@ class TestJson(unittest.TestCase):
             string = StringField()
             embedded_field = EmbeddedDocumentField(Embedded)
 
+            def __eq__(self, other):
+                return (self.string == other.string and
+                        self.embedded_field == other.embedded_field)
+
         doc = Doc(string="Hi", embedded_field=Embedded(string="Hi"))
 
         doc_json = doc.to_json(sort_keys=True, separators=(',', ':'))
@@ -98,6 +102,10 @@ class TestJson(unittest.TestCase):
             uuid_field = UUIDField(default=uuid.uuid4)
             generic_embedded_document_field = GenericEmbeddedDocumentField(
                                         default=lambda: EmbeddedDoc())
+
+            def __eq__(self, other):
+                import json
+                return json.loads(self.to_json()) == json.loads(other.to_json())
 
         doc = Doc()
         self.assertEqual(doc, Doc.from_json(doc.to_json()))


### PR DESCRIPTION
When 2 instances of a Document had id = None they would be considered
equal unless an __eq__ were implemented.

We now return False for such case. It now behaves more similar to
Django's ORM.
