### PR TITLE
Move nose/rednose from install dependencies to test dependencies

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -228,3 +228,4 @@ that much better:
  * Vicki Donchenko (https://github.com/kivistein)
  * Emile Caron (https://github.com/emilecaron)
  * Amit Lichtenberg (https://github.com/amitlicht)
+ * Lars Butler (https://github.com/larsbutler)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ Changes in 0.10.1 - DEV
 - Document save's save_condition error raises `SaveConditionError` exception #1070
 - Fix Document.reload for DynamicDocument. #1050
 - StrictDict & SemiStrictDict are shadowed at init time. #1105
+- Remove test dependencies (nose and rednose) from install dependencies list. #1079
 
 Changes in 0.10.0
 =================

--- a/setup.py
+++ b/setup.py
@@ -52,13 +52,13 @@ CLASSIFIERS = [
 extra_opts = {"packages": find_packages(exclude=["tests", "tests.*"])}
 if sys.version_info[0] == 3:
     extra_opts['use_2to3'] = True
-    extra_opts['tests_require'] = ['nose', 'coverage==3.7.1', 'blinker', 'Pillow>=2.0.0']
+    extra_opts['tests_require'] = ['nose', 'rednose', 'coverage==3.7.1', 'blinker', 'Pillow>=2.0.0']
     if "test" in sys.argv or "nosetests" in sys.argv:
         extra_opts['packages'] = find_packages()
         extra_opts['package_data'] = {"tests": ["fields/mongoengine.png", "fields/mongodb_leaf.png"]}
 else:
     # coverage 4 does not support Python 3.2 anymore
-    extra_opts['tests_require'] = ['nose', 'coverage==3.7.1', 'blinker', 'Pillow>=2.0.0', 'python-dateutil']
+    extra_opts['tests_require'] = ['nose', 'rednose', 'coverage==3.7.1', 'blinker', 'Pillow>=2.0.0', 'python-dateutil']
 
     if sys.version_info[0] == 2 and sys.version_info[1] == 6:
         extra_opts['tests_require'].append('unittest2')
@@ -79,6 +79,5 @@ setup(name='mongoengine',
       classifiers=CLASSIFIERS,
       install_requires=['pymongo>=2.7.1'],
       test_suite='nose.collector',
-      setup_requires=['nose', 'rednose'],  # Allow proper nose usage with setuptols and tox
       **extra_opts
 )

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ envlist = {py26,py27,py32,py33,py34,pypy,pypy3}-{mg27,mg28}
 commands =
     python setup.py nosetests {posargs}
 deps =
+    nose
+    rednose
     mg27: PyMongo<2.8
     mg28: PyMongo>=2.8,<3.0
     mg30: PyMongo>=3.0


### PR DESCRIPTION
This patch makes a small but impactful adjustment to the way mongoengine is installed and tested. The result is that `nose` and `rednose` are now no longer required for production installations of mongoengine. Test run semantics and behavior should remain unchanged.

Addresses issue https://github.com/MongoEngine/mongoengine/issues/1079. [Pull request #1082](https://github.com/MongoEngine/mongoengine/pull/1082) attempted to fix this, but it seems to have stalled as of 2.5 months ago.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1121)
<!-- Reviewable:end -->
