### PR TITLE
Fixed not being able to run tests on Windows

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 Changes in 0.10.6 - Dev
 =======================
 - Add support for mocking MongoEngine based on mongomock. #1151
+- Fixed not being able to run tests on Windows. #1153
 
 Changes in 0.10.5
 =================

--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,6 @@ deps =
     mg28: PyMongo>=2.8,<3.0
     mg30: PyMongo>=3.0
     mgdev: https://github.com/mongodb/mongo-python-driver/tarball/master
+setenv =
+    PYTHON_EGG_CACHE = {envdir}/python-eggs
+passenv = windir


### PR DESCRIPTION
On windows, pip needs the PYTHON_EGG_CACHE and windir environment variables to be able to install packages correctly. Therefore tox needs to pass these variables down to pip when tox installs packages locally.
PYTHON_EGG_CACHE is set to reside in the virtualenv directory so that it does not pollute a users global egg cache directory. Plus it may not be set by a user, even though I found it to be required for pip to run in virtualenv with tox.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1153)
<!-- Reviewable:end -->
