### PR TITLE
Tox support for cross-versions testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
 - sudo apt-get install python-dev python3-dev libopenjpeg-dev zlib1g-dev libjpeg-turbo8-dev
   libtiff4-dev libjpeg8-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev
   python-tk
-- travis_retry pip install tox>=1.9
+- travis_retry pip install tox>=1.9 coveralls
 script:
 - tox -e $(echo py$TRAVIS_PYTHON_VERSION-mg$PYMONGO-dj$DJANGO | tr -d . | sed -e 's/pypypy/pypy/') -- --with-coverage
 after_script: coveralls --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,30 +8,11 @@ python:
 - pypy
 - pypy3
 env:
-- PYMONGO=2.7 DJANGO=dev
-- PYMONGO=2.7 DJANGO=1.8
-- PYMONGO=2.7 DJANGO=1.7
-- PYMONGO=2.7 DJANGO=1.6
-- PYMONGO=2.7 DJANGO=1.5
-- PYMONGO=2.8 DJANGO=dev
-- PYMONGO=2.8 DJANGO=1.8
-- PYMONGO=2.8 DJANGO=1.7
-- PYMONGO=2.8 DJANGO=1.6
-- PYMONGO=2.8 DJANGO=1.5
+- PYMONGO=2.7
+- PYMONGO=2.8
+# - PYMONGO=3.0
+# - PYMONGO=dev
 matrix:
-  exclude:
-  - python: '2.6'
-    env: PYMONGO=2.7 DJANGO=dev
-  - python: '2.6'
-    env: PYMONGO=2.8
-  - python: '2.6'
-    env: PYMONGO=2.7 DJANGO=1.7
-  - python: '2.6'
-    env: PYMONGO=2.8 DJANGO=1.7
-  - python: '2.6'
-    env: PYMONGO=2.7 DJANGO=1.8
-  - python: '2.6'
-    env: PYMONGO=2.8 DJANGO=1.8
   fast_finish: true
 before_install:
 - travis_retry sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
@@ -44,9 +25,9 @@ install:
   libtiff4-dev libjpeg8-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev
   python-tk
 - travis_retry pip install tox>=1.9 coveralls
-- travis_retry tox -e $(echo py$TRAVIS_PYTHON_VERSION-mg$PYMONGO-dj$DJANGO | tr -d . | sed -e 's/pypypy/pypy/') -- -e test
+- travis_retry tox -e $(echo py$TRAVIS_PYTHON_VERSION-mg$PYMONGO | tr -d . | sed -e 's/pypypy/pypy/') -- -e test
 script:
-- tox -e $(echo py$TRAVIS_PYTHON_VERSION-mg$PYMONGO-dj$DJANGO | tr -d . | sed -e 's/pypypy/pypy/') -- --with-coverage
+- tox -e $(echo py$TRAVIS_PYTHON_VERSION-mg$PYMONGO | tr -d . | sed -e 's/pypypy/pypy/') -- --with-coverage
 after_script: coveralls --verbose
 notifications:
   irc: irc.freenode.org#mongoengine

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
   python-tk
 - travis_retry pip install tox>=1.9 coveralls
 script:
-- tox -e $(echo py$TRAVIS_PYTHON_VERSION-mg$PYMONGO-dj$DJANGO | tr -d . | sed -e 's/pypypy/pypy/') -- --with-coverage
+- travis_retry tox -e $(echo py$TRAVIS_PYTHON_VERSION-mg$PYMONGO-dj$DJANGO | tr -d . | sed -e 's/pypypy/pypy/') -- --with-coverage
 after_script: coveralls --verbose
 notifications:
   irc: irc.freenode.org#mongoengine

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
   python-tk
 - travis_retry pip install tox>=1.9
 script:
-- tox -e $(echo py$TRAVIS_PYTHON_VERSION-mg$PYMONGO-dj$DJANGO | tr -d . | sed -e 's/pypypy/pypy/') -- with-coverage
+- tox -e $(echo py$TRAVIS_PYTHON_VERSION-mg$PYMONGO-dj$DJANGO | tr -d . | sed -e 's/pypypy/pypy/') -- --with-coverage
 after_script: coveralls --verbose
 notifications:
   irc: irc.freenode.org#mongoengine

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,20 +8,30 @@ python:
 - pypy
 - pypy3
 env:
