### PR TITLE
Major dereferencing optimizations and fix for de-pickling outdated documents [migrated 921]

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -218,3 +218,4 @@ that much better:
  * Matthew Ellison (https://github.com/seglberg)
  * Jimmy Shen (https://github.com/jimmyshen)
  * J. Fernando Sánchez (https://github.com/balkian)
+ * Michael Chase (https://github.com/rxsegrxup)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,8 @@ Changes in 0.9.X - DEV
 ======================
 - ListField of embedded docs doesn't set the _instance attribute when iterating over it #914
 - Support += and *= for ListField #595
+- Use sets for populating dbrefs to dereference
+- Fixed unpickled documents replacing the global field's list. #888
 
 Changes in 0.9.0
 ================

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -206,7 +206,12 @@ class BaseDocument(object):
             if k in data:
                 setattr(self, k, data[k])
         if '_fields_ordered' in data:
-            setattr(type(self), '_fields_ordered', data['_fields_ordered'])
+            if self._dynamic:
+                setattr(self, '_fields_ordered', data['_fields_ordered'])
+            else:
+                _super_fields_ordered = type(self)._fields_ordered
+                setattr(self, '_fields_ordered', _super_fields_ordered)
+
         dynamic_fields = data.get('_dynamic_fields') or SON()
         for k in dynamic_fields.keys():
             setattr(self, k, data["_data"].get(k))

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -17,6 +17,15 @@ class PickleTest(Document):
     photo = FileField()
 
 
+class NewDocumentPickleTest(Document):
+    number = IntField()
+    string = StringField(choices=(('One', '1'), ('Two', '2')))
+    embedded = EmbeddedDocumentField(PickleEmbedded)
+    lists = ListField(StringField())
+    photo = FileField()
+    new_field = StringField()
+
+
 class PickleDyanmicEmbedded(DynamicEmbeddedDocument):
     date = DateTimeField(default=datetime.now)
 


### PR DESCRIPTION
Fixes #888:
 - When de-pickling a document that is **not** dynamic, the _fields_ordered of the current type should be used
- When de-pickling a document that **is** dynamic, the pickled _fields_ordered should be used for the current document **ONLY**

Dereferencing Optimizations:
 - Compiles the set of dbrefs as a set instead of a list so that conversions don't need to be made later
 - Checks for resolved objects via dict `x in dict` instead of list `x in list`.

Below is a preview of how the dereferencing optimizations improved loading 500 documents:

name | # of operations | name | # or operations
------- | ---- | -------- | ---
..bson/objectid.py:288 ObjectId.__eq__ | 250998 | ..bson/objectid.py:288 ObjectId.__eq__  | 998

(This output was generated by GreenletProfiler)

The left shows the master branches performance when retrieving 500 documents all of which have 2 referenced fields.
The right shows the same when using this pull request. 
Please note that the left displays O(n^2) where as the right displays O(n). Although the average time for each operation is `0.000005` (not shown above) as n increases this time becomes incredibly large.
I found this issue when compiling 67,000 records took **1 hour**

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/947)
<!-- Reviewable:end -->
