### PR TITLE
Copy field default value instead of using its reference.

### DIFF
--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -1,3 +1,4 @@
+import copy
 import operator
 import warnings
 import weakref
@@ -42,7 +43,8 @@ class BaseField(object):
     def __init__(self, db_field=None, name=None, required=False, default=None,
                  unique=False, unique_with=None, primary_key=False,
                  validation=None, choices=None, verbose_name=None,
-                 help_text=None, null=False, sparse=False, custom_data=None):
+                 help_text=None, null=False, sparse=False,
+                 copy_default=True, custom_data=None):
         """
         :param db_field: The database field to store this field in
             (defaults to the name of the field)
@@ -70,6 +72,8 @@ class BaseField(object):
         :param sparse: (optional) `sparse=True` combined with `unique=True` and `required=False`
             means that uniqueness won't be enforced for `None` values
         :param custom_data: (optional) Custom metadata for this field.
+        :param copy_default: (optional) Specify wether a non-callable
+           default value is copied when being used or not. Default to True.
         """
         self.db_field = (db_field or name) if not primary_key else '_id'
 
@@ -88,6 +92,7 @@ class BaseField(object):
         self.null = null
         self.sparse = sparse
         self._owner_document = None
+        self.copy_default = bool(copy_default)
         self.custom_data = custom_data
 
         # Adjust the appropriate creation counter, and save our local copy.
@@ -121,6 +126,8 @@ class BaseField(object):
                 value = self.default
                 if callable(value):
                     value = value()
+                elif self.copy_default:
+                    value = copy.deepcopy(value)
 
         if instance._initialised:
             try:

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -1617,7 +1617,7 @@ class FieldTest(unittest.TestCase):
                                'parent': "50a234ea469ac1eda42d347d"})
         mongoed = p1.to_mongo()
         self.assertTrue(isinstance(mongoed['parent'], ObjectId))
-        
+
     def test_cached_reference_field_get_and_save(self):
         """
         Tests #1047: CachedReferenceField creates DBRefs on to_python, but can't save them on to_mongo
@@ -1629,11 +1629,11 @@ class FieldTest(unittest.TestCase):
         class Ocorrence(Document):
             person = StringField()
             animal = CachedReferenceField(Animal)
-        
+
         Animal.drop_collection()
         Ocorrence.drop_collection()
-        
-        Ocorrence(person="testte", 
+
+        Ocorrence(person="testte",
                   animal=Animal(name="Leopard", tag="heavy").save()).save()
         p = Ocorrence.objects.get()
         p.person = 'new_testte'
@@ -3909,6 +3909,24 @@ class EmbeddedDocumentListFieldTestCase(unittest.TestCase):
         self.assertFalse(hasattr(a1.c_field, 'custom_data'))
         self.assertTrue(hasattr(CustomData.c_field, 'custom_data'))
         self.assertEqual(custom_data['a'], CustomData.c_field.custom_data['a'])
+
+    def test_default_value_copy(self):
+        """
+        Tests that reference passed in the `default` field parameter
+        is properly copied unless specified otherwise with the
+        `default_copy' parameter.
+        """
+        class A(Document):
+            field = DynamicField(default={})
+            field_without_copy = DynamicField(default={}, copy_default=False)
+
+        obj1 = A()
+        obj1.field['foo'] = 'foo'
+        obj1.field_without_copy['bar'] = 'bar'
+        obj2 = A()
+        self.assertTrue('bar' in obj2.field_without_copy)
+        self.assertNotEqual(id(obj1.field), id(obj2.field))
+        self.assertEqual(id(obj1.field_without_copy), id(obj2.field_without_copy))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The code below produces undefined behavior as several documents can share the same reference to `{}`. Therefore changes made by one document will affect others.

``` python
class Foo(Document):
    a_field = DynamicField(default={})
```

This is one of the Python's pitfalls, known by a few Python developers. I believe this corner-case should be handled by mongoengine.

This patch intends to prevent this to happen by introducing a functional change. Field default value is now copied when being used, unless told otherwise thru the new `copy_default` parameter.

Signed-off-by: Tristan Carel tristan.carel@gmail.com

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1078)

<!-- Reviewable:end -->
