### PR TITLE
Fix read_preference

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changes in 0.10.2
 - Allow shard key to point to a field in an embedded document. #551
 - Allow arbirary metadata in fields. #1129
 - ReferenceFields now support abstract document types. #837
+- Fix `read_preference` (it had chaining issues with PyMongo 2.x and it didn't work at all with PyMongo 3.x) #1042
 
 Changes in 0.10.1
 =======================

--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -1444,8 +1444,16 @@ class BaseQuerySet(object):
     def _cursor(self):
         if self._cursor_obj is None:
 
-            self._cursor_obj = self._collection.find(self._query,
-                                                     **self._cursor_args)
+            # In PyMongo 3+, we define the read preference on a collection
+            # level, not a cursor level. Thus, we need to get a cloned
+            # collection object using `with_options` first.
+            if IS_PYMONGO_3 and self._read_preference is not None:
+                self._cursor_obj = self._collection\
+                    .with_options(read_preference=self._read_preference)\
+                    .find(self._query, **self._cursor_args)
+            else:
+                self._cursor_obj = self._collection.find(self._query,
+                                                         **self._cursor_args)
             # Apply where clauses to cursor
             if self._where_clause:
                 where_clause = self._sub_js_fields(self._where_clause)

--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -930,6 +930,7 @@ class BaseQuerySet(object):
         validate_read_preference('read_preference', read_preference)
         queryset = self.clone()
         queryset._read_preference = read_preference
+        queryset._cursor_obj = None  # we need to re-create the cursor object whenever we apply read_preference
         return queryset
 
     def scalar(self, *fields):


### PR DESCRIPTION
I noticed something disturbing in our query logs earlier today - some of the queries were incorrectly routed to the primary when using `ReadPreference.SECONDARY`. Eventually, it came to my realization that `read_preference` wasn't working if it was put after `limit`, `skip`, or `hint` (and probably some other methods that allow chaining).

Note: As of now, the fix only works for pymongo ver < 3.0. I think `read_preference` is **completely** broken with ver >= 3.0, but I don't have full clarity on the situation yet. It seems that `self._collection.find` doesn't accept `read_preference` as a valid kwarg any more and if I'm reading pymongo's docs right, you can only set read preference on a client/database/collection, not a particular cursor. It doesn't seem to be set either way:

```
In [10]: import mongoengine

In [11]: from mongoengine import *

In [12]: from pymongo.read_preferences import ReadPreference

In [13]: import pymongo

In [14]: pymongo.version
Out[14]: '3.0.2'

In [15]: class A(Document):
    txt = StringField()
   ....:

In [16]: qs = A.objects.read_preference(ReadPreference.SECONDARY)

In [17]: qs._cursor._Cursor__read_preference
Out[17]: Primary()

In [18]: qs._cursor.collection.read_preference
Out[18]: Primary()
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1042)
<!-- Reviewable:end -->
