### PR TITLE
Support dotted notation in the db_field parameter

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -49,6 +49,18 @@ __all__ = [
 
 RECURSIVE_REFERENCE_CONSTANT = 'self'
 
+class BetterBaseFieldMixin(object):
+    def __get__(self, instance, owner):
+        """Enhanced descriptor that fetches data from mongo dictionaries based on dotted field notation.
+        """
+        val = super(BetterBaseFieldMixin, self).__get__(instance, owner)
+        if val is not None:
+            return val
+        db_field_name_seq = self.db_field.split('.')
+        if len(db_field_name_seq) > 1:
+            val = reduce(lambda d, k: d.get(k) if d else None, db_field_name_seq, instance._data)
+            return val
+
 
 class StringField(BaseField):
     """A unicode string field.


### PR DESCRIPTION
Issue:  support dotted notation in the db_field parameter
Currently this doesn't work: StringField(db_field='aParentKey.aChildKey')

Proposal: Add some lines to the **get** descriptor in BaseField

Caveat: I haven't even checked or tried the **set** descriptor

``` python
from mongoengine import DynamicDocument, StringField, IntField, connect
from mongoengine.fields import BetterBaseFieldMixin

class BetterStringField(BetterBaseFieldMixin, StringField):
    pass


class PumpkinWithNormalField(DynamicDocument):
    meta = {'collection':'pumpkins'}
    name = StringField()
    color = StringField()
    seeds = IntField()
    candle_color = StringField(db_field='candle.color')

    def __repr__(self):
        attrs = 'name candle_color id'.split()
        kv = ['%s=%s' % (k, unicode(getattr(self, k)),) for k in attrs]
        extra = ', '.join(kv)
        return '<%s %s>' % (self.__class__.__name__, extra,)

class PumpkinWithBetterField(DynamicDocument):
    meta = {'collection':'pumpkins'}
    name = StringField()
    color = StringField()
    seeds = IntField()
    candle_color = BetterStringField(db_field='candle.color')

    def __repr__(self):
        attrs = 'name candle_color id'.split()
        kv = ['%s=%s' % (k, unicode(getattr(self, k)),) for k in attrs]
        extra = ', '.join(kv)
        return '<%s %s>' % (self.__class__.__name__, extra,)

fixtures = [
        {'candle': {'burned': True, 'centimeters': 3.1, 'color': 'white'},
        'color': 'orange',
        'kilograms': 4.21,
        'name': 'spooky',
        'seeds': 491,
        'teeth': 8},
        {'candle': None,
        'color': 'orange',
        'kilograms': 1.31,
        'name': 'tiny',
        'seeds': 174,
        'teeth': 0},
        {'candle': {'burned': True, 'centimeters': 4.4, 'color': 'white'},
        'color': 'orange',
        'kilograms': 2.53,
        'name': 'ugly',
        'seeds': 405,
        'teeth': 6}
    ]

client = connect('test')

if not client.test.pumpkins.count():
    for record in fixtures:
        client.test.pumpkins.insert(record)


print 'See how the better pumpkins have candle colors?'
print 
for better_pumpkin in PumpkinWithNormalField.objects.filter(candle__color__exists=True):
    normal_pumpkin = PumpkinWithNormalField.objects.get(id=better_pumpkin.id)
    print 'better pumpkin candle color:', better_pumpkin.candle_color
    print 'normal_pumpkin candle color:', normal_pumpkin.candle_color
    print


assert PumpkinWithNormalField.objects.filter(candle__color__exists=True).count() == PumpkinWithBetterField.objects.filter(candle__color__exists=True).count()
print PumpkinWithNormalField.objects.filter(candle__color__exists=True)
print PumpkinWithBetterField.objects.filter(candle__color__exists=True)
```
## out

```
See how the better pumpkins have candle colors?

better pumpkin candle color: white
normal_pumpkin candle color: None

better pumpkin candle color: white
normal_pumpkin candle color: None

[<PumpkinWithNormalField name=spooky, candle_color=None, id=56287a52c86997beab2e1135>, <PumpkinWithNormalField name=ugly, candle_color=None, id=56287a52c86997beab2e1137>]
[<PumpkinWithBetterField name=spooky, candle_color=white, id=56287a52c86997beab2e1135>, <PumpkinWithBetterField name=ugly, candle_color=white, id=56287a52c86997beab2e1137>]
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1133)

<!-- Reviewable:end -->
