### PR TITLE
Allow sparse compound indexes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changes in 0.10.6 - Dev
 =======================
 - Add support for mocking MongoEngine based on mongomock. #1151
 - Fixed not being able to run tests on Windows. #1153
+- Allow creation of sparse compound indexes. #1114
 
 Changes in 0.10.5
 =================

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -839,10 +839,6 @@ class BaseDocument(object):
 
         if index_list:
             spec['fields'] = index_list
-        if spec.get('sparse', False) and len(spec['fields']) > 1:
-            raise ValueError(
-                'Sparse indexes can only have one field in them. '
-                'See https://jira.mongodb.org/browse/SERVER-2193')
 
         return spec
 

--- a/tests/document/indexes.py
+++ b/tests/document/indexes.py
@@ -863,6 +863,20 @@ class IndexesTest(unittest.TestCase):
         self.assertTrue([('provider_ids.foo', 1)] in info)
         self.assertTrue([('provider_ids.bar', 1)] in info)
 
+    def test_sparse_compound_indexes(self):
+
+        class MyDoc(Document):
+            provider_ids = DictField()
+            meta = {
+                "indexes": [{'fields': ("provider_ids.foo", "provider_ids.bar"),
+                             'sparse': True}],
+            }
+
+        info = MyDoc.objects._collection.index_information()
+        self.assertEqual([('provider_ids.foo', 1), ('provider_ids.bar', 1)],
+                         info['provider_ids.foo_1_provider_ids.bar_1']['key'])
+        self.assertTrue(info['provider_ids.foo_1_provider_ids.bar_1']['sparse'])
+
     def test_text_indexes(self):
 
         class Book(Document):


### PR DESCRIPTION
As of MongoDB 2.6, sparse compound indexes are allowed: <http://docs.mongodb.org/manual/core/index-sparse/#sparse-compound-indexes>.  This removes the explicit check prohibiting sparse compound indexes.  Also, I added a unit test to make sure that sparse-compound indexes work.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1114)
<!-- Reviewable:end -->
