### PR TITLE
Major dereferencing optimizations and fix for de-pickling outdated documents

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -218,3 +218,4 @@ that much better:
  * Matthew Ellison (https://github.com/seglberg)
  * Jimmy Shen (https://github.com/jimmyshen)
  * J. Fernando Sánchez (https://github.com/balkian)
+ * Michael Chase (https://github.com/rxsegrxup)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,13 @@ Changelog
 
 Changes in 0.9.X - DEV
 ======================
+- ListField of embedded docs doesn't set the _instance attribute when iterating over it #914
+- Support += and *= for ListField #595
+- Use sets for populating dbrefs to dereference
+- Fixed unpickled documents replacing the global field's list. #888
+
+Changes in 0.9.0
+================
 - Update FileField when creating a new file #714
 - Added `EmbeddedDocumentListField` for Lists of Embedded Documents. #826
 - ComplexDateTimeField should fall back to None when null=True #864

--- a/mongoengine/base/datastructures.py
+++ b/mongoengine/base/datastructures.py
@@ -125,6 +125,10 @@ class BaseList(list):
             value._instance = self._instance
         return value
 
+    def __iter__(self):
+        for i in xrange(self.__len__()):
+            yield self[i]
+
     def __setitem__(self, key, value, *args, **kwargs):
         if isinstance(key, slice):
             self._mark_as_changed()
@@ -155,6 +159,14 @@ class BaseList(list):
     def __setstate__(self, state):
         self = state
         return self
+
+    def __iadd__(self, other):
+        self._mark_as_changed()
+        return super(BaseList, self).__iadd__(other)
+
+    def __imul__(self, other):
+        self._mark_as_changed()
+        return super(BaseList, self).__imul__(other)
 
     def append(self, *args, **kwargs):
         self._mark_as_changed()

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -206,7 +206,12 @@ class BaseDocument(object):
             if k in data:
                 setattr(self, k, data[k])
         if '_fields_ordered' in data:
-            setattr(type(self), '_fields_ordered', data['_fields_ordered'])
+            if self._dynamic:
+                setattr(self, '_fields_ordered', data['_fields_ordered'])
+            else:
+                _super_fields_ordered = type(self)._fields_ordered
+                setattr(self, '_fields_ordered', _super_fields_ordered)
+
         dynamic_fields = data.get('_dynamic_fields') or SON()
         for k in dynamic_fields.keys():
             setattr(self, k, data["_data"].get(k))

--- a/tests/document/instance.py
+++ b/tests/document/instance.py
@@ -10,6 +10,7 @@ import uuid
 
 from datetime import datetime
 from bson import DBRef, ObjectId
+from tests import fixtures
 from tests.fixtures import (PickleEmbedded, PickleTest, PickleSignalsTest,
                             PickleDyanmicEmbedded, PickleDynamicTest)
 
@@ -2084,6 +2085,31 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(resurrected, pickle_doc)
         self.assertEqual(pickle_doc.string, "Two")
         self.assertEqual(pickle_doc.lists, ["1", "2", "3"])
+
+    def test_regular_document_pickle(self):
+
+        pickle_doc = PickleTest(number=1, string="One", lists=['1', '2'])
+        pickled_doc = pickle.dumps(pickle_doc)  # make sure pickling works even before the doc is saved
+        pickle_doc.save()
+
+        pickled_doc = pickle.dumps(pickle_doc)
+
+        # Test that when a document's definition changes the new
+        # definition is used
+        fixtures.PickleTest = fixtures.NewDocumentPickleTest
+        self.assertIn('new_field', fixtures.PickleTest._fields_ordered)
+
+        resurrected = pickle.loads(pickled_doc)
+        self.assertEqual(resurrected.__class__,
+                         fixtures.NewDocumentPickleTest)
+        self.assertEqual(resurrected._fields_ordered,
+                         fixtures.NewDocumentPickleTest._fields_ordered)
+        self.assertNotEqual(resurrected._fields_ordered,
+                            pickle_doc._fields_ordered)
+
+        # The local PickleTest is still a ref to the original
+        fixtures.PickleTest = PickleTest
+        self.assertNotIn('new_field', fixtures.PickleTest._fields_ordered)
 
     def test_dynamic_document_pickle(self):
 

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -946,6 +946,18 @@ class FieldTest(unittest.TestCase):
             BlogPost.objects.filter(info__0__test__exact='5').count(), 0)
         self.assertEqual(
             BlogPost.objects.filter(info__100__test__exact='test').count(), 0)
+
+        post = BlogPost()
+        post.info = ['1', '2']
+        post.save()
+        post = BlogPost.objects(info=['1', '2']).get()
+        post.info += ['3', '4']
+        post.save()
+        self.assertEqual(BlogPost.objects(info=['1', '2', '3', '4']).count(), 1)
+        post = BlogPost.objects(info=['1', '2', '3', '4']).get()
+        post.info *= 2
+        post.save()
+        self.assertEqual(BlogPost.objects(info=['1', '2', '3', '4', '1', '2', '3', '4']).count(), 1)
         BlogPost.drop_collection()
 
     def test_list_field_passed_in_value(self):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -17,6 +17,15 @@ class PickleTest(Document):
     photo = FileField()
 
 
+class NewDocumentPickleTest(Document):
+    number = IntField()
+    string = StringField(choices=(('One', '1'), ('Two', '2')))
+    embedded = EmbeddedDocumentField(PickleEmbedded)
+    lists = ListField(StringField())
+    photo = FileField()
+    new_field = StringField()
+
+
 class PickleDyanmicEmbedded(DynamicEmbeddedDocument):
     date = DateTimeField(default=datetime.now)
 


### PR DESCRIPTION
Fixes #888:
 - When de-pickling a document that is **not** dynamic, the _fields_ordered of the current type should be used
- When de-pickling a document that **is** dynamic, the pickled _fields_ordered should be used for the current document **ONLY**

Dereferencing Optimizations:
 - Compiles the set of dbrefs as a set instead of a list so that conversions don't need to be made later
 - Checks for resolved objects via dict `x in dict` instead of list `x in list`.

Below is a preview of how the dereferencing optimizations improved loading 500 documents:

name | # of operations | name | # or operations
------- | ---- | -------- | ---
..bson/objectid.py:288 ObjectId.__eq__ | 250998 | ..bson/objectid.py:288 ObjectId.__eq__  | 998

(This output was generated by GreenletProfiler)

The left shows the master branches performance when retrieving 500 documents all of which have 2 referenced fields.
The right shows the same when using this pull request. 
Please note that the left displays O(n^2) where as the right displays O(n). Although the average time for each operation is `0.000005` (not shown above) as n increases this time becomes incredibly large.
I found this issue when compiling 67,000 records took **1 hour**

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/921)
<!-- Reviewable:end -->
