### PR TITLE
Added authentication mechanism support. Transport mechanism to pymongo d...

### DIFF
--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -138,9 +138,21 @@ def get_db(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
         db = conn[conn_settings['name']]
         # Authenticate if necessary
         if conn_settings['username'] and conn_settings['password']:
-            db.authenticate(conn_settings['username'],
-                            conn_settings['password'],
-                            source=conn_settings['authentication_source'])
+            # PyMongo new signature include mechanism an MongoDB 3 as default
+            # have SCRAM-SHA-1. To can get back compatibility use
+            # 'authmechanism'
+            # as extra arguments with connect or register_connection methods.
+            args = {
+                'name': conn_settings['username'],
+                'password': conn_settings['password'],
+                'source': conn_settings['authentication_source']
+            }
+
+            if 'authmechanism' in conn_settings:
+                args['mechanism'] = conn_settings['authmechanism']
+
+            db.authenticate(**args)
+
         _dbs[alias] = db
     return _dbs[alias]
 


### PR DESCRIPTION
...river authmechanism config using kwargs. It is need to get connectivity with MongoDB 3 because Mongoengine doesn't send mechanism and MongoDB on version 3 has as default SSL.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/905)

<!-- Reviewable:end -->
