### PR TITLE
adapted setup.cfg to use nosetests standard + readme adapted

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,11 @@ Tests
 To run the test suite, ensure you are running a local instance of MongoDB on
 the standard port, and run: ``python setup.py test``.
 
+If you wish to run one single or selected tests, use the nosetest convention. It will find the folder,
+eventually the file, go to the TestClass specified after the colon and eventually right to the single test.
+Also use the -s argument if you want to print out whatever or access pdb while testing.
+``python setup.py nosetests --tests tests/test_django.py:QuerySetTest.test_get_document_or_404 -s``
+
 Community
 =========
 - `MongoEngine Users mailing list

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,5 +7,6 @@ detailed-errors = 1
 #cover-html-dir = ../htmlcov
 #cover-package = mongoengine
 py3where = build
-where = tests
+#where = tests
+tests = tests
 #tests =  document/__init__.py


### PR DESCRIPTION
adapted setup.cfg to use nose tests standard and allow usage of --tests argument, documenting it in the readme

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/963)
<!-- Reviewable:end -->
