### PR TITLE
ComplexDateTimeField should fallback to None if null=True

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -216,3 +216,4 @@ that much better:
  * Mikhail Moshnogorsky (https://github.com/mikhailmoshnogorsky)
  * Diego Berrocal (https://github.com/cestdiego)
  * Matthew Ellison (https://github.com/mmelliso)
+ * Jimmy Shen (https://github.com/jimmyshen)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -69,7 +69,7 @@ Changes in 0.9.X - DEV
 - Fixed a few instances where reverse_delete_rule was written as reverse_delete_rules. #791
 - Make `in_bulk()` respect `no_dereference()` #775
 - Handle None from model __str__; Fixes #753 #754
-
+- ComplexDateTimeField should fall back to None when null=True #864
 
 Changes in 0.8.7
 ================

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -510,7 +510,7 @@ class ComplexDateTimeField(StringField):
     def __get__(self, instance, owner):
         data = super(ComplexDateTimeField, self).__get__(instance, owner)
         if data is None:
-            return datetime.datetime.now()
+            return None if self.null else datetime.datetime.now()
         if isinstance(data, datetime.datetime):
             return data
         return self._convert_from_string(data)

--- a/tests/document/instance.py
+++ b/tests/document/instance.py
@@ -2760,6 +2760,12 @@ class InstanceTest(unittest.TestCase):
         class User(Document):
             name = StringField()
             height = IntField(default=184, null=True)
+            str_fld = StringField(null=True)
+            int_fld = IntField(null=True)
+            flt_fld = FloatField(null=True)
+            dt_fld = DateTimeField(null=True)
+            cdt_fld = ComplexDateTimeField(null=True)
+
         User.objects.delete()
         u = User(name='user')
         u.save()
@@ -2775,6 +2781,18 @@ class InstanceTest(unittest.TestCase):
         User.objects(name='user').update_one(set__height=None, upsert=True)
         u_from_db = User.objects.get(name='user')
         self.assertEquals(u_from_db.height, None)
+
+        # 864
+        User.objects.delete()
+        u = User(name='user')
+        u.save()
+        u_from_db = User.objects.get(name='user')
+
+        self.assertIsNone(u_from_db.str_fld)
+        self.assertIsNone(u_from_db.int_fld)
+        self.assertIsNone(u_from_db.flt_fld)
+        self.assertIsNone(u_from_db.dt_fld)
+        self.assertIsNone(u_from_db.cdt_fld)
 
     def test_not_saved_eq(self):
         """Ensure we can compare documents not saved.


### PR DESCRIPTION
Hi,

I was playing with the new 'null' behavior, which I would like to use in a project I'm working on. While messing with it on master, I noticed some inconsistency in the behavior with regard to DateTimeField and ComplexDateTimeField.

Here's a demonstration:

```python
def test_null_datetime_fields():
    class TestDoc(Document):
        dt_field = DateTimeField(null=True)
        cdt_field = ComplexDateTimeField(null=True)

    doc = TestDoc()
    doc.save()

    assert doc.dt_field is None
    assert doc.cdt_field is None
```

The cause seems to be related to some logic specific to ComplexDateTimeField that falls back to datetime.now on retrieval from db. I'm not sure what the motivation was for the different behavior between DateTimeField and ComplexDateTimeField -- it was introduced a long time ago and there's even a test to ensure it doesn't regress:

https://github.com/MongoEngine/mongoengine/commit/0187a0e1

Thoughts?