### PR TITLE
complex field

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -693,7 +693,8 @@ class BaseDocument(object):
                     default = default()
                 if isinstance(default, BaseDocument):
                     changed_fields.append(field_name)
-                elif not only_fields or field_name in only_fields:
+                elif (not isinstance(field, ComplexBaseField) and
+                        (not only_fields or field_name in only_fields)):
                     changed_fields.append(field_name)
 
         if errors_dict:

--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -214,8 +214,8 @@ class ComplexBaseField(BaseField):
         GenericReferenceField = _import_class('GenericReferenceField')
         EmbeddedDocumentListField = _import_class('EmbeddedDocumentListField')
         dereference = (self._auto_dereference and
-                       (self.field is None or isinstance(self.field,
-                                                         (GenericReferenceField, ReferenceField))))
+                       self.field and
+                       isinstance(self.field, (GenericReferenceField, ReferenceField)))
 
         _dereference = _import_class("DeReference")()
 

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -677,6 +677,8 @@ class DynamicField(ComplexBaseField):
             if '_ref' in value:
                 value = doc_cls._get_db().dereference(value['_ref'])
             return doc_cls._from_son(value)
+        if isinstance(value, BaseDocument):
+            return value
 
         return super(DynamicField, self).to_python(value)
 

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -630,7 +630,7 @@ class GenericEmbeddedDocumentField(BaseField):
         return data
 
 
-class DynamicField(BaseField):
+class DynamicField(ComplexBaseField):
 
     """A truly dynamic field type capable of handling different and varying
     types of data.


### PR DESCRIPTION
1 do not mark complex field as changed when parse from son
2 change DynamicField to subclass from ComplexField

1: since no data actually store in db, then no need to append it to changed_fields, otherwise when call save method without changes, they will appear in removals set unnecessarily
2: as metioned: https://github.com/MongoEngine/mongoengine/issues/889#issuecomment-86858273

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/924)

<!-- Reviewable:end -->
