### PR TITLE
Fixes and tests for default 'id' field creation in Document metaclass

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,7 @@ Changes in 0.9.X - DEV
 - Fix for issue where FileField deletion did not free space in GridFS. 
 - No_dereference() not respected on embedded docs containing reference. #517
 - Document save raise an exception if save_condition fails #1005
+- Fixes some internal _id handling issue. #961
 
 Changes in 0.9.0
 ================

--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -310,7 +310,7 @@ Dealing with deletion of referred documents
 By default, MongoDB doesn't check the integrity of your data, so deleting
 documents that other documents still hold references to will lead to consistency
 issues.  Mongoengine's :class:`ReferenceField` adds some functionality to
-safeguard against these kinds of database integrit2y problems, providing each
+safeguard against these kinds of database integrity problems, providing each
 reference with a delete rule specification.  A delete rule is specified by
 supplying the :attr:`reverse_delete_rule` attributes on the
 :class:`ReferenceField` definition, like this::

--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -310,7 +310,7 @@ Dealing with deletion of referred documents
 By default, MongoDB doesn't check the integrity of your data, so deleting
 documents that other documents still hold references to will lead to consistency
 issues.  Mongoengine's :class:`ReferenceField` adds some functionality to
-safeguard against these kinds of database integrity problems, providing each
+safeguard against these kinds of database integrit2y problems, providing each
 reference with a delete rule specification.  A delete rule is specified by
 supplying the :attr:`reverse_delete_rule` attributes on the
 :class:`ReferenceField` definition, like this::

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -184,7 +184,7 @@ class BaseDocument(object):
             self__initialised = False
         # Check if the user has created a new instance of a class
         if (self._is_document and self__initialised
-                and self__created and name == self._meta['id_field']):
+                and self__created and name == self._meta.get('id_field')):
             super(BaseDocument, self).__setattr__('_created', False)
 
         super(BaseDocument, self).__setattr__(name, value)

--- a/mongoengine/base/metaclasses.py
+++ b/mongoengine/base/metaclasses.py
@@ -390,10 +390,16 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
             new_class._fields['id'] = ObjectIdField(db_field='_id')
             new_class._fields['id'].name = 'id'
             new_class.id = new_class._fields['id']
-
-        # Prepend id field to _fields_ordered
-        if 'id' in new_class._fields and 'id' not in new_class._fields_ordered:
-            new_class._fields_ordered = ('id', ) + new_class._fields_ordered
+            new_class._db_field_map['id'] = '_id'
+            new_class._reverse_db_field_map['_id'] = 'id'
+            if 'id' in new_class._fields_ordered:
+                # An existing id field will be overwritten anyway, so remove it
+                loc = new_class._fields_ordered.index('id')
+                new_class._fields_ordered = new_class._fields_ordered[:loc] + \
+                                            new_class._fields_ordered[loc+1:]
+            else:
+                # Prepend id field to _fields_ordered
+                new_class._fields_ordered = ('id', ) + new_class._fields_ordered
 
         # Merge in exceptions with parent hierarchy
         exceptions_to_merge = (DoesNotExist, MultipleObjectsReturned)

--- a/mongoengine/base/metaclasses.py
+++ b/mongoengine/base/metaclasses.py
@@ -418,8 +418,8 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
         id_basename, id_db_basename, i = 'auto_id', '_auto_id', 0
         while id_name in self._fields or \
                 id_db_name in (v.db_field for v in self._fields.values()):
-            id_name = '{}_{}'.format(id_basename, i)
-            id_db_name = '{}_{}'.format(id_db_basename, i)
+            id_name = '{0}_{1}'.format(id_basename, i)
+            id_db_name = '{0}_{1}'.format(id_db_basename, i)
             i += 1
         return id_name, id_db_name
 

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -152,6 +152,8 @@ class Document(BaseDocument):
         """
 
         def fget(self):
+            if not 'id_field' in self._meta:
+                return None
             return getattr(self, self._meta['id_field'])
 
         def fset(self, value):

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -152,7 +152,7 @@ class Document(BaseDocument):
         """
 
         def fget(self):
-            if not 'id_field' in self._meta:
+            if 'id_field' not in self._meta:
                 return None
             return getattr(self, self._meta['id_field'])
 

--- a/tests/document/inheritance.py
+++ b/tests/document/inheritance.py
@@ -316,13 +316,29 @@ class InheritanceTest(unittest.TestCase):
 
         class EuropeanCity(City):
             name = StringField()
-            country = StringField()
 
         berlin = EuropeanCity(name='Berlin', continent='Europe')
         self.assertEqual(len(berlin._db_field_map), len(berlin._fields_ordered))
         self.assertEqual(len(berlin._reverse_db_field_map), len(berlin._fields_ordered))
-        self.assertEqual(len(berlin._fields_ordered), 4)
+        self.assertEqual(len(berlin._fields_ordered), 3)
         self.assertEqual(berlin._fields_ordered[0], 'id')
+
+    def test_auto_id_not_set_if_specific_in_parent_class(self):
+
+        class City(Document):
+            continent = StringField()
+            city_id = IntField(primary_key=True)
+            meta = {'abstract': True,
+                    'allow_inheritance': False}
+
+        class EuropeanCity(City):
+            name = StringField()
+
+        berlin = EuropeanCity(name='Berlin', continent='Europe')
+        self.assertEqual(len(berlin._db_field_map), len(berlin._fields_ordered))
+        self.assertEqual(len(berlin._reverse_db_field_map), len(berlin._fields_ordered))
+        self.assertEqual(len(berlin._fields_ordered), 3)
+        self.assertEqual(berlin._fields_ordered[0], 'city_id')
 
     def test_auto_id_vs_non_pk_id_field(self):
 
