### PR TITLE
[fix] SortedListField: update whole list if order is changed

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -547,6 +547,7 @@ class BaseDocument(object):
         EmbeddedDocument = _import_class("EmbeddedDocument")
         DynamicEmbeddedDocument = _import_class("DynamicEmbeddedDocument")
         ReferenceField = _import_class("ReferenceField")
+        SortedListField = _import_class("SortedListField")
         changed_fields = []
         changed_fields += getattr(self, '_changed_fields', [])
 
@@ -577,6 +578,12 @@ class BaseDocument(object):
                 if (hasattr(field, 'field') and
                         isinstance(field.field, ReferenceField)):
                     continue
+                elif (isinstance(field, SortedListField) and field._ordering):
+                    # if ordering is affected whole list is changed
+                    if any(map(lambda d: field._ordering in d._changed_fields, data)):
+                        changed_fields.append(db_field_name)
+                        continue
+
                 self._nestable_types_changed_fields(
                     changed_fields, key, data, inspected)
         return changed_fields

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -916,6 +916,13 @@ class FieldTest(unittest.TestCase):
         self.assertEqual(post.comments[0].content, comment2.content)
         self.assertEqual(post.comments[1].content, comment1.content)
 
+        post.comments[0].order = 2
+        post.save()
+        post.reload()
+
+        self.assertEqual(post.comments[0].content, comment1.content)
+        self.assertEqual(post.comments[1].content, comment2.content)
+
         BlogPost.drop_collection()
 
     def test_reverse_list_sorting(self):


### PR DESCRIPTION
In case we have document with `SortedListField` in DB and we want to update order by changing `ordering` field
`SortedListField.to_mongo` returns correct sorted list
But `BaseDocument._delta` generates wrong `set_data` trying to update only specific fields at specific indexes without realizing that list order is changed and those indexes are incorrect
To fix that we make `BaseDocument._get_changed_fields` aware of `SortedListField` with `_ordering` behavior.

Related test cases are added

Cheers

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/978)
<!-- Reviewable:end -->
