### PR TITLE
Fixes #934 - Added option to disable field existence check.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -221,3 +221,4 @@ that much better:
  * Michael Chase (https://github.com/rxsegrxup)
  * Eremeev Danil (https://github.com/elephanter)
  * Catstyle Lee (https://github.com/Catstyle)
+ * Thomas Gordon Lowrey IV (https://github.com/gordol)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 Changes in 0.9.X - DEV
 ======================
+- Added Document meta option to restore backwards compatibility of allowing data to be loaded from a Mongo collection which contains fields that are undefined in the Document model. #953
 - Fixed mark_as_changed to handle higher/lower level fields changed. #927
 - ListField of embedded docs doesn't set the _instance attribute when iterating over it #914
 - Support += and *= for ListField #595

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -70,7 +70,7 @@ class BaseDocument(object):
 
         signals.pre_init.send(self.__class__, document=self, values=values)
 
-        __ignore_undefined_fields = values.pop("__ignore_undefined_fields", False)
+        __ignore_undefined_fields = self._meta.get("ignore_undefined_fields", False)
 
         # Check if there are undefined fields supplied, if so raise an
         # Exception.
@@ -672,7 +672,7 @@ class BaseDocument(object):
         return cls._meta.get('collection', None)
 
     @classmethod
-    def _from_son(cls, son, _auto_dereference=True, only_fields=None, created=False, ignore_undefined_fields=True):
+    def _from_son(cls, son, _auto_dereference=True, only_fields=None, created=False):
         """Create an instance of a Document (subclass) from a PyMongo SON.
         """
         if not only_fields:
@@ -724,7 +724,7 @@ class BaseDocument(object):
         if cls.STRICT:
             data = dict((k, v)
                         for k, v in data.iteritems() if k in cls._fields)
-        obj = cls(__auto_convert=False, _created=created, __only_fields=only_fields, __ignore_undefined_fields=ignore_undefined_fields, **data)
+        obj = cls(__auto_convert=False, _created=created, __only_fields=only_fields, **data)
         obj._changed_fields = changed_fields
         if not _auto_dereference:
             obj._fields = fields

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -70,9 +70,11 @@ class BaseDocument(object):
 
         signals.pre_init.send(self.__class__, document=self, values=values)
 
+        __ignore_undefined_fields = values.pop("__ignore_undefined_fields", False)
+
         # Check if there are undefined fields supplied, if so raise an
         # Exception.
-        if not self._dynamic:
+        if not self._dynamic and not __ignore_undefined_fields:
             for var in values.keys():
                 if var not in self._fields.keys() + ['id', 'pk', '_cls', '_text_score']:
                     msg = (
@@ -670,7 +672,7 @@ class BaseDocument(object):
         return cls._meta.get('collection', None)
 
     @classmethod
-    def _from_son(cls, son, _auto_dereference=True, only_fields=None, created=False):
+    def _from_son(cls, son, _auto_dereference=True, only_fields=None, created=False, ignore_undefined_fields=True):
         """Create an instance of a Document (subclass) from a PyMongo SON.
         """
         if not only_fields:
@@ -722,7 +724,7 @@ class BaseDocument(object):
         if cls.STRICT:
             data = dict((k, v)
                         for k, v in data.iteritems() if k in cls._fields)
-        obj = cls(__auto_convert=False, _created=created, __only_fields=only_fields, **data)
+        obj = cls(__auto_convert=False, _created=created, __only_fields=only_fields, __ignore_undefined_fields=ignore_undefined_fields, **data)
         obj._changed_fields = changed_fields
         if not _auto_dereference:
             obj._fields = fields

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -70,7 +70,7 @@ class BaseDocument(object):
 
         signals.pre_init.send(self.__class__, document=self, values=values)
 
-        __ignore_undefined_fields = self._meta.get("ignore_undefined_fields", False)
+        __ignore_undefined_fields = values.pop("__ignore_undefined_fields", False)
 
         # Check if there are undefined fields supplied, if so raise an
         # Exception.
@@ -675,6 +675,9 @@ class BaseDocument(object):
     def _from_son(cls, son, _auto_dereference=True, only_fields=None, created=False):
         """Create an instance of a Document (subclass) from a PyMongo SON.
         """
+
+        ignore_undefined_fields = cls._meta.get("ignore_undefined_fields", False)
+
         if not only_fields:
             only_fields = []
 
@@ -724,7 +727,7 @@ class BaseDocument(object):
         if cls.STRICT:
             data = dict((k, v)
                         for k, v in data.iteritems() if k in cls._fields)
-        obj = cls(__auto_convert=False, _created=created, __only_fields=only_fields, **data)
+        obj = cls(__auto_convert=False, _created=created, __only_fields=only_fields, __ignore_undefined_fields=ignore_undefined_fields, **data)
         obj._changed_fields = changed_fields
         if not _auto_dereference:
             obj._fields = fields

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -3174,7 +3174,7 @@ class FieldTest(unittest.TestCase):
 
     def test_undefined_field_allowed_read(self):
         """
-        Test read from data wtih undefined fields #934 #953
+        Test read from data with undefined fields #934 #953
         """
 
         class A(Document):
@@ -3196,7 +3196,7 @@ class FieldTest(unittest.TestCase):
 
     def test_undefined_field_not_allowed_read(self):
         """
-        Test read from data wtih undefined fields #934 #953
+        Test read from data with undefined fields #934 #953
         """
 
         class A(Document):

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -3172,6 +3172,86 @@ class FieldTest(unittest.TestCase):
         self.assertRaises(FieldDoesNotExist, test)
 
 
+    def test_undefined_field_allowed_read(self):
+        """
+        Test read from data wtih undefined fields #934 #953
+        """
+
+        class A(Document):
+            test = StringField(required=True)
+            test2 = StringField(required=True)
+            meta = {'collection': 'undefined_test'}
+
+        class B(Document):
+            test = StringField(required=True)
+            meta = {'collection': 'undefined_test', 'ignore_undefined_fields': True}
+
+        a = A()
+        a.test = 'one'
+        a.test2 = 'two'
+        a.save()
+
+        try:
+            b = B.objects.get()
+            self.assertEqual(b.test, a.test)
+        except Exception:
+            self.fail()
+
+    def test_undefined_field_not_allowed_read(self):
+        """
+        Test read from data wtih undefined fields #934 #953
+        """
+
+        class A(Document):
+            test = StringField(required=True)
+            test2 = StringField(required=True)
+            meta = {'collection': 'undefined_test'}
+
+        class B(Document):
+            test = StringField(required=True)
+            meta = {'collection': 'undefined_test'}
+
+        a = A()
+        a.test = 'one'
+        a.test2 = 'two'
+        a.save()
+
+        def test():
+            b = B.objects.get()
+
+        self.assertRaises(FieldDoesNotExist, test)
+
+
+    def test_undefined_field_allowed_write(self):
+        """
+        Test write to undefined fields
+        """
+
+        class A(Document):
+            test = StringField(required=True)
+            meta = {'ignore_undefined_fields': True}
+
+        def test():
+            A(test2='test')
+
+        self.assertRaises(FieldDoesNotExist, test)
+
+    def test_undefined_field_not_allowed_write(self):
+        """
+        Test write to undefined fields
+        """
+
+        class A(Document):
+            test = StringField(required=True)
+
+        def test():
+            A(test2='test')
+
+        self.assertRaises(FieldDoesNotExist, test)
+
+
+
+
 class EmbeddedDocumentListFieldTestCase(unittest.TestCase):
 
     @classmethod

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -3191,11 +3191,8 @@ class FieldTest(unittest.TestCase):
         a.test2 = 'two'
         a.save()
 
-        try:
-            b = B.objects.get()
-            self.assertEqual(b.test, a.test)
-        except Exception:
-            self.fail()
+        b = B.objects.get()
+        self.assertEqual(b.test, a.test)
 
     def test_undefined_field_not_allowed_read(self):
         """


### PR DESCRIPTION

I threw together this patch as an idea to fix #934.

I haven't dug too deep into Mongoengine to know what else this might affect, but I used _from_son in BaseDocument object as my injection point. The idea being that if one tries to define in code a field that does not exist, an error is still raised, but if one pulls in data from a PyMongo object, we don't raise an error.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/953)
<!-- Reviewable:end -->