-- PYMONGO=2.7.2
-- PYMONGO=2.8
+- PYMONGO=2.7 DJANGO=dev
+- PYMONGO=2.7 DJANGO=1.8
+- PYMONGO=2.7 DJANGO=1.7
+- PYMONGO=2.7 DJANGO=1.6
+- PYMONGO=2.7 DJANGO=1.5
+- PYMONGO=2.8 DJANGO=dev
+- PYMONGO=2.8 DJANGO=1.8
+- PYMONGO=2.8 DJANGO=1.7
+- PYMONGO=2.8 DJANGO=1.6
+- PYMONGO=2.8 DJANGO=1.5
 matrix:
   exclude:
   - python: '2.6'
-    env: PYMONGO=2.7.2 
+    env: PYMONGO=2.7 DJANGO=dev
   - python: '2.6'
     env: PYMONGO=2.8
   - python: '2.6'
-    env: PYMONGO=2.7.2
+    env: PYMONGO=2.7 DJANGO=1.7
   - python: '2.6'
-    env: PYMONGO=2.8
-  allow_failures:
-  - python: pypy3
+    env: PYMONGO=2.8 DJANGO=1.7
+  - python: '2.6'
+    env: PYMONGO=2.7 DJANGO=1.8
+  - python: '2.6'
+    env: PYMONGO=2.8 DJANGO=1.8
   fast_finish: true
 before_install:
 - travis_retry sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
@@ -33,19 +43,9 @@ install:
 - sudo apt-get install python-dev python3-dev libopenjpeg-dev zlib1g-dev libjpeg-turbo8-dev
   libtiff4-dev libjpeg8-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev
   python-tk
-- if [[ $PYMONGO == 'dev' ]]; then travis_retry pip install https://github.com/mongodb/mongo-python-driver/tarball/master;
-  true; fi
-- if [[ $PYMONGO != 'dev' ]]; then travis_retry pip install pymongo==$PYMONGO; true;
-  fi
-- travis_retry pip install https://pypi.python.org/packages/source/p/python-dateutil/python-dateutil-2.1.tar.gz#md5=1534bb15cf311f07afaa3aacba1c028b
-- travis_retry pip install coveralls
-- travis_retry python setup.py install
+- travis_retry pip install tox>=1.9
 script:
-- travis_retry python setup.py test
-- if [[ $TRAVIS_PYTHON_VERSION == '3.'* ]]; then 2to3 . -w; fi;
-- coverage run --source=mongoengine setup.py test
-- coverage report -m
-- python benchmark.py
+- tox -e $(echo py$TRAVIS_PYTHON_VERSION-mg$PYMONGO-dj$DJANGO | tr -d . | sed -e 's/pypypy/pypy/') -- with-coverage
 after_script: coveralls --verbose
 notifications:
   irc: irc.freenode.org#mongoengine

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,9 @@ install:
   libtiff4-dev libjpeg8-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev
   python-tk
 - travis_retry pip install tox>=1.9 coveralls
+- travis_retry tox -e $(echo py$TRAVIS_PYTHON_VERSION-mg$PYMONGO-dj$DJANGO | tr -d . | sed -e 's/pypypy/pypy/') -- -e test
 script:
-- travis_retry tox -e $(echo py$TRAVIS_PYTHON_VERSION-mg$PYMONGO-dj$DJANGO | tr -d . | sed -e 's/pypypy/pypy/') -- --with-coverage
+- tox -e $(echo py$TRAVIS_PYTHON_VERSION-mg$PYMONGO-dj$DJANGO | tr -d . | sed -e 's/pypypy/pypy/') -- --with-coverage
 after_script: coveralls --verbose
 notifications:
   irc: irc.freenode.org#mongoengine

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -44,7 +44,7 @@ General Guidelines
 - Avoid backward breaking changes if at all possible.
 - Write inline documentation for new classes and methods.
 - Write tests and make sure they pass (make sure you have a mongod
-  running on the default port, then execute ``python setup.py test``
+  running on the default port, then execute ``python setup.py nosetests``
   from the cmd line to run the test suite).
 - Ensure tests pass on every Python and PyMongo versions.
   You can test on these versions locally by executing ``tox``

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -46,6 +46,8 @@ General Guidelines
 - Write tests and make sure they pass (make sure you have a mongod
   running on the default port, then execute ``python setup.py test``
   from the cmd line to run the test suite).
