### PR TITLE
Make BaseDict and BaseList work like dict and list

### DIFF
--- a/mongoengine/base/datastructures.py
+++ b/mongoengine/base/datastructures.py
@@ -13,7 +13,7 @@ class BaseDict(dict):
     _instance = None
     _name = None
 
-    def __init__(self, dict_items, instance, name):
+    def __init__(self, dict_items, instance=None, name=None):
         Document = _import_class('Document')
         EmbeddedDocument = _import_class('EmbeddedDocument')
 
@@ -95,7 +95,7 @@ class BaseList(list):
     _instance = None
     _name = None
 
-    def __init__(self, list_items, instance, name):
+    def __init__(self, list_items, instance=None, name=None):
         Document = _import_class('Document')
         EmbeddedDocument = _import_class('EmbeddedDocument')
 


### PR DESCRIPTION
Python's `dict()` and `list()` take one arg and optional kwargs,
but `BaseDict()` and `BaseList()` break that signature, causing
an incompatibility between MongoEngine and libraries like Bunch.

This commit changes the signature of the `BaseDict` and `BaseList`
constructors to make them compatible with their native `dict`
and `list` counterparts.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/850)

<!-- Reviewable:end -->
