### PR TITLE
Fix DictField with '_cls' field is converted to Document on access

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -794,6 +794,7 @@ class DictField(ComplexBaseField):
 
     def __init__(self, basecls=None, field=None, *args, **kwargs):
         self.field = field
+        self._auto_dereference = False
         self.basecls = basecls or BaseField
         if not issubclass(self.basecls, BaseField):
             self.error('DictField only accepts dict values')


### PR DESCRIPTION
Following issue #1058

The fix is pretty simple: set `_auto_dereference` to `False` in DictField `__init__`

However I'm wondering why the `__get__` method with dereferencing functionality are in so many places (`ComplexBaseField`, `ReferenceField`, `CachedReferenceField`, `GenericReferenceField`).
From my point of view, their should be a single `Dereferencable` wich implement this special `__get__` method. Class which should be subclassed by the reference related fields only.

@MRigal This part of the code is not simple to understand, so it's possible I'm missing a point (or the actual behavior is already more or less what I'm saying), so what do you think of this ?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1088)
<!-- Reviewable:end -->
