### PR TITLE
Don't send a "cls" option to ensureIndex

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -119,7 +119,7 @@ that much better:
  * Anton Kolechkin
  * Sergey Nikitin
  * psychogenic
- * Stefan Wójcik
+ * Stefan Wójcik (https://github.com/wojcikstefan)
  * dimonb
  * Garry Polley
  * James Slagle
@@ -138,7 +138,6 @@ that much better:
  * hellysmile
  * Jaepil Jeong
  * Daniil Sharou
- * Stefan Wójcik
  * Pete Campton
  * Martyn Smith
  * Marcelo Anton

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,7 @@ Changes in 0.9.X - DEV
 - Fixed unpickled documents replacing the global field's list. #888
 - Fixed storage of microseconds in ComplexDateTimeField and unused separator option. #910
 - Django support was removed and will be available as a separate extension. #958
+- Don't send a "cls" option to ensureIndex (related to https://jira.mongodb.org/browse/SERVER-769)
 
 Changes in 0.9.0
 ================

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -677,6 +677,12 @@ class Document(BaseDocument):
                 cls_indexed = cls_indexed or includes_cls(fields)
                 opts = index_opts.copy()
                 opts.update(spec)
+
+                # we shouldn't pass 'cls' to the collection.ensureIndex options
+                # because of https://jira.mongodb.org/browse/SERVER-769
+                if 'cls' in opts:
+                    del opts['cls']
+
                 collection.ensure_index(fields, background=background,
                                         drop_dups=drop_dups, **opts)
 
@@ -684,6 +690,12 @@ class Document(BaseDocument):
         # only if another index doesn't begin with _cls
         if (index_cls and not cls_indexed and
                 cls._meta.get('allow_inheritance', ALLOW_INHERITANCE) is True):
+
+            # we shouldn't pass 'cls' to the collection.ensureIndex options
+            # because of https://jira.mongodb.org/browse/SERVER-769
+            if 'cls' in index_opts:
+                del index_opts['cls']
+
             collection.ensure_index('_cls', background=background,
                                     **index_opts)
 


### PR DESCRIPTION
We shouldn't send any options to `collection.ensureIndex` that aren't supported by the index spec. See the unit test for more details.

Related to https://jira.mongodb.org/browse/SERVER-769

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/900)
<!-- Reviewable:end -->
