### PR TITLE
Ensure Indexes before Each Save (Resolves #812)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,8 @@ Changelog
 
 Changes in 0.9.X - DEV
 ======================
-- Generate Unique Indicies for Lists of EmbeddedDocuments #358
+- Ensure Indexes before Each Save #812
+- Generate Unique Indices for Lists of EmbeddedDocuments #358
 - Sparse fields #515
 - write_concern not in params of Collection#remove #801
 - Better BaseDocument equality check when not saved #798

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -285,6 +285,8 @@ class Document(BaseDocument):
 
         try:
             collection = self._get_collection()
+            if self._meta.get('auto_create_index', True):
+                self.ensure_indexes()
             if created:
                 if force_insert:
                     object_id = collection.insert(doc, **write_concern)


### PR DESCRIPTION
#### Commit Details
- Rely on caching within the PyMongo driver to provide lightweight calls
  while indices are cached.
- Closes MongoEngine/mongoengine#812.
