### PR TITLE
Updated setup.py to limit pymongo version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(name='mongoengine',
       long_description=LONG_DESCRIPTION,
       platforms=['any'],
       classifiers=CLASSIFIERS,
-      install_requires=['pymongo>=2.7.1'],
+      install_requires=['pymongo>=2.7.1, < 3.0.0'],
       test_suite='nose.collector',
       **extra_opts
 )


### PR DESCRIPTION
Currently mongoengine doesn't support pymongo 3.0.0

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/945)
<!-- Reviewable:end -->
