### PR TITLE
Allow shard key to be in an embedded document (#551)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -229,3 +229,4 @@ that much better:
  * Emile Caron (https://github.com/emilecaron)
  * Amit Lichtenberg (https://github.com/amitlicht)
  * Lars Butler (https://github.com/larsbutler)
+ * George Macon (https://github.com/gmacon)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+Changes in 0.10.2
+=================
+- Allow shard key to point to a field in an embedded document. #551
+
 Changes in 0.10.1
 =======================
 - Fix infinite recursion with CASCADE delete rules under specific conditions. #1046

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -341,8 +341,12 @@ class Document(BaseDocument):
                 select_dict['_id'] = object_id
                 shard_key = self.__class__._meta.get('shard_key', tuple())
                 for k in shard_key:
-                    actual_key = self._db_field_map.get(k, k)
-                    select_dict[actual_key] = doc[actual_key]
+                    path = self._lookup_field(k.split('.'))
+                    actual_key = [p.db_field for p in path]
+                    val = doc
+                    for ak in actual_key:
+                        val = val[ak]
+                    select_dict['.'.join(actual_key)] = val
 
                 def is_new_object(last_error):
                     if last_error is not None:
@@ -444,7 +448,12 @@ class Document(BaseDocument):
         select_dict = {'pk': self.pk}
         shard_key = self.__class__._meta.get('shard_key', tuple())
         for k in shard_key:
-            select_dict[k] = getattr(self, k)
+            path = self._lookup_field(k.split('.'))
+            actual_key = [p.db_field for p in path]
+            val = self
+            for ak in actual_key:
+                val = getattr(val, ak)
+            select_dict['__'.join(actual_key)] = val
         return select_dict
 
     def update(self, **kwargs):

--- a/tests/document/instance.py
+++ b/tests/document/instance.py
@@ -484,6 +484,20 @@ class InstanceTest(unittest.TestCase):
         doc.reload()
         Animal.drop_collection()
 
+    def test_reload_sharded_nested(self):
+        class SuperPhylum(EmbeddedDocument):
+            name = StringField()
+
+        class Animal(Document):
+            superphylum = EmbeddedDocumentField(SuperPhylum)
+            meta = {'shard_key': ('superphylum.name',)}
+
+        Animal.drop_collection()
+        doc = Animal(superphylum=SuperPhylum(name='Deuterostomia'))
+        doc.save()
+        doc.reload()
+        Animal.drop_collection()
+
     def test_reload_referencing(self):
         """Ensures reloading updates weakrefs correctly
         """
@@ -2712,6 +2726,32 @@ class InstanceTest(unittest.TestCase):
 
         def change_shard_key():
             log.machine = "127.0.0.1"
+
+        self.assertRaises(OperationError, change_shard_key)
+
+    def test_shard_key_in_embedded_document(self):
+        class Foo(EmbeddedDocument):
+            foo = StringField()
+
+        class Bar(Document):
+            meta = {
+                'shard_key': ('foo.foo',)
+            }
+            foo = EmbeddedDocumentField(Foo)
+            bar = StringField()
+
+        foo_doc = Foo(foo='hello')
+        bar_doc = Bar(foo=foo_doc, bar='world')
+        bar_doc.save()
+
+        self.assertTrue(bar_doc.id is not None)
+
+        bar_doc.bar = 'baz'
+        bar_doc.save()
+
+        def change_shard_key():
+            bar_doc.foo.foo = 'something'
+            bar_doc.save()
 
         self.assertRaises(OperationError, change_shard_key)
 


### PR DESCRIPTION
This implements shard keys on embedded documents (#551).

The implementation here doesn't notice that you've tried to change the shard key until you save the document (though it still works as before when the shard key is on the toplevel document).  I don't see a straightforward way to detect the changed shard keys earlier, so I'm leaving it like this for now, but I can try to come up with a way if you think it's necessary.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1158)
<!-- Reviewable:end -->
