### PR TITLE
Implemented support for switchable connection handlers

### DIFF
--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -1,7 +1,8 @@
 from pymongo import MongoClient, ReadPreference, uri_parser
 from mongoengine.python_support import IS_PYMONGO_3
 
-__all__ = ['ConnectionError', 'connect', 'register_connection', 'BaseConnectionHandler']
+__all__ = ['ConnectionError', 'BaseConnectionHandler',
+           'connect', 'register_connection', 'set_connection_handler']
 
 
 class ConnectionError(Exception):

--- a/mongoengine/context_managers.py
+++ b/mongoengine/context_managers.py
@@ -1,5 +1,5 @@
 from mongoengine.common import _import_class
-from mongoengine.connection import DEFAULT_CONNECTION_NAME, get_db
+from mongoengine.connection import get_db
 
 
 __all__ = ("switch_db", "switch_collection", "no_dereference",
@@ -34,7 +34,7 @@ class switch_db(object):
         self.cls = cls
         self.collection = cls._get_collection()
         self.db_alias = db_alias
-        self.ori_db_alias = cls._meta.get("db_alias", DEFAULT_CONNECTION_NAME)
+        self.ori_db_alias = cls._meta.get("db_alias")
 
     def __enter__(self):
         """ change the db_alias and clear the cached collection """

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -21,7 +21,7 @@ from mongoengine.errors import (InvalidQueryError, InvalidDocumentError,
 from mongoengine.python_support import IS_PYMONGO_3
 from mongoengine.queryset import (OperationError, NotUniqueError,
                                   QuerySet, transform)
-from mongoengine.connection import get_db, DEFAULT_CONNECTION_NAME
+from mongoengine.connection import get_db
 from mongoengine.context_managers import switch_db, switch_collection
 
 __all__ = ('Document', 'EmbeddedDocument', 'DynamicDocument',
@@ -167,7 +167,7 @@ class Document(BaseDocument):
     @classmethod
     def _get_db(cls):
         """Some Model using other db_alias"""
-        return get_db(cls._meta.get("db_alias", DEFAULT_CONNECTION_NAME))
+        return get_db(alias=cls._meta.get("db_alias"))
 
     @classmethod
     def _get_collection(cls):
@@ -480,10 +480,10 @@ class Document(BaseDocument):
         """
         signals.pre_delete.send(self.__class__, document=self)
 
-        # Delete FileFields separately 
+        # Delete FileFields separately
         FileField = _import_class('FileField')
         for name, field in self._fields.iteritems():
-            if isinstance(field, FileField): 
+            if isinstance(field, FileField):
                 getattr(self, name).delete()
 
         try:

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -26,7 +26,7 @@ from base import (BaseField, ComplexBaseField, ObjectIdField, GeoJsonBaseField,
                   get_document, BaseDocument)
 from queryset import DO_NOTHING, QuerySet
 from document import Document, EmbeddedDocument
-from connection import get_db, DEFAULT_CONNECTION_NAME
+from connection import get_db
 
 try:
     from PIL import Image, ImageOps
@@ -989,7 +989,7 @@ class ReferenceField(BaseField):
 class CachedReferenceField(BaseField):
     """
     A referencefield with cache fields to purpose pseudo-joins
-    
+
     .. versionadded:: 0.9
     """
 
@@ -1274,7 +1274,7 @@ class GridFSProxy(object):
 
     def __init__(self, grid_id=None, key=None,
                  instance=None,
-                 db_alias=DEFAULT_CONNECTION_NAME,
+                 db_alias=None,
                  collection_name='fs'):
         self.grid_id = grid_id  # Store GridFS id for file
         self.key = key
@@ -1417,7 +1417,7 @@ class FileField(BaseField):
     proxy_class = GridFSProxy
 
     def __init__(self,
-                 db_alias=DEFAULT_CONNECTION_NAME,
+                 db_alias=None,
                  collection_name="fs", **kwargs):
         super(FileField, self).__init__(**kwargs)
         self.collection_name = collection_name
@@ -1688,11 +1688,11 @@ class SequenceField(BaseField):
     representation of the default integer counter value.
     
     .. note::
-    
-        In case the counter is defined in the abstract document, it will be 
-        common to all inherited documents and the default sequence name will 
+
+        In case the counter is defined in the abstract document, it will be
+        common to all inherited documents and the default sequence name will
         be the class name of the abstract document.
-    
+
     .. versionadded:: 0.5
     .. versionchanged:: 0.8 added `value_decorator`
     """
@@ -1704,7 +1704,7 @@ class SequenceField(BaseField):
     def __init__(self, collection_name=None, db_alias=None, sequence_name=None,
                  value_decorator=None, *args, **kwargs):
         self.collection_name = collection_name or self.COLLECTION_NAME
-        self.db_alias = db_alias or DEFAULT_CONNECTION_NAME
+        self.db_alias = db_alias
         self.sequence_name = sequence_name
         self.value_decorator = (callable(value_decorator) and
                                 value_decorator or self.VALUE_DECORATOR)

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -21,7 +21,7 @@ from decimal import Decimal
 from bson import Binary, DBRef, ObjectId
 
 from mongoengine import *
-from mongoengine.connection import get_db
+from mongoengine.connection import get_db, purge
 from mongoengine.base import _document_registry
 from mongoengine.base.datastructures import BaseDict, EmbeddedDocumentList
 from mongoengine.errors import NotRegistered
@@ -33,6 +33,7 @@ __all__ = ("FieldTest", "EmbeddedDocumentListFieldTestCase")
 class FieldTest(unittest.TestCase):
 
     def setUp(self):
+        purge()
         connect(db='mongoenginetest')
         self.db = get_db()
 
@@ -40,6 +41,7 @@ class FieldTest(unittest.TestCase):
         self.db.drop_collection('fs.files')
         self.db.drop_collection('fs.chunks')
         self.db.drop_collection('mongoengine.counters')
+        purge()
 
     def test_default_values_nothing_set(self):
         """Ensure that default field values are used when creating a document.
@@ -575,9 +577,7 @@ class FieldTest(unittest.TestCase):
         from mongoengine import connection
 
         # Reset the connections
-        connection._connection_settings = {}
-        connection._connections = {}
-        connection._dbs = {}
+        purge()
 
         connect(db='mongoenginetest', tz_aware=True)
 
@@ -1617,7 +1617,7 @@ class FieldTest(unittest.TestCase):
                                'parent': "50a234ea469ac1eda42d347d"})
         mongoed = p1.to_mongo()
         self.assertTrue(isinstance(mongoed['parent'], ObjectId))
-        
+
     def test_cached_reference_field_get_and_save(self):
         """
         Tests #1047: CachedReferenceField creates DBRefs on to_python, but can't save them on to_mongo
@@ -1629,11 +1629,11 @@ class FieldTest(unittest.TestCase):
         class Ocorrence(Document):
             person = StringField()
             animal = CachedReferenceField(Animal)
-        
+
         Animal.drop_collection()
         Ocorrence.drop_collection()
-        
-        Ocorrence(person="testte", 
+
+        Ocorrence(person="testte",
                   animal=Animal(name="Leopard", tag="heavy").save()).save()
         p = Ocorrence.objects.get()
         p.person = 'new_testte'

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -16,7 +16,7 @@ from pymongo.read_preferences import ReadPreference
 from bson import ObjectId, DBRef
 
 from mongoengine import *
-from mongoengine.connection import get_connection, get_db
+from mongoengine.connection import get_connection, get_db, purge
 from mongoengine.python_support import PY3, IS_PYMONGO_3
 from mongoengine.context_managers import query_counter, switch_db
 from mongoengine.queryset import (QuerySet, QuerySetManager,
@@ -68,6 +68,7 @@ def skip_pymongo3(f):
 class QuerySetTest(unittest.TestCase):
 
     def setUp(self):
+        purge()
         connect(db='mongoenginetest')
         connect(db='mongoenginetest2', alias='test2')
 
@@ -83,6 +84,9 @@ class QuerySetTest(unittest.TestCase):
         Person.drop_collection()
         self.PersonMeta = PersonMeta
         self.Person = Person
+
+    def tearDown(self):
+        purge()
 
     def test_initialisation(self):
         """Ensure that a QuerySet is correctly initialised by QuerySetManager.

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -31,9 +31,7 @@ def get_tz_awareness(connection):
 class ConnectionTest(unittest.TestCase):
 
     def tearDown(self):
-        mongoengine.connection._connection_settings = {}
-        mongoengine.connection._connections = {}
-        mongoengine.connection._dbs = {}
+        mongoengine.connection._connection_handler.purge()
 
     def test_connect(self):
         """Ensure that the connect() method works properly.
@@ -207,7 +205,7 @@ class ConnectionTest(unittest.TestCase):
 
         connect('mongoenginetest2', alias='t2', host="127.0.0.1")
 
-        mongo_connections = mongoengine.connection._connections
+        mongo_connections = mongoengine.connection._connection_handler.__connections__
         self.assertEqual(len(mongo_connections.items()), 2)
         self.assertTrue('t1' in mongo_connections.keys())
         self.assertTrue('t2' in mongo_connections.keys())

--- a/tests/test_replicaset_connection.py
+++ b/tests/test_replicaset_connection.py
@@ -24,14 +24,10 @@ from mongoengine.connection import ConnectionError
 class ConnectionTest(unittest.TestCase):
 
     def setUp(self):
-        mongoengine.connection._connection_settings = {}
-        mongoengine.connection._connections = {}
-        mongoengine.connection._dbs = {}
+        mongoengine.connection._connection_handler.purge()
 
     def tearDown(self):
-        mongoengine.connection._connection_settings = {}
-        mongoengine.connection._connections = {}
-        mongoengine.connection._dbs = {}
+        mongoengine.connection._connection_handler.purge()
 
     def test_replicaset_uri_passes_read_preference(self):
         """Requires a replica set called "rs" on port 27017


### PR DESCRIPTION
I moved all code related to database connection setup into DefaultConnectionHandler and updated tests accordingly.

This code allows to implement custom logic for controlling database connections. For example, in my application i want to switch database by setting `db_alias` in `flask.g`. So, i'll use following approach:

``` python
from mongoengine.connection import DefaultConnectionHandler, set_connection_handler

class MyHandler(DefaultConnectionHandler):
    def get_db(self, *args, **kwargs):
        return super(MyHandler, self).get_db(alias=flask.g.db_alias)

set_connection_handler(MyHandler())
```

My code passes tests, but i'd like to listen to any opinions about this solution.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1080)

<!-- Reviewable:end -->