@@ -334,13 +350,14 @@ class InheritanceTest(unittest.TestCase):
 
         class EuropeanCity(City):
             name = StringField()
-            country = StringField()
 
         berlin = EuropeanCity(name='Berlin', continent='Europe')
         self.assertEqual(len(berlin._db_field_map), len(berlin._fields_ordered))
         self.assertEqual(len(berlin._reverse_db_field_map), len(berlin._fields_ordered))
-        self.assertEqual(len(berlin._fields_ordered), 5)
-        self.assertEqual(berlin._fields_ordered[0], 'id')
+        self.assertEqual(len(berlin._fields_ordered), 4)
+        self.assertEqual(berlin._fields_ordered[0], 'auto_id_0')
+        berlin.save()
+        self.assertEqual(berlin.pk, berlin.auto_id_0)
 
     def test_abstract_document_creation_does_not_fail(self):
 
@@ -350,7 +367,7 @@ class InheritanceTest(unittest.TestCase):
                     'allow_inheritance': False}
         bkk = City(continent='asia')
         self.assertEqual(None, bkk.pk)
-        # TODO: expected error? Shouldn'twe created a new error type
+        # TODO: expected error? Shouldn't we create a new error type?
         self.assertRaises(KeyError, lambda: setattr(bkk, 'pk', 1))
 
     def test_allow_inheritance_embedded_document(self):

--- a/tests/document/inheritance.py
+++ b/tests/document/inheritance.py
@@ -307,6 +307,17 @@ class InheritanceTest(unittest.TestCase):
         doc = Animal(name='dog')
         self.assertFalse('_cls' in doc.to_mongo())
 
+    def test_abstract_document_creation_does_not_fail(self):
+
+        class City(Document):
+            continent = StringField()
+            meta = {'abstract': True,
+                    'allow_inheritance': False}
+        bkk = City(continent='asia')
+        self.assertEqual(None, bkk.pk)
+        # TODO: expected error? Shouldn'twe created a new error type
+        self.assertRaises(KeyError, lambda: setattr(bkk, 'pk', 1))
+
     def test_allow_inheritance_embedded_document(self):
         """Ensure embedded documents respect inheritance
         """

--- a/tests/document/inheritance.py
+++ b/tests/document/inheritance.py
@@ -324,6 +324,24 @@ class InheritanceTest(unittest.TestCase):
         self.assertEqual(len(berlin._fields_ordered), 4)
         self.assertEqual(berlin._fields_ordered[0], 'id')
 
+    def test_auto_id_vs_non_pk_id_field(self):
+
+        class City(Document):
+            continent = StringField()
+            id = IntField()
+            meta = {'abstract': True,
+                    'allow_inheritance': False}
+
+        class EuropeanCity(City):
+            name = StringField()
+            country = StringField()
+
+        berlin = EuropeanCity(name='Berlin', continent='Europe')
+        self.assertEqual(len(berlin._db_field_map), len(berlin._fields_ordered))
+        self.assertEqual(len(berlin._reverse_db_field_map), len(berlin._fields_ordered))
+        self.assertEqual(len(berlin._fields_ordered), 5)
+        self.assertEqual(berlin._fields_ordered[0], 'id')
+
     def test_abstract_document_creation_does_not_fail(self):
 
         class City(Document):

--- a/tests/document/inheritance.py
+++ b/tests/document/inheritance.py
@@ -307,6 +307,23 @@ class InheritanceTest(unittest.TestCase):
         doc = Animal(name='dog')
         self.assertFalse('_cls' in doc.to_mongo())
 
+    def test_abstract_handle_ids_in_metaclass_properly(self):
+
+        class City(Document):
+            continent = StringField()
+            meta = {'abstract': True,
+                    'allow_inheritance': False}
+
+        class EuropeanCity(City):
+            name = StringField()
+            country = StringField()
+
+        berlin = EuropeanCity(name='Berlin', continent='Europe')
+        self.assertEqual(len(berlin._db_field_map), len(berlin._fields_ordered))
+        self.assertEqual(len(berlin._reverse_db_field_map), len(berlin._fields_ordered))
+        self.assertEqual(len(berlin._fields_ordered), 4)
+        self.assertEqual(berlin._fields_ordered[0], 'id')
+
     def test_abstract_document_creation_does_not_fail(self):
 
         class City(Document):

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -3689,11 +3689,9 @@ class QuerySetTest(unittest.TestCase):
     def test_scalar(self):
 
         class Organization(Document):
-            id = ObjectIdField('_id')
             name = StringField()
 
         class User(Document):
-            id = ObjectIdField('_id')
             name = StringField()
             organization = ObjectIdField()
 


### PR DESCRIPTION
It's a pity we were waiting too long for tests for PR #688, so I decided to copy the logic and provide tests.

It allowed me to fix a couple other places too.

The tests also allowed me to find out that in one case, we are still messing up fields. I'll appreciate your input on this one

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/961)
<!-- Reviewable:end -->
