### PR TITLE
Bad property name for text search index meta

### DIFF
--- a/docs/guide/text-indexes.rst
+++ b/docs/guide/text-indexes.rst
@@ -17,7 +17,7 @@ Use the *$* prefix to set a text index, Look the declaration::
       meta = {'indexes': [
           {'fields': ['$title', "$content"],
            'default_language': 'english',
-           'weight': {'title': 10, 'content': 2}
+           'weights': {'title': 10, 'content': 2}
           }
       ]}
 


### PR DESCRIPTION
The correct name for MongoDB text search index definition property is "weights" not "weight". Using "weight" will cause "Index with name ... already exists with different options". This is misleading and has to be changed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1084)
<!-- Reviewable:end -->
