### PR TITLE
ReferenceFields can now reference abstract Document types

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -230,3 +230,4 @@ that much better:
  * Amit Lichtenberg (https://github.com/amitlicht)
  * Lars Butler (https://github.com/larsbutler)
  * George Macon (https://github.com/gmacon)
+ * Ashley Whetter (https://github.com/AWhetter)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changes in 0.10.2
 =================
 - Allow shard key to point to a field in an embedded document. #551
 - Allow arbirary metadata in fields. #1129
+- ReferenceFields now support abstract document types. #837
 
 Changes in 0.10.1
 =======================

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -967,12 +967,12 @@ class ReferenceField(BaseField):
         id_field = cls._fields[id_field_name]
 
         id_ = id_field.to_mongo(id_)
-        if self.dbref:
-            collection = cls._get_collection_name()
-            return DBRef(collection, id_)
-        elif self.document_type._meta.get('abstract'):
+        if self.document_type._meta.get('abstract'):
             collection = cls._get_collection_name()
             return DBRef(collection, id_, cls=cls._class_name)
+        elif self.dbref:
+            collection = cls._get_collection_name()
+            return DBRef(collection, id_)
 
         return id_
 

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -996,6 +996,14 @@ class ReferenceField(BaseField):
             self.error('You can only reference documents once they have been '
                        'saved to the database')
 
+        if self.document_type._meta.get('abstract') and \
+                not isinstance(value, self.document_type):
+            self.error('%s is not an instance of abstract reference'
+                    ' type %s' % (value._class_name,
+                        self.document_type._class_name)
+                    )
+
+
     def lookup_member(self, member_name):
         return self.document_type._fields.get(member_name)
 

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -896,6 +896,10 @@ class ReferenceField(BaseField):
           or as the :class:`~pymongo.objectid.ObjectId`.id .
         :param reverse_delete_rule: Determines what to do when the referring
           object is deleted
+
+        .. note ::
+            A reference to an abstract document type is always stored as a
+            :class:`~pymongo.dbref.DBRef`, regardless of the value of `dbref`.
         """
         if not isinstance(document_type, basestring):
             if not issubclass(document_type, (Document, basestring)):

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -2331,6 +2331,31 @@ class FieldTest(unittest.TestCase):
         Sister.drop_collection()
         Brother.drop_collection()
 
+    def test_abstract_reference_base_type(self):
+        """Ensure that an an abstract reference fails validation when given a
+        Document that does not inherit from the abstract type.
+        """
+        class Sibling(Document):
+            name = StringField()
+            meta = {"abstract": True}
+
+        class Brother(Sibling):
+            sibling = ReferenceField(Sibling)
+
+        class Mother(Document):
+            name = StringField()
+
+        Brother.drop_collection()
+        Mother.drop_collection()
+
+        mother = Mother(name="Carol")
+        mother.save()
+        brother = Brother(name="Bob", sibling=mother)
+        self.assertRaises(ValidationError, brother.save)
+
+        Brother.drop_collection()
+        Mother.drop_collection()
+
     def test_generic_reference(self):
         """Ensure that a GenericReferenceField properly dereferences items.
         """

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -2281,6 +2281,56 @@ class FieldTest(unittest.TestCase):
         Member.drop_collection()
         BlogPost.drop_collection()
 
+    def test_reference_class_with_abstract_parent(self):
+        """Ensure that a class with an abstract parent can be referenced.
+        """
+        class Sibling(Document):
+            name = StringField()
+            meta = {"abstract": True}
+
+        class Sister(Sibling):
+            pass
+
+        class Brother(Sibling):
+            sibling = ReferenceField(Sibling)
+
+        Sister.drop_collection()
+        Brother.drop_collection()
+
+        sister = Sister(name="Alice")
+        sister.save()
+        brother = Brother(name="Bob", sibling=sister)
+        brother.save()
+
+        self.assertEquals(Brother.objects[0].sibling.name, sister.name)
+
+        Sister.drop_collection()
+        Brother.drop_collection()
+
+    def test_reference_abstract_class(self):
+        """Ensure that an abstract class instance cannot be used in the
+        reference of that abstract class.
+        """
+        class Sibling(Document):
+            name = StringField()
+            meta = {"abstract": True}
+
+        class Sister(Sibling):
+            pass
+
+        class Brother(Sibling):
+            sibling = ReferenceField(Sibling)
+
+        Sister.drop_collection()
+        Brother.drop_collection()
+
+        sister = Sibling(name="Alice")
+        brother = Brother(name="Bob", sibling=sister)
+        self.assertRaises(ValidationError, brother.save)
+
+        Sister.drop_collection()
+        Brother.drop_collection()
+
     def test_generic_reference(self):
         """Ensure that a GenericReferenceField properly dereferences items.
         """


### PR DESCRIPTION
Documents can now reference abstract types, and refer to any Document that inherits from the type. For example:
```python
class Sibling(Document):
    name = StringField()
    meta = {"abstract": True}

class Sister(Sibling):
    pass

class Brother(Sibling):
    sibling = ReferenceField(Sibling)

class Mother(Document):
    name = StringField()
```
In this situation, a Brother can store an instance of a Sister or a Brother in the `sibling` field, and retrieve the same Sister or Brother, through the same field, as a full object (and not a Sibling object).

Storing a Document in a reference field of an abstract type will fail validation, however, if the Document does not inherit from the abstract type specified on the ReferenceField. Thus trying to store a Mother on the `sibling` field of Brother, will fail validation.

Fixes #837

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1155)
<!-- Reviewable:end -->
