### PR TITLE
Upgrade doc for 0.9.0 on mongoengine.org is empty

### DIFF
--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -7,8 +7,6 @@ Upgrading
 
 The 0.8.7 package on pypi was corrupted.  If upgrading from 0.8.7 to 0.9.0 please follow:
 
-.. code-block::
-
     pip uninstall pymongo
     pip uninstall mongoengine
     pip install pymongo==2.8


### PR DESCRIPTION
Not certain how to test, but the upgrade instructions for 0.9.0 are empty here:

http://docs.mongoengine.org/upgrade.html

with the previous code block declaration. This changes the first block to match the syntax used for following blocks, which work correctly both on Github and the documentation website.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/987)
<!-- Reviewable:end -->
