### PR TITLE
Mongomock expects a uri which begins with mongodb:// otherwise it thr…

### DIFF
--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -145,6 +145,9 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
                     connection = _connections[db_alias]
                     break
 
+                if is_mock:
+                    conn_settings['host'] = conn_settings['host'].replace('mongomock', 'mongodb')
+
             _connections[alias] = connection if connection else connection_class(**conn_settings)
         except Exception, e:
             raise ConnectionError("Cannot connect to database %s :\n%s" % (alias, e))


### PR DESCRIPTION
…ows an exception. We only need the client to be of type mongomock.MongoClient in order for mongoengine to use mongomock.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1211)
<!-- Reviewable:end -->
