### PR TITLE
fixed Document.reload

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changes in 0.10.1 - DEV
 - Fix infinite recursion with CASCADE delete rules under specific conditions. #1046
 - Fix CachedReferenceField bug when loading cached docs as DBRef but failing to save them. #1047
 - Fix ignored chained options #842
+- Fix Document.reload for DynamicDocument. #1050
 
 Changes in 0.10.0
 =================

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -588,7 +588,7 @@ class Document(BaseDocument):
         else:
             raise self.DoesNotExist("Document does not exist")
 
-        for field in self._fields_ordered:
+        for field in obj._data:
             if not fields or field in fields:
                 try:
                     setattr(self, field, self._reload(field, obj[field]))

--- a/tests/document/dynamic.py
+++ b/tests/document/dynamic.py
@@ -88,6 +88,18 @@ class DynamicTest(unittest.TestCase):
         p.update(unset__misc=1)
         p.reload()
 
+    def test_reload_dynamic_field(self):
+        self.Person.objects.delete()
+        p = self.Person.objects.create()
+        p.update(age=1)
+
+        self.assertEqual(len(p._data), 3)
+        self.assertEqual(sorted(p._data.keys()), ['_cls', 'id', 'name'])
+
+        p.reload()
+        self.assertEqual(len(p._data), 4)
+        self.assertEqual(sorted(p._data.keys()), ['_cls', 'age', 'id', 'name'])
+
     def test_dynamic_document_queries(self):
         """Ensure we can query dynamic fields"""
         p = self.Person()


### PR DESCRIPTION
use obj._data instead of self._fields_ordered since DynamicDocument missing some attributes

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1052)
<!-- Reviewable:end -->
