### PR TITLE
improve _created status when switch collection and db

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -224,3 +224,5 @@ that much better:
  * Matthieu Rigal (https://github.com/MRigal)
  * Charanpal Dhanjal (https://github.com/charanpald)
  * Emmanuel Leblond (https://github.com/touilleMan)
+ * Breeze.Kay (https://github.com/9nix00)
+

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 Changes in 0.9.X - DEV
 ======================
+- improve Document._created status when switch collection and db #1020
 - Queryset update doesn't go through field validation #453
 - Added support for specifying authentication source as option `authSource` in URI. #967
 - Fixed mark_as_changed to handle higher/lower level fields changed. #927

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 
 Changes in 0.9.X - DEV
 ======================
-- improve Document._created status when switch collection and db #1020
+- Improve Document._created status when switch collection and db #1020
 - Queryset update doesn't go through field validation #453
 - Added support for specifying authentication source as option `authSource` in URI. #967
 - Fixed mark_as_changed to handle higher/lower level fields changed. #927

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -477,7 +477,7 @@ class Document(BaseDocument):
             raise OperationError(message)
         signals.post_delete.send(self.__class__, document=self)
 
-    def switch_db(self, db_alias):
+    def switch_db(self, db_alias, keep_created=True):
         """
         Temporarily switch the database for a document instance.
 
@@ -499,12 +499,12 @@ class Document(BaseDocument):
         self._get_collection = lambda: collection
         self._get_db = lambda: db
         self._collection = collection
-        self._created = True
+        self._created = True if not keep_created else self._created
         self.__objects = self._qs
         self.__objects._collection_obj = collection
         return self
 
-    def switch_collection(self, collection_name):
+    def switch_collection(self, collection_name, keep_created=True):
         """
         Temporarily switch the collection for a document instance.
 
@@ -525,7 +525,7 @@ class Document(BaseDocument):
             collection = cls._get_collection()
         self._get_collection = lambda: collection
         self._collection = collection
-        self._created = True
+        self._created = True if not keep_created else self._created
         self.__objects = self._qs
         self.__objects._collection_obj = collection
         return self

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -503,8 +503,7 @@ class Document(BaseDocument):
 
         :param str db_alias: The database alias to use for saving the document
 
-        :param bool keep_created: keep self._created value after call `swith_db()` when True,
-                    else will always set self._created value to True
+        :param bool keep_created: keep self._created value after switching db, else is reset to True
 
 
         .. seealso::
@@ -535,8 +534,7 @@ class Document(BaseDocument):
         :param str collection_name: The database alias to use for saving the
             document
 
-        :param bool keep_created: keep self._created value after call `swith_db()` when True,
-                    else will always set self._created value to True
+        :param bool keep_created: keep self._created value after switching collection, else is reset to True
 
 
         .. seealso::

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -503,6 +503,10 @@ class Document(BaseDocument):
 
         :param str db_alias: The database alias to use for saving the document
 
+        :param bool keep_created: keep self._created value after call `swith_db()` when True,
+                    else will always set self._created value to True
+
+
         .. seealso::
             Use :class:`~mongoengine.context_managers.switch_collection`
             if you need to read from another collection
@@ -530,6 +534,10 @@ class Document(BaseDocument):
 
         :param str collection_name: The database alias to use for saving the
             document
+
+        :param bool keep_created: keep self._created value after call `swith_db()` when True,
+                    else will always set self._created value to True
+
 
         .. seealso::
             Use :class:`~mongoengine.context_managers.switch_db`

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -306,51 +306,6 @@ class SignalTests(unittest.TestCase):
         ei.switch_db("testdb-1", keep_created=False)
         self.assertEqual(self.get_signal_output(ei.save), ['Is created'])
 
-    def test_signals_with_switch_sharding_db(self):
-
-        import pymongo
-        from mongoengine.connection import get_connection
-
-        connect('mongoenginetest', alias='testdb1')
-        expected_connection = get_connection('testdb1')
-
-        connect('mongoenginetest', alias='testdb2')
-        actual_connection = get_connection('testdb2')
-
-        if pymongo.version_tuple[0] < 3:
-            IS_PYMONGO_3 = False
-        else:
-            IS_PYMONGO_3 = True
-
-        ei = self.ExplicitId(id=123)
-        ei.switch_db("testdb1")
-        self.assertEqual(self.get_signal_output(ei.save), ['Is created'])
-        ei.switch_db("testdb1")
-        self.assertEqual(self.get_signal_output(ei.save), ['Is updated'])
-
-        ei.switch_db("testdb2", keep_created=False)
-        self.assertEqual(self.get_signal_output(ei.save), ['Is created'])
-        ei.switch_db("testdb2", keep_created=False)
-        self.assertEqual(self.get_signal_output(ei.save), ['Is created'])
-
-        # Handle PyMongo 3+ Async Connection
-        if IS_PYMONGO_3:
-            # Ensure we are connected, throws ServerSelectionTimeoutError otherwise.
-            # Purposely not catching exception to fail test if thrown.
-            expected_connection.server_info()
-
-        self.assertEqual(expected_connection, actual_connection)
-
-
-
-
-
-
-
-
-
-
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
this feature is useful when we update the switched collection and want to send signals. 

e.g: we have a template collection named "user", we have collections create from "user"  named "user__1","user__2","user__N".

when we update "user__N", we have to set self._created = False after call `switch_collection()`, this is a bad practice.  if we forget do this.  the `singal.post_save`'s `created` argument  will always be True.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1020)
<!-- Reviewable:end -->
