### PR TITLE
EmbeddedDoc. prepare_query_value for None value

### DIFF
--- a/mongoengine/base/datastructures.py
+++ b/mongoengine/base/datastructures.py
@@ -113,7 +113,7 @@ class BaseList(list):
         value = super(BaseList, self).__getitem__(key)
 
         EmbeddedDocument = _import_class('EmbeddedDocument')
-        if isinstance(value, EmbeddedDocument) and value._instance is None:
+        if isinstance(value, EmbeddedDocument) and getattr(value, '_instance', None) is None:
             value._instance = self._instance
         elif not isinstance(value, BaseDict) and isinstance(value, dict):
             value = BaseDict(value, None, '%s.%s' % (self._name, key))

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -491,7 +491,7 @@ class BaseDocument(object):
                 # remove lower level changed fields
                 level = '.'.join(levels[:idx]) + '.'
                 remove = self._changed_fields.remove
-                for field in self._changed_fields:
+                for field in copy.copy(self._changed_fields):
                     if field.startswith(level):
                         remove(field)
 

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -566,8 +566,13 @@ class EmbeddedDocumentField(BaseField):
         return self.document_type._fields.get(member_name)
 
     def prepare_query_value(self, op, value):
+
         if value is None:
-            return None
+            return value
+
+        if isinstance(value, list) and len(value) == 0:
+            return value
+
         if not isinstance(value, self.document_type):
             value = self.document_type._from_son(value)
         super(EmbeddedDocumentField, self).prepare_query_value(op, value)

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -566,6 +566,8 @@ class EmbeddedDocumentField(BaseField):
         return self.document_type._fields.get(member_name)
 
     def prepare_query_value(self, op, value):
+        if value is None:
+            return None
         if not isinstance(value, self.document_type):
             value = self.document_type._from_son(value)
         super(EmbeddedDocumentField, self).prepare_query_value(op, value)


### PR DESCRIPTION
Filtering field for None value on Embedded Document was casing Query to crash.

Something like:

MyModel.objects.filter(myembeddedfield = None)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1163)

<!-- Reviewable:end -->