+- Ensure tests pass on every Python and PyMongo versions.
+  You can test on these versions locally by executing ``tox``
 - Add yourself to AUTHORS :)
 
 Documentation

--- a/README.rst
+++ b/README.rst
@@ -38,12 +38,11 @@ Dependencies
 
 Optional Dependencies
 ---------------------
-- **Django Integration:** Django>=1.4.0 for Python 2.x or PyPy and Django>=1.5.0 for Python 3.x
 - **Image Fields**: Pillow>=2.0.0
 - dateutil>=2.1.0
 
 .. note
-   MongoEngine always runs it's test suite against the latest patch version of each dependecy. e.g.: Django 1.6.5
+   MongoEngine always runs it's test suite against the latest patch version of each dependecy. e.g.: PyMongo 3.0.1
 
 Examples
 ========

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,10 @@ tox and each supported Python version should be installed in your environment:
 If you wish to run one single or selected tests, use the nosetest convention. It will find the folder,
 eventually the file, go to the TestClass specified after the colon and eventually right to the single test.
 Also use the -s argument if you want to print out whatever or access pdb while testing.
-``python setup.py nosetests --tests tests/test_django.py:QuerySetTest.test_get_document_or_404 -s``
+
+.. code-block:: shell
+
+    $ python setup.py nosetests --tests tests/test_django.py:QuerySetTest.test_get_document_or_404 -s
 
 Community
 =========

--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,7 @@ Some simple examples of what MongoEngine code looks like::
 Tests
 =====
 To run the test suite, ensure you are running a local instance of MongoDB on
-the standard port, and run: ``python setup.py test``.
+the standard port, and run: ``python setup.py nosetests``.
 
 To run the test suite on every supported Python version and every supported PyMongo version,
 you can use ``tox``.

--- a/README.rst
+++ b/README.rst
@@ -8,10 +8,10 @@ MongoEngine
 
 .. image:: https://secure.travis-ci.org/MongoEngine/mongoengine.png?branch=master
   :target: http://travis-ci.org/MongoEngine/mongoengine
-  
-.. image:: https://coveralls.io/repos/MongoEngine/mongoengine/badge.png?branch=master 
+
+.. image:: https://coveralls.io/repos/MongoEngine/mongoengine/badge.png?branch=master
   :target: https://coveralls.io/r/MongoEngine/mongoengine?branch=master
-  
+
 .. image:: https://landscape.io/github/MongoEngine/mongoengine/master/landscape.png
    :target: https://landscape.io/github/MongoEngine/mongoengine/master
    :alt: Code Health
@@ -97,6 +97,17 @@ Tests
 =====
 To run the test suite, ensure you are running a local instance of MongoDB on
 the standard port, and run: ``python setup.py test``.
+
+To run the test suite on every supported Python version and every supported PyMongo version,
+you can use ``tox``.
+tox and each supported Python version should be installed in your environment:
+
+.. code-block:: shell
+
+    # Install tox
+    $ pip install tox
+    # Run the test suites
+    $ tox
 
 Community
 =========

--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,11 @@ tox and each supported Python version should be installed in your environment:
     # Run the test suites
     $ tox
 
