### PR TITLE
Resolve configparser issue on pypy3 pip install or setup.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,12 @@ import os
 import sys
 from setuptools import setup, find_packages
 
+# Avoid configparser issues on PyPy3
+if sys.version_info >= (3, 0):
+    from distutils.core import setup
+else:
+    from setuptools import setup
+
 # Hack to silence atexit traceback in newer python versions
 try:
     import multiprocessing


### PR DESCRIPTION
- To resolve `configparser.InterpolationSyntaxError: '%' must be followed by '%' or '(', found: '%pypi'`

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1149)
<!-- Reviewable:end -->
