### PR TITLE
Fix crash when applying deletion rules

### DIFF
--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -432,6 +432,8 @@ class BaseQuerySet(object):
         # references
         for rule_entry in delete_rules:
             document_cls, field_name = rule_entry
+            if document_cls._meta.get('abstract'):
+                continue
             rule = doc._meta['delete_rules'][rule_entry]
             if rule == DENY and document_cls.objects(
                     **{field_name + '__in': self}).count() > 0:
@@ -441,6 +443,8 @@ class BaseQuerySet(object):
 
         for rule_entry in delete_rules:
             document_cls, field_name = rule_entry
+            if document_cls._meta.get('abstract'):
+                continue
             rule = doc._meta['delete_rules'][rule_entry]
             if rule == CASCADE:
                 ref_q = document_cls.objects(**{field_name + '__in': self})


### PR DESCRIPTION
When deleting a document references by other, if that refence is
defined on an abstract document, the operation fails, because it tries
to apply deletion on the abstract class which doesn't have a QuerySet.

Fix is simply to ignore document classes which are defined abstract when
applying rules on all classes referencing the document.