+If you wish to run one single or selected tests, use the nosetest convention. It will find the folder,
+eventually the file, go to the TestClass specified after the colon and eventually right to the single test.
+Also use the -s argument if you want to print out whatever or access pdb while testing.
+``python setup.py nosetests --tests tests/test_django.py:QuerySetTest.test_get_document_or_404 -s``
+
 Community
 =========
 - `MongoEngine Users mailing list

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,5 +7,6 @@ detailed-errors = 1
 #cover-html-dir = ../htmlcov
 #cover-package = mongoengine
 py3where = build
-where = tests
+#where = tests
+tests = tests
 #tests =  document/__init__.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,9 @@
 [nosetests]
-verbosity = 3
+rednose = 1
+verbosity = 2
 detailed-errors = 1
-#with-coverage = 1
-#cover-erase = 1
-#cover-html = 1
-#cover-html-dir = ../htmlcov
-#cover-package = mongoengine
+cover-erase = 1
+cover-branches = 1
+cover-package = mongoengine
 py3where = build
-#where = tests
-tests = tests
-#tests =  document/__init__.py
+where = tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,5 +5,4 @@ detailed-errors = 1
 cover-erase = 1
 cover-branches = 1
 cover-package = mongoengine
-py3where = build
-where = tests
+tests = tests

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ init = os.path.join(os.path.dirname(__file__), 'mongoengine', '__init__.py')
 version_line = list(filter(lambda l: l.startswith('VERSION'), open(init)))[0]
 
 VERSION = get_version(eval(version_line.split('=')[-1]))
-print(VERSION)
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
@@ -79,5 +78,6 @@ setup(name='mongoengine',
       classifiers=CLASSIFIERS,
       install_requires=['pymongo>=2.7.1'],
       test_suite='nose.collector',
+      setup_requires=['nose', 'rednose'],  # Allow proper nose usage with setuptols and tox
       **extra_opts
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py27,py32,py33,py34,pypy,pypy3}-{mg27,mg28,mg30}-{dj15,dj16,dj17,djdev},
+    {py27,py32,py33,py34,pypy,pypy3}-{mg27,mg28,mg30}-{dj15,dj16,dj17,dj18,djdev},
     py26-{mg27,mg28,mg30}-{dj15,dj16}
 
 [testenv]
@@ -14,4 +14,5 @@ deps =
     dj15: Django<1.6
     dj16: Django>=1.6,<1.7
     dj17: Django>=1.7,<1.8
+    dj18: Django>=1.8,<1.9
     djdev: https://github.com/django/django/tarball/master

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist =
+    {py27,py32,py33,py34,pypy,pypy3}-{mg27,mg28,mg30}-{dj15,dj16,dj17,djdev},
+    py26-{mg27,mg28,mg30}-{dj15,dj16}
+
+[testenv]
+commands =
+    python setup.py test
+deps =
+    mg27: PyMongo<2.8
+    mg28: PyMongo>=2.8,<3.0
+    mg30: PyMongo>=3.0
+    mgdev: https://github.com/mongodb/mongo-python-driver/tarball/master
+    dj15: Django<1.6
+    dj16: Django>=1.6,<1.7
+    dj17: Django>=1.7,<1.8
+    djdev: https://github.com/django/django/tarball/master

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
 
 [testenv]
 commands =
-    python setup.py test
+    python setup.py nosetests {posargs}
 deps =
     mg27: PyMongo<2.8
     mg28: PyMongo>=2.8,<3.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
-envlist =
-    {py27,py32,py33,py34,pypy,pypy3}-{mg27,mg28,mg30}-{dj15,dj16,dj17,dj18,djdev},
-    py26-{mg27,mg28,mg30}-{dj15,dj16}
+envlist = {py26,py27,py32,py33,py34,pypy,pypy3}-{mg27,mg28}
+#envlist = {py26,py27,py32,py33,py34,pypy,pypy3}-{mg27,mg28,mg30,mgdev}
 
 [testenv]
 commands =
@@ -11,8 +10,3 @@ deps =
     mg28: PyMongo>=2.8,<3.0
     mg30: PyMongo>=3.0
     mgdev: https://github.com/mongodb/mongo-python-driver/tarball/master
-    dj15: Django<1.6
-    dj16: Django>=1.6,<1.7
-    dj17: Django>=1.7,<1.8
-    dj18: Django>=1.8,<1.9
-    djdev: https://github.com/django/django/tarball/master


### PR DESCRIPTION
Mongoengine is tested on different PyMongo versions, different Python versions...
This pull-request add a ``tox.ini`` file allowing to run the test suite on every supported version composition .
This allow to do proper testing before submitting pull-requests without having to wait for TravisCI cross-versions testing.

To run the test in tox, simply run:
```shell
$ tox
```

It will create a virtualenv for each combination and run the same test suite (like TravisCI).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/960)
<!-- Reviewable:end -->
