### PR TITLE
Adding a little bit to the django auth part of mongoengine

### DIFF
--- a/mongoengine/django/auth.py
+++ b/mongoengine/django/auth.py
@@ -395,12 +395,15 @@ class MongoEngineBackend(object):
     def get_user(self, user_id):
         return self.user_document.objects.with_id(user_id)
 
+    # TODO: needs the whole permissions logic
+
     @property
     def user_document(self):
         if self._user_doc is False:
             from .mongo_auth.models import get_user_document
             self._user_doc = get_user_document()
         return self._user_doc
+
 
 def get_user(userid):
     """Returns a User object from an id (User.id). Django's equivalent takes

--- a/mongoengine/django/auth.py
+++ b/mongoengine/django/auth.py
@@ -328,6 +328,17 @@ class User(Document):
         # Otherwise we need to check the backends.
         return _user_has_perm(self, perm, obj)
 
+    def has_perms(self, perm_list, obj=None):
+        """
+        Returns True if the user has each of the specified permissions. If
+        object is passed, it checks if the user has all required perms for this
+        object.
+        """
+        for perm in perm_list:
+            if not self.has_perm(perm, obj):
+                return False
+        return True
+
     def has_module_perms(self, app_label):
         """
         Returns True if the user has any permissions in the given app label.

--- a/mongoengine/django/mongo_auth/models.py
+++ b/mongoengine/django/mongo_auth/models.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import UserManager
-from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 try:
     from django.utils.module_loading import import_module
@@ -78,7 +77,6 @@ class MongoUserManager(UserManager):
         for name in self.dj_model.REQUIRED_FIELDS:
             field = models.CharField(_(name), max_length=30)
             field.contribute_to_class(self.dj_model, name)
-
 
     def get(self, *args, **kwargs):
         try:

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -40,7 +40,7 @@ except Exception:
 try:
     from django.test import modify_settings
     DJ17 = True
-except ImproperlyConfigured:
+except Exception:
     DJ17 = False
 from mongoengine.django.sessions import SessionStore, MongoSession
 from mongoengine.django.tests import MongoTestCase

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -11,7 +11,6 @@ from django.http import Http404
 from django.template import Context, Template
 from django.conf import settings
 from django.core.paginator import Paginator
-from django.test import modify_settings
 
 settings.configure(
     USE_TZ=True,
@@ -38,6 +37,11 @@ try:
     DJ15 = True
 except Exception:
     DJ15 = False
+try:
+    from django.test import modify_settings
+    DJ17 = True
+except ImproperlyConfigured:
+    DJ17 = False
 from mongoengine.django.sessions import SessionStore, MongoSession
 from mongoengine.django.tests import MongoTestCase
 from datetime import tzinfo, timedelta
@@ -345,8 +349,8 @@ class MongoAuthBackendTest(MongoTestCase):
         )
 
     def setUp(self):
-        if not DJ15:
-            raise SkipTest('mongo_auth requires Django 1.5')
+        if not DJ17:
+            raise SkipTest('mongo_auth backend tests require Django 1.7')
         self.patched_settings = modify_settings(
             AUTHENTICATION_BACKENDS={'append': self.backend},
         )
@@ -390,7 +394,7 @@ class MongoAuthBackendTest(MongoTestCase):
         # reloading user to purge the _perm_cache
         user = self.UserModel._default_manager.get(pk=self.user.pk)
         raise SkipTest("Permission logic not implemented on Mongo Backend")
-        self.assertEqual(user.get_all_permissions() == {'auth.test'}, True)
+        self.assertEqual(user.get_all_permissions() == set(['auth.test']), True)
         self.assertEqual(user.get_group_permissions(), set())
         self.assertEqual(user.has_module_perms('Group'), False)
         self.assertEqual(user.has_module_perms('auth'), True)


### PR DESCRIPTION
Gosh I didn't realize at the beginning how deep the hole is !!! But maybe this small additions may show to other people what is working and what not, and how much is missing here.

It's a kind of "documenting via testing" purpose.

This allowed to not loose the aborted PR #756 and actually gave me some inside on the opportunity to really detach the django part, as proposed in issue #958 

If you think it helps nothing to merge it in, I'll be fine with it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/962)
<!-- Reviewable:end -->
