### PR TITLE
fields.ReferenceField: add integer values to `reverse_delete_rule` docs

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -863,12 +863,11 @@ class ReferenceField(BaseField):
 
     The options are:
 
-      * DO_NOTHING  - don't do anything (default).
-      * NULLIFY     - Updates the reference to null.
-      * CASCADE     - Deletes the documents associated with the reference.
-      * DENY        - Prevent the deletion of the reference object.
-      * PULL        - Pull the reference from a :class:`~mongoengine.fields.ListField`
-                      of references
+      * DO_NOTHING (0)  - don't do anything (default).
+      * NULLIFY    (1)  - Updates the reference to null.
+      * CASCADE    (2)  - Deletes the documents associated with the reference.
+      * DENY       (3)  - Prevent the deletion of the reference object.
+      * PULL       (4)  - Pull the reference from a :class:`~mongoengine.fields.ListField` of references
 
     Alternative syntax for registering delete rules (useful when implementing
     bi-directional delete rules)


### PR DESCRIPTION
When I first tried to use the `reverse_delete_rule` feature of
`ReferenceField`, I had to dig through the source code to find what the
actual integer values were expected to be for DO_NOTHING, NULLIFY,
CASCADE, DENY, and PULL (or at least, where these constants were defined
so that I could import and use them). This patch adds the integer values
for those constants (which are defined in mongoengine.queryset.base) to
the docs so that users can easily choose the correct integer value.

Note: A possible improvement on this change would be to include
`mongoengine.queryset.base` module documentation in the generated docs,
and then update the `ReferenceField` docs to link to the documentation
of these constants (DO_NOTHING, NULLIFY, etc.). 
[If you'd like me to do this instead of the current minimal change, I'll be happy to amend my patch.]

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1122)
<!-- Reviewable:end -->
