### PR TITLE
Suggested fix for #1047: CachedReferenceField DBRefs bug

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -227,3 +227,4 @@ that much better:
  * Breeze.Kay (https://github.com/9nix00)
  * Vicki Donchenko (https://github.com/kivistein)
  * Emile Caron (https://github.com/emilecaron)
+ * Amit Lichtenberg (https://github.com/amitlicht)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 Changes in 0.10.1 - DEV
 =======================
 - Fix infinite recursion with CASCADE delete rules under specific conditions. #1046
+- Fix CachedReferenceField bug when loading cached docs as DBRef but failing to save them. #1047
 
 Changes in 0.10.0
 =================

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -1034,6 +1034,7 @@ class CachedReferenceField(BaseField):
             collection = self.document_type._get_collection_name()
             value = DBRef(
                 collection, self.document_type.id.to_python(value['_id']))
+            return self.document_type._from_son(self.document_type._get_db().dereference(value))
 
         return value
 

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -1617,6 +1617,27 @@ class FieldTest(unittest.TestCase):
                                'parent': "50a234ea469ac1eda42d347d"})
         mongoed = p1.to_mongo()
         self.assertTrue(isinstance(mongoed['parent'], ObjectId))
+        
+    def test_cached_reference_field_get_and_save(self):
+        """
+        Tests #1047: CachedReferenceField creates DBRefs on to_python, but can't save them on to_mongo
+        """
+        class Animal(Document):
+            name = StringField()
+            tag = StringField()
+
+        class Ocorrence(Document):
+            person = StringField()
+            animal = CachedReferenceField(Animal)
+        
+        Animal.drop_collection()
+        Ocorrence.drop_collection()
+        
+        Ocorrence(person="testte", 
+                  animal=Animal(name="Leopard", tag="heavy").save()).save()
+        p = Ocorrence.objects.get()
+        p.person = 'new_testte'
+        p.save()
 
     def test_cached_reference_fields(self):
         class Animal(Document):


### PR DESCRIPTION
CachedReferenceField creates DBRef on to_python, but can't save them on to_mongo.

Dereferencing DBRef to document type before returning it from to_python.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1048)
<!-- Reviewable:end -->
