### PR TITLE
Fix the unit tests for mongodb w/ profiling enabled

### DIFF
--- a/mongoengine/django/tests.py
+++ b/mongoengine/django/tests.py
@@ -23,7 +23,7 @@ class MongoTestCase(TestCase):
 
     def dropCollections(self):
         for collection in self.db.collection_names():
-            if collection == 'system.indexes':
+            if collection.startswith('system.'):
                 continue
             self.db.drop_collection(collection)
 


### PR DESCRIPTION
If you run MongoDB with profiling enabled, one of the tests fails with a following error:

```
======================================================================
ERROR: test_mongo_test_case (tests.test_django.MongoTestCaseTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "mongoengine/django/tests.py", line 31, in tearDown
    self.dropCollections()
  File "mongoengine/django/tests.py", line 28, in dropCollections
    self.db.drop_collection(collection)
  File "/Users/wojcikstefan/Repos/mongoengine/env/lib/python2.7/site-packages/pymongo/database.py", line 490, in drop_collection
    read_preference=ReadPreference.PRIMARY)
  File "/Users/wojcikstefan/Repos/mongoengine/env/lib/python2.7/site-packages/pymongo/database.py", line 439, in command
    uuid_subtype, compile_re, **kwargs)[0]
  File "/Users/wojcikstefan/Repos/mongoengine/env/lib/python2.7/site-packages/pymongo/database.py", line 345, in _command
    msg, allowable_errors)
  File "/Users/wojcikstefan/Repos/mongoengine/env/lib/python2.7/site-packages/pymongo/helpers.py", line 182, in _check_command_response
    raise OperationFailure(msg % errmsg, code, response)
OperationFailure: command SON([('drop', u'system.profile')]) on namespace test_dummy.$cmd failed: turn off profiling before dropping system.profile collection

----------------------------------------------------------------------
```

This PR fixes it.