### PR TITLE
mark_as_changed issue

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -220,3 +220,4 @@ that much better:
  * J. Fernando Sánchez (https://github.com/balkian)
  * Michael Chase (https://github.com/rxsegrxup)
  * Eremeev Danil (https://github.com/elephanter)
+ * Catstyle Lee (https://github.com/Catstyle)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 Changes in 0.9.X - DEV
 ======================
+- Fixed mark_as_changed to handle higher/lower level fields changed. #927
 - ListField of embedded docs doesn't set the _instance attribute when iterating over it #914
 - Support += and *= for ListField #595
 - Use sets for populating dbrefs to dereference

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -483,7 +483,19 @@ class BaseDocument(object):
             key = self._db_field_map.get(key, key)
 
         if key not in self._changed_fields:
-            self._changed_fields.append(key)
+            levels, idx = key.split('.'), 1
+            while idx <= len(levels):
+                if '.'.join(levels[:idx]) in self._changed_fields:
+                    break
+                idx += 1
+            else:
+                self._changed_fields.append(key)
+                # remove lower level changed fields
+                level = '.'.join(levels[:idx]) + '.'
+                remove = self._changed_fields.remove
+                for field in self._changed_fields:
+                    if field.startswith(level):
+                        remove(field)
 
     def _clear_changed_fields(self):
         """Using get_changed_fields iterate and remove any fields that are


### PR DESCRIPTION
fix mark_as_changed: rm lower level changed fields otherwise may cause conflict update error
this issue appears when retrieve from db

``` python
In [34]: class Foo(mongoengine.Document):
    
    bar = mongoengine.DictField()
   ....:     

In [35]: Foo.objects.delete()
Out[35]: 1

In [36]: foo = Foo()

In [37]: foo.save()
Out[37]: <Foo: Foo object>

In [38]: foo = Foo.objects.first()

In [39]: foo.bar['what'] = 'ever'

In [40]: foo.bar['other'] = {}

In [41]: foo._changed_fields
Out[41]: ['bar.what', 'bar.other']

In [42]: foo.bar['other']['what'] = 'ever'

In [43]: foo._changed_fields
Out[43]: ['bar.what', 'bar.other', 'bar.other.what']

In [44]: foo.save()
---------------------------------------------------------------------------
OperationError                            Traceback (most recent call last)
<ipython-input-44-e6645f54a3c0> in <module>()
----> 1 foo.save()

.../mongoengine/document.pyc in save(self, force_insert, validate, clean, write_concern, cascade, cascade_kwargs, _refs, save_condition, **kwargs)
    365                 message = u'Tried to save duplicate unique keys (%s)'
    366                 raise NotUniqueError(message % unicode(err))
--> 367             raise OperationError(message % unicode(err))
    368         id_field = self._meta['id_field']
    369         if created or id_field not in self._meta.get('shard_key', []):

OperationError: Could not save document (Cannot update 'bar.other' and 'bar.other.what' at the same time)
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/927)
<!-- Reviewable:end -->
