### PR TITLE
Use SaveConditionError instead of OperationError in save_condition

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changes in 0.10.1 - DEV
 - Fix infinite recursion with CASCADE delete rules under specific conditions. #1046
 - Fix CachedReferenceField bug when loading cached docs as DBRef but failing to save them. #1047
 - Fix ignored chained options #842
+- Document save's save_condition error raises `SaveConditionError` exception #1070
 
 Changes in 0.10.0
 =================

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -16,7 +16,8 @@ from mongoengine.base import (
     ALLOW_INHERITANCE,
     get_document
 )
-from mongoengine.errors import InvalidQueryError, InvalidDocumentError
+from mongoengine.errors import (InvalidQueryError, InvalidDocumentError,
+                                SaveConditionError)
 from mongoengine.python_support import IS_PYMONGO_3
 from mongoengine.queryset import (OperationError, NotUniqueError,
                                   QuerySet, transform)
@@ -359,8 +360,8 @@ class Document(BaseDocument):
                     last_error = collection.update(select_dict, update_query,
                                                    upsert=upsert, **write_concern)
                     if not upsert and last_error['nModified'] == 0:
-                        raise OperationError('Race condition preventing'
-                                             ' document update detected')
+                        raise SaveConditionError('Race condition preventing'
+                                                 ' document update detected')
                     created = is_new_object(last_error)
 
             if cascade is None:

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -295,6 +295,8 @@ class Document(BaseDocument):
             if the condition is satisfied in the current db record.
         .. versionchanged:: 0.10
             :class:`OperationError` exception raised if save_condition fails.
+        .. versionchanged:: 0.10.1
+            :class: save_condition failure now raises a `SaveConditionError`
         """
         signals.pre_save.send(self.__class__, document=self)
 

--- a/mongoengine/errors.py
+++ b/mongoengine/errors.py
@@ -41,6 +41,10 @@ class NotUniqueError(OperationError):
     pass
 
 
+class SaveConditionError(OperationError):
+    pass
+
+
 class FieldDoesNotExist(Exception):
     """Raised when trying to set a field
     not declared in a :class:`~mongoengine.Document`

--- a/tests/document/instance.py
+++ b/tests/document/instance.py
@@ -17,7 +17,7 @@ from tests.fixtures import (PickleEmbedded, PickleTest, PickleSignalsTest,
 from mongoengine import *
 from mongoengine.errors import (NotRegistered, InvalidDocumentError,
                                 InvalidQueryError, NotUniqueError,
-                                FieldDoesNotExist)
+                                FieldDoesNotExist, SaveConditionError)
 from mongoengine.queryset import NULLIFY, Q
 from mongoengine.connection import get_db
 from mongoengine.base import get_document
@@ -1021,7 +1021,7 @@ class InstanceTest(unittest.TestCase):
         flip(w1)
         self.assertTrue(w1.toggle)
         self.assertEqual(w1.count, 1)
-        self.assertRaises(OperationError,
+        self.assertRaises(SaveConditionError,
             w1.save, save_condition={'save_id': UUID(42)})
         w1.reload()
         self.assertFalse(w1.toggle)
@@ -1050,7 +1050,7 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(w1.count, 2)
         flip(w2)
         flip(w2)
-        self.assertRaises(OperationError,
+        self.assertRaises(SaveConditionError,
             w2.save, save_condition={'save_id': old_id})
         w2.reload()
         self.assertFalse(w2.toggle)
@@ -1063,7 +1063,7 @@ class InstanceTest(unittest.TestCase):
         self.assertTrue(w1.toggle)
         self.assertEqual(w1.count, 3)
         flip(w1)
-        self.assertRaises(OperationError,
+        self.assertRaises(SaveConditionError,
             w1.save, save_condition={'count__gte': w1.count})
         w1.reload()
         self.assertTrue(w1.toggle)


### PR DESCRIPTION
Hi there,

Working with `save_condition` in save, I realised using an `OperationError` exception is too vague when trying to return fine errors to client, example:

```python
class Doc(Document):
    version = fields.IntField(default=1)
    field = fields.StringField(unique=True)

doc_1 = Doc(field='unique').save()
try:
    doc_2 = Doc(field='unique').save() # raises NotUniqueError, subclass of OperationError
except OperationError:
    # Should handle HTTP 400 error
    pass
doc_1.field = 'two'
http_if_match = 42 # Client provide If-Match header in HTTP request
try:
    doc_1.save(save_condition={'version': http_if_match}) # raises OperationError
except OperationError:
    # Should handle HTTP 412
    pass
```

I solve this by replacing the `OperationError` triggered by an invalid `save_condition` by a new `SaveConditionError` (subclass of `OperationError`, to mimic the behaviour of `NotUniqueError`)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1070)
<!-- Reviewable:end -->
