### PR TITLE
Fix code formatting in upgrade doc

### DIFF
--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -5,9 +5,7 @@ Upgrading
 0.9.0
 *****
 
-The 0.8.7 package on pypi was corrupted.  If upgrading from 0.8.7 to 0.9.0 please follow:
-
-.. code-block::
+The 0.8.7 package on pypi was corrupted.  If upgrading from 0.8.7 to 0.9.0 please follow: ::
 
     pip uninstall pymongo
     pip uninstall mongoengine


### PR DESCRIPTION
This fixes rendering on the documentation website:
http://docs.mongoengine.org/upgrade.html

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/988)
<!-- Reviewable:end -->
