### PR TITLE
Add support related to abc in `Document` and `EmbeddedDocument`

### DIFF
--- a/mongoengine/base/metaclasses.py
+++ b/mongoengine/base/metaclasses.py
@@ -1,3 +1,4 @@
+from abc import ABCMeta
 import warnings
 
 from mongoengine.common import _import_class
@@ -13,7 +14,7 @@ from mongoengine.base.fields import BaseField, ComplexBaseField, ObjectIdField
 __all__ = ('DocumentMetaclass', 'TopLevelDocumentMetaclass')
 
 
-class DocumentMetaclass(type):
+class DocumentMetaclass(ABCMeta):
     """Metaclass for all documents.
     """
 

--- a/tests/document/inheritance.py
+++ b/tests/document/inheritance.py
@@ -470,6 +470,26 @@ class InheritanceTest(unittest.TestCase):
 
         self.assertFalse(B._meta["abstract"])
 
+    def test_abstract_makes_abcmeta(self):
+        from abc import abstractmethod
+
+        class A(EmbeddedDocument):
+            meta = {"abstract": True}
+
+            @abstractmethod
+            def method(self):
+                """ Must be implemented in subclasses """
+
+        class B(A):
+            """ Does not implement ``method`` """
+
+        class C(A):
+            def method(self):
+                """ Everything is good, method is implemented """
+
+        self.assertRaises(Exception, B)
+        self.assertNotEqual(C(), None)
+
     def test_inherited_collections(self):
         """Ensure that subclassed documents don't override parents'
         collections


### PR DESCRIPTION
Decorating with @abstractmethod will behave the same way as if using the
abc.ABCMeta as a metaclass.

This is something I was looking for when I have a Document or EmbeddedDocument declared as abstract. 

``` python
class A(Document):
    meta = {"abstract" = True}
```

My intent at first was to only make the metaclass inherit from abc.ABCMeta if `meta["abstract"] is True`, but it's not as trivial as inheriting all the time. I don't see any drawback of the latest, but if there is and that I'm not the only one looking for that feature, I'd be glad to look a little more into it.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1139)

<!-- Reviewable:end -->
