### PR TITLE
Allow to loads undeclared field with meta attribute (fix #934)

### DIFF
--- a/docs/apireference.rst
+++ b/docs/apireference.rst
@@ -34,6 +34,9 @@ Documents
 .. autoclass:: mongoengine.ValidationError
   :members:
 
+.. autoclass:: mongoengine.FieldDoesNotExist
+
+
 Context Managers
 ================
 

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -70,9 +70,9 @@ class BaseDocument(object):
 
         signals.pre_init.send(self.__class__, document=self, values=values)
 
-        # Check if there are undefined fields supplied, if so raise an
-        # Exception.
-        if not self._dynamic and self._meta.get('strict', True):
+        # Check if there are undefined fields supplied to the constructor,
+        # if so raise an Exception.
+        if not self._dynamic and (self._meta.get('strict', True) or _created):
             for var in values.keys():
                 if var not in self._fields.keys() + ['id', 'pk', '_cls', '_text_score']:
                     msg = (

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -72,7 +72,7 @@ class BaseDocument(object):
 
         # Check if there are undefined fields supplied, if so raise an
         # Exception.
-        if not self._dynamic:
+        if not self._dynamic and self._meta.get('strict', True):
             for var in values.keys():
                 if var not in self._fields.keys() + ['id', 'pk', '_cls', '_text_score']:
                     msg = (

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -135,6 +135,11 @@ class Document(BaseDocument):
     doesn't contain a list) if allow_inheritance is True. This can be
     disabled by either setting cls to False on the specific index or
     by setting index_cls to False on the meta dictionary for the document.
+
+    By default, any extra attribute existing in stored data but not declared
+    in your model will raise a :class:`~mongoengine.FieldDoesNotExist` error.
+    This can be disabled by setting :attr:`strict` to ``False``
+    in the :attr:`meta` dictionnary.
     """
 
     # The __metaclass__ attribute is removed by 2to3 when running with Python3

--- a/mongoengine/errors.py
+++ b/mongoengine/errors.py
@@ -42,7 +42,14 @@ class NotUniqueError(OperationError):
 
 
 class FieldDoesNotExist(Exception):
-    pass
+    """Raised when trying to set a field
+    not declared in a :class:`~mongoengine.Document`
+    or an :class:`~mongoengine.EmbeddedDocument`.
+
+    To avoid this behavior on data loading,
+    you should the :attr:`strict` to ``False``
+    in the :attr:`meta` dictionnary.
+    """
 
 
 class ValidationError(AssertionError):

--- a/tests/document/instance.py
+++ b/tests/document/instance.py
@@ -2480,8 +2480,7 @@ class InstanceTest(unittest.TestCase):
             'data': [1, 2, 3]
         })
 
-        with self.assertRaises(FieldDoesNotExist):
-            User.objects.first()
+        self.assertRaises(FieldDoesNotExist, User.objects.first)
 
     def test_load_undefined_fields_with_strict_false(self):
         class User(Document):
@@ -2523,8 +2522,7 @@ class InstanceTest(unittest.TestCase):
             }
         })
 
-        with self.assertRaises(FieldDoesNotExist):
-            User.objects.first()
+        self.assertRaises(FieldDoesNotExist, User.objects.first)
 
     def test_load_undefined_fields_on_embedded_document_with_strict_false_on_doc(self):
         class Thing(EmbeddedDocument):
@@ -2547,8 +2545,7 @@ class InstanceTest(unittest.TestCase):
             }
         })
 
-        with self.assertRaises(FieldDoesNotExist):
-            User.objects.first()
+        self.assertRaises(FieldDoesNotExist, User.objects.first)
 
     def test_load_undefined_fields_on_embedded_document_with_strict_false(self):
         class Thing(EmbeddedDocument):

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -3160,7 +3160,7 @@ class FieldTest(unittest.TestCase):
 
     def test_undefined_field_exception(self):
         """Tests if a `FieldDoesNotExist` exception is raised when trying to
-        set a value to a field that's not defined.
+        instanciate a document with a field that's not defined.
         """
 
         class Doc(Document):

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -3171,6 +3171,21 @@ class FieldTest(unittest.TestCase):
 
         self.assertRaises(FieldDoesNotExist, test)
 
+    def test_undefined_field_exception_with_strict(self):
+        """Tests if a `FieldDoesNotExist` exception is raised when trying to
+        instanciate a document with a field that's not defined,
+        even when strict is set to False.
+        """
+
+        class Doc(Document):
+            foo = StringField(db_field='f')
+            meta = {'strict': False}
+
+        def test():
+            Doc(bar='test')
+
+        self.assertRaises(FieldDoesNotExist, test)
+
 
 class EmbeddedDocumentListFieldTestCase(unittest.TestCase):
 


### PR DESCRIPTION
This pull request try to fix #934 by adding an optionnal meta attribute: `strict`.

This attribute disable field existence check on data load, but not on constructor calls.

It also document both behaviors.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/957)
<!-- Reviewable:end -->
