### PR TITLE
Add support for mocking MongoEngine based on mongomock

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -233,3 +233,4 @@ that much better:
  * Ashley Whetter (https://github.com/AWhetter)
  * Paul-Armand Verhaegen (https://github.com/paularmand)
  * Steven Rossiter (https://github.com/BeardedSteve)
+ * Luo Peng (https://github.com/RussellLuo)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 Changes in 0.10.5
 =================
 - Fix for reloading of strict with special fields. #1156
+- Add support for mocking MongoEngine based on mongomock. #1151
 
 Changes in 0.10.4
 =================

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -8,6 +8,7 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
+from nose.plugins.skip import SkipTest
 
 import pymongo
 from bson.tz_util import utc
@@ -50,6 +51,22 @@ class ConnectionTest(unittest.TestCase):
         connect('mongoenginetest2', alias='testdb')
         conn = get_connection('testdb')
         self.assertTrue(isinstance(conn, pymongo.mongo_client.MongoClient))
+
+    def test_connect_in_mocking(self):
+        """Ensure that the connect() method works properly in mocking.
+        """
+        try:
+            import mongomock
+        except ImportError:
+            raise SkipTest('you need mongomock installed to run this testcase')
+
+        connect('mongoenginetest', host='mongomock://localhost')
+        conn = get_connection()
+        self.assertTrue(isinstance(conn, mongomock.MongoClient))
+
+        connect('mongoenginetest2', host='mongomock://localhost', alias='testdb')
+        conn = get_connection('testdb')
+        self.assertTrue(isinstance(conn, mongomock.MongoClient))
 
     def test_disconnect(self):
         """Ensure that the disconnect() method works properly
@@ -151,7 +168,7 @@ class ConnectionTest(unittest.TestCase):
             self.assertRaises(ConnectionError, get_db, 'test1')
 
         # Authentication succeeds with "authSource"
-        test_conn2 = connect(
+        connect(
             'mongoenginetest', alias='test2',
             host=('mongodb://username2:password@localhost/'
                   'mongoenginetest?authSource=admin')


### PR DESCRIPTION
Using `mongomock://` scheme in URI enables the mocking. Fix #1045.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1151)
<!-- Reviewable:end -->
