### PR TITLE
save_condition falls back to "n" if "nModified" is not found to suppo…

### DIFF
--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -361,8 +361,7 @@ class Document(BaseDocument):
                     upsert = save_condition is None
                     last_error = collection.update(select_dict, update_query,
                                                    upsert=upsert, **write_concern)
-                    n_modified = last_error.get('nModified', last_error["n"])
-                    if not upsert and n_modified == 0:
+                    if not upsert and last_error["n"] == 0:
                         raise SaveConditionError('Race condition preventing'
                                                  ' document update detected')
                     created = is_new_object(last_error)

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -361,7 +361,8 @@ class Document(BaseDocument):
                     upsert = save_condition is None
                     last_error = collection.update(select_dict, update_query,
                                                    upsert=upsert, **write_concern)
-                    if not upsert and last_error['nModified'] == 0:
+                    n_modified = last_error.get('nModified', last_error["n"])
+                    if not upsert and n_modified == 0:
                         raise SaveConditionError('Race condition preventing'
                                                  ' document update detected')
                     created = is_new_object(last_error)


### PR DESCRIPTION
A one line edit so that those of us still stuck on 2.4 can enjoy the save_condition atomicity :) When nModified is not available, if falls back to "n"

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1096)
<!-- Reviewable:end -->
