### PR TITLE
SequenceField for abstract classes now have a proper name

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -672,7 +672,7 @@ class BaseDocument(object):
 
     @classmethod
     def _get_collection_name(cls):
-        """Returns the collection name for this class.
+        """Returns the collection name for this class. None for abstract class
         """
         return cls._meta.get('collection', None)
 

--- a/mongoengine/base/metaclasses.py
+++ b/mongoengine/base/metaclasses.py
@@ -424,7 +424,6 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
         return id_name, id_db_name
 
 
-
 class MetaDict(dict):
 
     """Custom dictionary for meta classes.

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -145,7 +145,7 @@ class Document(BaseDocument):
     my_metaclass = TopLevelDocumentMetaclass
     __metaclass__ = TopLevelDocumentMetaclass
 
-    __slots__ = ('__objects')
+    __slots__ = ('__objects',)
 
     def pk():
         """Primary key alias
@@ -174,10 +174,10 @@ class Document(BaseDocument):
             db = cls._get_db()
             collection_name = cls._get_collection_name()
             # Create collection as a capped collection if specified
-            if cls._meta['max_size'] or cls._meta['max_documents']:
+            if cls._meta.get('max_size') or cls._meta.get('max_documents'):
                 # Get max document limit and max byte size from meta
-                max_size = cls._meta['max_size'] or 10000000  # 10MB default
-                max_documents = cls._meta['max_documents']
+                max_size = cls._meta.get('max_size') or 10000000  # 10MB default
+                max_documents = cls._meta.get('max_documents')
 
                 if collection_name in db.collection_names():
                     cls._collection = db[collection_name]

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -1694,7 +1694,7 @@ class SequenceField(BaseField):
         self.sequence_name = sequence_name
         self.value_decorator = (callable(value_decorator) and
                                 value_decorator or self.VALUE_DECORATOR)
-        return super(SequenceField, self).__init__(*args, **kwargs)
+        super(SequenceField, self).__init__(*args, **kwargs)
 
     def generate(self):
         """
@@ -1740,7 +1740,7 @@ class SequenceField(BaseField):
         if self.sequence_name:
             return self.sequence_name
         owner = self.owner_document
-        if issubclass(owner, Document):
+        if issubclass(owner, Document) and not owner._meta.get('abstract'):
             return owner._get_collection_name()
         else:
             return ''.join('_%s' % c if c.isupper() else c


### PR DESCRIPTION
Partial fix for #497 which IMHO is not completely legitime as a bug. At least, now each SequenceField counter will have the name of the abstract class and several abstract classes will not clash each other.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1026)
<!-- Reviewable:end -->
