### PR TITLE
Enable ops in queries using elemMatch for EmbeddedDocuments

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ Changes in 0.10.1 - DEV
 - Fix Document.reload for DynamicDocument. #1050
 - StrictDict & SemiStrictDict are shadowed at init time. #1105
 - Remove test dependencies (nose and rednose) from install dependencies list. #1079
+- Recursively build query when using elemMatch operator. #1130
 
 Changes in 0.10.0
 =================

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -4116,6 +4116,15 @@ class QuerySetTest(unittest.TestCase):
         ak = list(Bar.objects(foo__match=Foo(shape="square", color="purple")))
         self.assertEqual([b1], ak)
 
+        ak = list(
+            Bar.objects(foo__elemMatch={'shape': "square", "color__exists": True}))
+        self.assertEqual([b1, b2], ak)
+
+        ak = list(
+            Bar.objects(foo__match={'shape': "square", "color__exists": True}))
+        self.assertEqual([b1, b2], ak)
+
+
     def test_upsert_includes_cls(self):
         """Upserts should include _cls information for inheritable classes
         """


### PR DESCRIPTION
The following example query would have failed to compile:
```
Bar.objects(foo__elemMatch={'shape': "square", "color__exists": True})
```

This adds support for this query.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1117)
<!-- Reviewable:end -->
