### PR TITLE
Remove 'rednose' dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,4 @@
 [nosetests]
-rednose = 1
 verbosity = 2
 detailed-errors = 1
 cover-erase = 1

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,6 @@ setup(name='mongoengine',
       classifiers=CLASSIFIERS,
       install_requires=['pymongo>=2.7.1'],
       test_suite='nose.collector',
-      setup_requires=['nose', 'rednose'],  # Allow proper nose usage with setuptols and tox
+      setup_requires=['nose'],  # Allow proper nose usage with setuptols and tox
       **extra_opts
 )


### PR DESCRIPTION
It’s hosted on an unreliable third-party site, and is unnecessary for mongoengine.

See: #1079.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1082)
<!-- Reviewable:end -->
