### PR TITLE
fix-#1105: StrictDict & SemiStrictDict are shadowed at init time

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Changes in 0.10.1 - DEV
 - Fix ignored chained options #842
 - Document save's save_condition error raises `SaveConditionError` exception #1070
 - Fix Document.reload for DynamicDocument. #1050
+- StrictDict & SemiStrictDict are shadowed at init time. #1105
 
 Changes in 0.10.0
 =================

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -85,7 +85,6 @@ class BaseDocument(object):
             self._data = SemiStrictDict.create(
                 allowed_keys=self._fields_ordered)()
 
-        self._data = {}
         self._dynamic_fields = SON()
 
         # Assign default values to instance


### PR DESCRIPTION
fixes #1105

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1113)
<!-- Reviewable:end -->
