### PR TITLE
Fix #863: Request Support for $min, $max Field update operators

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 Changes in 0.9.X - DEV
 ======================
+- Request Support for $min, $max Field update operators #863
 - `BaseDict` does not follow `setdefault` #866
 - Add support for $type operator # 766
 - Fix tests for pymongo 2.8+ #877

--- a/mongoengine/queryset/transform.py
+++ b/mongoengine/queryset/transform.py
@@ -26,7 +26,7 @@ MATCH_OPERATORS = (COMPARISON_OPERATORS + GEO_OPERATORS +
 
 UPDATE_OPERATORS = ('set', 'unset', 'inc', 'dec', 'pop', 'push',
                     'push_all', 'pull', 'pull_all', 'add_to_set',
-                    'set_on_insert')
+                    'set_on_insert', 'min', 'max')
 
 
 def query(_doc_cls=None, _field_operation=False, **query):

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -510,6 +510,17 @@ class QuerySetTest(unittest.TestCase):
         self.assertEqual(post.comments[0].by, 'joe')
         self.assertEqual(post.comments[0].votes.score, 4)
 
+    def test_update_min_max(self):
+        class Scores(Document):
+            high_score = IntField()
+            low_score = IntField()
+        scores = Scores(high_score=800, low_score=200)
+        scores.save()
+        Scores.objects(id=scores.id).update(min__low_score=150)
+        self.assertEqual(Scores.objects(id=scores.id).get().low_score, 150)
+        Scores.objects(id=scores.id).update(min__low_score=250)
+        self.assertEqual(Scores.objects(id=scores.id).get().low_score, 150)
+
     def test_updates_can_have_match_operators(self):
 
         class Comment(EmbeddedDocument):


### PR DESCRIPTION
fixes #863 