### PR TITLE
Prevent pymongo 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pymongo
+pymongo<=2.8.1


### PR DESCRIPTION
RE: #939 
pymongo3 breaks mongoengine==0.9.0 this will prevent  users from adding pymongo<=2.8.1 to their requirements.txt as well as make .9 work "out of the box"

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1097)
<!-- Reviewable:end -->
