### PR TITLE
Add an optional max_length param to the ListField

### DIFF
--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -1056,6 +1056,35 @@ class FieldTest(unittest.TestCase):
 
         Simple.drop_collection()
 
+    def test_list_field_max_length(self):
+        """Ensure that ListField's max_length is respected."""
+
+        class Foo(Document):
+            items = ListField(IntField(), max_length=5)
+
+        foo = Foo()
+
+        # Make sure foo.save doesn't let us save too many items
+        for i in range(5):
+            foo.items.append(i)
+            foo.save()
+
+        foo.items.append(i+1)
+        self.assertRaises(ValidationError, foo.save)
+
+        # Make sure foo.update with $set doesn't let us save too many items
+        self.assertRaises(ValidationError, foo.update, set__items=[1,2,3,4,5,6])
+
+        # Make sure you can still grow the list past the limit with $push.
+        # Ideally it wouldn't be possible, but there's no reliable way to
+        # enforce it (though https://jira.mongodb.org/browse/SERVER-21649 may
+        # change it in the future). Reloading and re-saving the document
+        # should still raise an error.
+        foo.update(push__items=6)
+        foo.reload()
+        self.assertEqual(len(foo.items), 6)
+        self.assertRaises(ValidationError, foo.save)
+
     def test_list_field_rejects_strings(self):
         """Strings aren't valid list field data types"""
 
@@ -1655,7 +1684,7 @@ class FieldTest(unittest.TestCase):
                                'parent': "50a234ea469ac1eda42d347d"})
         mongoed = p1.to_mongo()
         self.assertTrue(isinstance(mongoed['parent'], ObjectId))
-        
+
     def test_cached_reference_field_get_and_save(self):
         """
         Tests #1047: CachedReferenceField creates DBRefs on to_python, but can't save them on to_mongo
@@ -1667,11 +1696,11 @@ class FieldTest(unittest.TestCase):
         class Ocorrence(Document):
             person = StringField()
             animal = CachedReferenceField(Animal)
-        
+
         Animal.drop_collection()
         Ocorrence.drop_collection()
-        
-        Ocorrence(person="testte", 
+
+        Ocorrence(person="testte",
                   animal=Animal(name="Leopard", tag="heavy").save()).save()
         p = Ocorrence.objects.get()
         p.person = 'new_testte'


### PR DESCRIPTION
We have a similar param on a `StringField` already.

For the `ListField`, aside from being a nice feature, it also serves a more important role - it adds a layer of control over your list fields that might be essential to the performance of your database. Accidentally adding a document with thousands of items in a list - especially if they're indexed - can cause a significant slow down in MongoDB. Having `ListField.max_length` doesn't protect you from everything (e.g. $push is still possible), but at least it adds some extra sanity checks.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1174)
<!-- Reviewable:end -->
