### PR TITLE
ListField of embedded docs doesn't set the _instance attribute when iterating over it

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 Changes in 0.9.X - DEV
 ======================
+- ListField of embedded docs doesn't set the _instance attribute when iterating over it #914
 - Support += and *= for ListField #595
 
 Changes in 0.9.0

--- a/mongoengine/base/datastructures.py
+++ b/mongoengine/base/datastructures.py
@@ -125,6 +125,10 @@ class BaseList(list):
             value._instance = self._instance
         return value
 
+    def __iter__(self):
+        for i in xrange(self.__len__()):
+            yield self[i]
+
     def __setitem__(self, key, value, *args, **kwargs):
         if isinstance(key, slice):
             self._mark_as_changed()

--- a/tests/document/instance.py
+++ b/tests/document/instance.py
@@ -2799,5 +2799,21 @@ class InstanceTest(unittest.TestCase):
         self.assertNotEqual(p, p1)
         self.assertEqual(p, p)
 
+    def test_list_iter(self):
+        # 914
+        class B(EmbeddedDocument):
+            v = StringField()
+
+        class A(Document):
+            l = ListField(EmbeddedDocumentField(B))
+
+        A.objects.delete()
+        A(l=[B(v='1'), B(v='2'), B(v='3')]).save()
+        a = A.objects.get()
+        self.assertEqual(a.l._instance, a)
+        for idx, b in enumerate(a.l):
+            self.assertEqual(b._instance, a)
+        self.assertEqual(idx, 2)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
fixes #914 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/920)
<!-- Reviewable:end -->
