### PR TITLE
Travis configuration to run against multiple mongoDB versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ before_install:
     travis_retry sudo apt-get update &&
     travis_retry sudo apt-get install -y mongodb-org=$MONGODB;
   fi
+- sleep 15 # mongo may not be responded directly. See http://docs.travis-ci.com/user/database-setup/#MongoDB
 - mongo --version
 install:
 - sudo apt-get install python-dev python3-dev libopenjpeg-dev zlib1g-dev libjpeg-turbo8-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_install:
     travis_retry sudo apt-get update &&
     if [ `echo $MONGODB | sed -e 's/.\.\(.\).*/\1/'` = '4' ]; then
       travis_retry sudo apt-get install -y mongodb-10gen=$MONGODB;
+      sudo service mongodb start
     else
       travis_retry sudo apt-get install -y mongodb-org=$MONGODB;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,40 @@ python:
 - pypy
 - pypy3
 env:
-- PYMONGO=2.7
-- PYMONGO=2.8
-- PYMONGO=3.0
-- PYMONGO=dev
+- PYMONGO=2.7 MONGODB=2.6.6
+- PYMONGO=2.8 MONGODB=2.6.6
+- PYMONGO=3.0 MONGODB=2.6.6
+- PYMONGO=dev MONGODB=2.6.6
+- PYMONGO=2.7 MONGODB=3.0.4
+- PYMONGO=2.8 MONGODB=3.0.4
+- PYMONGO=3.0 MONGODB=3.0.4
+- PYMONGO=dev MONGODB=3.0.4
 matrix:
   fast_finish: true
+  include:
+  - python: "2.7"
+    env: PYMONGO=3.0 MONGODB=2.4.14
+  - python: "3.4"
+    env: PYMONGO=3.0 MONGODB=2.4.14
 before_install:
-- travis_retry sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-- echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' |
-  sudo tee /etc/apt/sources.list.d/mongodb.list
-- travis_retry sudo apt-get update
-- travis_retry sudo apt-get install mongodb-org-server
+- if [ `echo $MONGODB | sed -e 's/\(.\).*/\1/'` = '2' ]; then
+    travis_retry sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10 &&
+    echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' |
+      sudo tee /etc/apt/sources.list.d/mongodb.list &&
+    travis_retry sudo apt-get update &&
+    if [ `echo $MONGODB | sed -e 's/.\.\(.\).*/\1/'` = '4' ]; then
+      travis_retry sudo apt-get install -y mongodb-10gen=$MONGODB;
+    else
+      travis_retry sudo apt-get install -y mongodb-org=$MONGODB;
+    fi
+  else
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10 &&
+    echo "deb http://repo.mongodb.org/apt/ubuntu "$(lsb_release -sc)"/mongodb-org/3.0 multiverse" |
+      sudo tee /etc/apt/sources.list.d/mongodb-org-3.0.list &&
+    travis_retry sudo apt-get update &&
+    travis_retry sudo apt-get install -y mongodb-org=$MONGODB;
+  fi
+- mongo --version
 install:
 - sudo apt-get install python-dev python3-dev libopenjpeg-dev zlib1g-dev libjpeg-turbo8-dev
   libtiff4-dev libjpeg8-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
     travis_retry sudo apt-get update &&
     if [ `echo $MONGODB | sed -e 's/.\.\(.\).*/\1/'` = '4' ]; then
       travis_retry sudo apt-get install -y mongodb-10gen=$MONGODB;
-      sudo service mongodb start
+      sudo service mongodb start;
     else
       travis_retry sudo apt-get install -y mongodb-org=$MONGODB;
     fi


### PR DESCRIPTION
Following issue #1057, I've tweaked the travis.yml config to make it work on multiple mongoDB version:
- the tests are launched against mongoDB 3.0.4 and 2.6.6
- two more custom build are triggered with to test for mongoDB 2.4.14 with python2.7 and 3.4

At the end this trigger 56 (!) builds which is pretty huge... to see if we choose to only test a subset of this or keep everything

Regarding mongoDB 2.4.14, it seems the unittests fall into an infinite wait

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1061)

<!-- Reviewable:end -->
