### PR TITLE
added MultiLingualField

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -1,4 +1,5 @@
 import copy
+from locale import locale_alias
 import operator
 import numbers
 from collections import Hashable
@@ -28,6 +29,13 @@ from mongoengine.base.fields import ComplexBaseField
 __all__ = ('BaseDocument', 'NON_FIELD_ERRORS')
 
 NON_FIELD_ERRORS = '__all__'
+
+
+SUPPORTED_LANGUAGES = sorted(set([
+    locale_string.split("_")[0].lower()
+    for locale_string in locale_alias.values()
+    if locale_string != "C"
+]))
 
 
 class BaseDocument(object):
@@ -421,6 +429,16 @@ class BaseDocument(object):
         """
         use_db_field = kwargs.pop('use_db_field', True)
         return json_util.dumps(self.to_mongo(use_db_field),  *args, **kwargs)
+
+    @property
+    def current_lang(self):
+        if not hasattr(self, '_current_lang'):
+            self._current_lang = 'en'
+        return self._current_lang
+
+    def set_lang(self, lang):
+        assert lang in SUPPORTED_LANGUAGES, 'Language %s is not supported' % lang
+        self._current_lang = lang
 
     @classmethod
     def from_json(cls, json_data, created=False):

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -2040,7 +2040,7 @@ class MultiLingualField(BaseField):
         return instance.current_lang
 
     def to_python(self, value):
-        return {lang_obj['language']: lang_obj['value'] for lang_obj in value.iteritems()}
+        return {lang_obj['language']: lang_obj['value'] for lang_obj in value}
 
     def to_mongo(self, value):
         return [{'language': lang, 'value': v} for lang, v in copy.deepcopy(value).iteritems()]

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -3222,6 +3222,56 @@ class FieldTest(unittest.TestCase):
         self.assertRaises(FieldDoesNotExist, test)
 
 
+    def test_multilingual_field_simple_usecase(self):
+        class Person(Document):
+            name = MultiLingualField()
+
+        p = Person()
+        chinese_name = 'yaoyao'
+        english_name = 'almog'
+        p.name = english_name
+        assert p.name == english_name
+        assert p._data['name'] == {'en': english_name}
+
+        p.set_lang('zh')
+        p.name = chinese_name
+        assert p.name == chinese_name
+        assert 'zh' in p._data['name'] and p._data['name']['zh'] == chinese_name
+        assert 'en' in p._data['name'] and p._data['name']['en'] == english_name
+
+    def test_multilingual_set_lang(self):
+        class Person(Document):
+            name = MultiLingualField()
+
+        p = Person()
+        # assert that the default lang is en
+        self.assertEqual(p.current_lang, 'en')
+
+        # normal language change
+        p.set_lang('zh')
+        self.assertEqual(p.current_lang, 'zh')
+
+        # unsupported language assertion
+        self.assertRaises(Exception, p.set_lang, ('blang',))
+
+    def test_multilingual_to_mongo(self):
+        class Person(Document):
+            name = MultiLingualField()
+
+        p = Person()
+        names = {'en': 'almog', 'zh': 'yaoyao'}
+        needed_to_mongo_value = sorted([{'language': lang, 'value': val} for lang, val in names.items()])
+        assert sorted(Person.name.to_mongo(names)) == needed_to_mongo_value
+
+    def test_multilingual_to_python(self):
+        class Person(Document):
+            name = MultiLingualField()
+
+        p = Person()
+        names = [{'language': 'en', 'value': 'almog'}, {'language': 'zh', 'value': 'yaoyao'}]
+        self.assertEqual(Person.name.to_python(names), {'en': 'almog', 'zh': 'yaoyao'})
+
+
 class EmbeddedDocumentListFieldTestCase(unittest.TestCase):
 
     @classmethod


### PR DESCRIPTION
I added `MultiLingualField` similar to the one available in MongoKit.

Usage:

```
class Doc(Document):
    multi = MultiLingualField()

>>> d = Doc()
>>> d.multi = 'almog'
>>> d.set_lang('zh')
>>> d.multi = 'almog in Chinese'
>>> print d.multi # almog in Chinese
>>> d.set_lang('en')
>>> print d.multi # almog
```

In `d._data`, multi is represented as dictionary `{'en': 'almog', 'zh': 'almog in Chinese'}`.
In MongoDB it will be `[{'language': 'en', 'value': 'almog'}, {'language': 'zh', 'value': 'almog in Chinese'}]`

In order to control the document current language I added two methods to the `BaseDocument`:
- property `current_lang`
- method `set_lang`

Some Problems:
1. Actually I wanted to initiate the _current_lang at the constructor but I wasn't sure where it should go, so currently I initiate it inside the `current_lang` property.
2. I wasn't sure were to drop the `SUPPORTED_LANGUAGES` variable. Currently it is inside `document.py`

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/986)

<!-- Reviewable:end -->
