### PR TITLE
Fix #714, rebase version of #827

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -217,3 +217,4 @@ that much better:
  * Diego Berrocal (https://github.com/cestdiego)
  * Matthew Ellison (https://github.com/seglberg)
  * Jimmy Shen (https://github.com/jimmyshen)
+ * J. Fernando Sánchez (https://github.com/balkian)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -77,6 +77,7 @@ Changes in 0.9.X - DEV
 - Fixed a few instances where reverse_delete_rule was written as reverse_delete_rules. #791
 - Make `in_bulk()` respect `no_dereference()` #775
 - Handle None from model __str__; Fixes #753 #754
+- Update FileField when creating a new file #714
 
 Changes in 0.8.7
 ================

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -1357,6 +1357,7 @@ class GridFSProxy(object):
     def new_file(self, **kwargs):
         self.newfile = self.fs.new_file(**kwargs)
         self.grid_id = self.newfile._id
+        self._mark_as_changed()
 
     def put(self, file_obj, **kwargs):
         if self.grid_id:

--- a/tests/fields/file_tests.py
+++ b/tests/fields/file_tests.py
@@ -114,6 +114,42 @@ class FileTest(unittest.TestCase):
         # Ensure deleted file returns None
         self.assertTrue(result.the_file.read() == None)
 
+    def test_file_fields_stream_after_none(self):
+        """Ensure that a file field can be written to after it has been saved as
+        None
+        """
+        class StreamFile(Document):
+            the_file = FileField()
+
+        StreamFile.drop_collection()
+
+        text = b('Hello, World!')
+        more_text = b('Foo Bar')
+        content_type = 'text/plain'
+
+        streamfile = StreamFile()
+        streamfile.save()
+        streamfile.the_file.new_file()
+        streamfile.the_file.write(text)
+        streamfile.the_file.write(more_text)
+        streamfile.the_file.close()
+        streamfile.save()
+
+        result = StreamFile.objects.first()
+        self.assertTrue(streamfile == result)
+        self.assertEqual(result.the_file.read(), text + more_text)
+        #self.assertEqual(result.the_file.content_type, content_type)
+        result.the_file.seek(0)
+        self.assertEqual(result.the_file.tell(), 0)
+        self.assertEqual(result.the_file.read(len(text)), text)
+        self.assertEqual(result.the_file.tell(), len(text))
+        self.assertEqual(result.the_file.read(len(more_text)), more_text)
+        self.assertEqual(result.the_file.tell(), len(text + more_text))
+        result.the_file.delete()
+
+        # Ensure deleted file returns None
+        self.assertTrue(result.the_file.read() == None)
+
     def test_file_fields_set(self):
 
         class SetFile(Document):


### PR DESCRIPTION
The original commit to fix #714 was months old, so I rebased the changes from the updated master branch.

All tests pass in my environment, except for two that I couldn't get to work in mongoengine/master either:

```
ERROR: test_queryset_aggregation_framework (tests.QuerySetTest)
----------------------------------------------------------------------
OperationFailure: command SON([('aggregate', u'person'), ('pipeline', [{'$match': {'age': {'$lte': 22}}}, {'$project': {'name': {'$toUpper': '$name'}}}]), ('cursor', {})]) failed: unrecognized field "cursor

ERROR: test_text_indexes (tests.IndexesTest)
----------------------------------------------------------------------
OperationFailure: text search not enabled
```


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/833)
<!-- Reviewable:end -->
