### PR TITLE
Modified ReferenceField validation to accept instances of ObjectId.

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -1002,8 +1002,8 @@ class ReferenceField(BaseField):
 
     def validate(self, value):
 
-        if not isinstance(value, (self.document_type, DBRef)):
-            self.error("A ReferenceField only accepts DBRef or documents")
+        if not isinstance(value, (self.document_type, DBRef, ObjectId)):
+            self.error("A ReferenceField only accepts DBRef, ObjectId or documents")
 
         if isinstance(value, Document) and value.id is None:
             self.error('You can only reference documents once they have been '


### PR DESCRIPTION
Setting reference field to an object id by attribute was failing validation but setting when initializing the document functioned. I allowed ObjectId to pass validation. to_python already works with ObjectId with or without the dbref flag and all tests pass with this change.

This corrects issue #902.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/903)

<!-- Reviewable:end -->
