### PR TITLE
[Doc] Text search: note about inheritance

### DIFF
--- a/docs/guide/text-indexes.rst
+++ b/docs/guide/text-indexes.rst
@@ -21,6 +21,17 @@ Use the *$* prefix to set a text index, Look the declaration::
           }
       ]}
 
+.. note:: 
+
+  If inheritance is allowed, _cls is added by default to the start of the 
+  index. Thus, to perform a text search, the query predicate must include 
+  equality match conditions on the _cls key (see `Compound Index 
+  <https://docs.mongodb.org/manual/core/index-text/#compound-index>`_), 
+  and MongoEngine can't text search on a class and its subclasses.
+
+  Unless absolutely sure every text search will be performed on a (sub)class
+  with no child class, _cls needs to be removed explicitly from the index 
+  (see :class:`~mongoengine.Document`).
 
 
 Querying


### PR DESCRIPTION
This commit adds a note about text indexes and inheritance.

By default, text search only works when querying for a specific subclass.

Here's my class:

```
class Scenario(db.Document):

    name = db.StringField(required=True, max_length=25,
        verbose_name='Name')
    sources = db.StringField(max_length=25,
        verbose_name='Source')

    meta = {'allow_inheritance': True, 
            'indexes': [ 
                {'fields': ['$name']},
            ]
    }
```

The text index is created:

```
    {
            "v" : 1,
            "key" : {
                    "_cls" : 1,
                    "_fts" : "text",
                    "_ftsx" : 1
            },
            "name" : "_cls_1_name_text",
            "ns" : "myapp.scenario",
            "background" : false,
            "weights" : {
                    "name" : 1
            },
            "default_language" : "english",
            "language_override" : "language",
            "textIndexVersion" : 3
    }
```

Unfortunately, when using [text search](http://docs.mongoengine.org/en/latest/guide/text-indexes.html) like this:

```
Scenario.objects.search_text("test")
```

I get following error:

```
pymongo.errors.OperationFailure: database error: error processing query: ns=simutheque.scenarioTree: $and
    _cls $in [ "Scenario" "Scenario.SubClass1" "Scenario.SubClass2" ]
    TEXT : query=est, language=english, caseSensitive=0, diacriticSensitive=0, tag=NULL
Sort: {}
Proj: { _text_score: { $meta: "textScore" } }
 planner returned error: failed to use text index to satisfy $text query (if text index is compound, are equality predicates given for all prefix fields?)
```

Indeed, according to [MongoDB docs](https://docs.mongodb.org/manual/core/index-text/#compound-index), 

> If the compound text index includes keys preceding the text index key, to perform a $text search, the query predicate must include equality match conditions on the preceding keys.

However, MongoEngine uses the `_cls` attribute and adds it to the index, then to the query:

```
{'_cls': {'$in': ('Scenario', 'Scenario.SubClass1', 'Scenario.SubClass2')}, '$text': SON([('$search', 'test')])}
```

When searching for a specific subclass, however, the query succeeds:

```
{'$and': [{'_cls': {'$in': ('Scenario', 'Scenario.SubClass1', 'Scenario.SubClass2')}}, {'$text': SON([('$search', 'test')]), '_cls': 'Scenario.SubClass1'}]}
```

(BTW, there is something suboptimal here, as the `$in` condition is useless.)

This is fixed by removing _cls from the index.

```
meta = {'allow_inheritance': True, 
        'indexes': [ 
            {'fields': ['$name'], 'cls': False},
        ]
}
```

or

```
meta = {'allow_inheritance': True, 
        'indexes': [ 
            {'fields': ['$name']},
        ],
        'index_cls': False
}
```

I'm not sure this default behavior should be changed in the code, but it is a bit tricky, so I think it ought to be documented.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1209)

<!-- Reviewable:end -->
