### PR TITLE
Indirection-free optimized field metadata.

### DIFF
--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -172,11 +172,11 @@ arguments can be set on all fields:
         class Shirt(Document):
             size = StringField(max_length=3, choices=SIZE)
 
-:attr:`help_text` (Default: None)
-    Optional help text to output with the field -- used by form libraries
-
-:attr:`verbose_name` (Default: None)
-    Optional human-readable name for the field -- used by form libraries
+:attr:`**kwargs` (Optional)
+    You can supply additional metadata as arbitrary additional keyword
+    arguments.  You can not override existing attributes, however.  Common
+    choices include `help_text` and `verbose_name`, commonly used by form and
+    widget libraries.
 
 
 List fields

--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -64,7 +64,11 @@ class BaseField(object):
             then the default value is set
         :param sparse: (optional) `sparse=True` combined with `unique=True` and `required=False`
             means that uniqueness won't be enforced for `None` values
-        :param **kwargs: (optional) Arbitrary indirection-free metadata for this field.
+        :param **kwargs: (optional) Arbitrary indirection-free metadata for
+            this field can be supplied as additional keyword arguments and
+            accessed as attributes of the field. Must not conflict with any
+            existing attributes. Common metadata includes `verbose_name` and
+            `help_text`.
         """
         self.db_field = (db_field or name) if not primary_key else '_id'
 

--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -82,13 +82,14 @@ class BaseField(object):
         self.sparse = sparse
         self._owner_document = None
         
+        # Detect and report conflicts between metadata and base properties.
         conflicts = set(dir(self)).intersect(kwargs)
         if conflicts:
             raise TypeError("%s already has attribute(s): %s" % (
-                self.__class__.__name__,
-                ', '.join(conflicts)
-            ))
-            
+                self.__class__.__name__, ', '.join(conflicts) ))
+        
+        # Assign metadata to the instance
+        # This efficient method is available because no __slots__ are defined.
         self.__dict__.update(kwargs)
 
         # Adjust the appropriate creation counter, and save our local copy.

--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -41,8 +41,7 @@ class BaseField(object):
 
     def __init__(self, db_field=None, name=None, required=False, default=None,
                  unique=False, unique_with=None, primary_key=False,
-                 validation=None, choices=None, verbose_name=None,
-                 help_text=None, null=False, sparse=False, custom_data=None
+                 validation=None, choices=None, null=False, sparse=False,
                  **kwargs):
         """
         :param db_field: The database field to store this field in
@@ -61,16 +60,10 @@ class BaseField(object):
             field.  Generally this is deprecated in favour of the
             `FIELD.validate` method
         :param choices: (optional) The valid choices
-        :param verbose_name: (optional)  The verbose name for the field.
-            Designed to be human readable and is often used when generating
-            model forms from the document model.
-        :param help_text: (optional) The help text for this field and is often
-            used when generating model forms from the document model.
         :param null: (optional) Is the field value can be null. If no and there is a default value
             then the default value is set
         :param sparse: (optional) `sparse=True` combined with `unique=True` and `required=False`
             means that uniqueness won't be enforced for `None` values
-        :param custom_data: (optional) Custom metadata for this field.
         :param **kwargs: (optional) Arbitrary indirection-free metadata for this field.
         """
         self.db_field = (db_field or name) if not primary_key else '_id'
@@ -85,12 +78,9 @@ class BaseField(object):
         self.primary_key = primary_key
         self.validation = validation
         self.choices = choices
-        self.verbose_name = verbose_name
-        self.help_text = help_text
         self.null = null
         self.sparse = sparse
         self._owner_document = None
-        self.custom_data = custom_data
         
         conflicts = set(dir(self)).intersect(kwargs)
         if conflicts:

--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -42,7 +42,8 @@ class BaseField(object):
     def __init__(self, db_field=None, name=None, required=False, default=None,
                  unique=False, unique_with=None, primary_key=False,
                  validation=None, choices=None, verbose_name=None,
-                 help_text=None, null=False, sparse=False, custom_data=None):
+                 help_text=None, null=False, sparse=False, custom_data=None
+                 **kwargs):
         """
         :param db_field: The database field to store this field in
             (defaults to the name of the field)
@@ -70,6 +71,7 @@ class BaseField(object):
         :param sparse: (optional) `sparse=True` combined with `unique=True` and `required=False`
             means that uniqueness won't be enforced for `None` values
         :param custom_data: (optional) Custom metadata for this field.
+        :param **kwargs: (optional) Arbitrary indirection-free metadata for this field.
         """
         self.db_field = (db_field or name) if not primary_key else '_id'
 
@@ -89,6 +91,15 @@ class BaseField(object):
         self.sparse = sparse
         self._owner_document = None
         self.custom_data = custom_data
+        
+        conflicts = set(dir(self)).intersect(kwargs)
+        if conflicts:
+            raise TypeError("%s already has attribute(s): %s" % (
+                self.__class__.__name__,
+                ', '.join(conflicts)
+            ))
+            
+        self.__dict__.update(kwargs)
 
         # Adjust the appropriate creation counter, and save our local copy.
         if self.db_field == '_id':

--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -83,7 +83,7 @@ class BaseField(object):
         self._owner_document = None
         
         # Detect and report conflicts between metadata and base properties.
-        conflicts = set(dir(self)).intersect(kwargs)
+        conflicts = set(dir(self)) & set(kwargs)
         if conflicts:
             raise TypeError("%s already has attribute(s): %s" % (
                 self.__class__.__name__, ', '.join(conflicts) ))


### PR DESCRIPTION
Please consider this patch.  It:

* **Removes special cases.**  The former `verbose_name`, `help_text`, and `custom_data` special cases have been removed and are fully covered/supported by this change.  Those test cases didn't even need to change, and it's likely advisable to continue to document _de-facto_ standard labels for new users.
* **Saves space.**  Only store metadata you actually care about, i.e. saves three `None` associations on every field if you, like me, don't use the aforementioned metadata in every project.  As `__slots__` is not in use, those would be stored in the `self.__dict__` mapping.  (Which is what this patch updates flexibly instead.)
* **Removes unnecessary indirection.**  Additionally, every access to that metadata requires at least an extra attribute lookup, and will almost always have an additional attribute lookup or array dereferencing beyond that, to support storage of multiple metadata values.
* **Type less, get more done.** Use of `custom_data` as a dictionary adds 20 extra characters to every declaration, or more if using the JSON-like dictionary literal with more than two key/value pairs.
* **Eliminates glue.**  With `custom_data` being what it is, a fixed name, use with most widget libraries will continue to require adaption glue.  Is the value of `custom_data` a dictionary, or instance of a custom class?  More glue.  Arbitrary field metadata allows the application author to adapt MongoEngine to the widget library more easily, through plain declaration of the attributes required by the library.  As the author of a [web framework](https://github.com/marrow/WebCore) that integrates MongoEngine, and a template/widget framework, glue is a concern for me.
* **Has documentation.** Apparently `custom_data` wasn't documented.

Thank you for your consideration.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1129)
<!-- Reviewable:end -->
