### PR TITLE
Raise TypeError when `__in`-operator used with a Document

### DIFF
--- a/mongoengine/common.py
+++ b/mongoengine/common.py
@@ -34,7 +34,10 @@ def _import_class(cls_name):
     queryset_classes = ('OperationError',)
     deref_classes = ('DeReference',)
 
-    if cls_name in doc_classes:
+    if cls_name == 'BaseDocument':
+        from mongoengine.base import document as module
+        import_classes = ['BaseDocument']
+    elif cls_name in doc_classes:
         from mongoengine import document as module
         import_classes = doc_classes
     elif cls_name in field_classes:

--- a/mongoengine/queryset/transform.py
+++ b/mongoengine/queryset/transform.py
@@ -106,14 +106,14 @@ def query(_doc_cls=None, **kwargs):
                 # it as such in the context of this method is most definitely a mistake.
                 BaseDocument = _import_class('BaseDocument')
                 if isinstance(value, BaseDocument):
-                    raise TypeError('When using the `in`, `nin`, `all`, or ' \
-                                    '`near`-operators you can\'t use a ' \
-                                    '`Document`, you must wrap your object ' \
-                                    'in a list (object -> [object]).')
+                    raise TypeError("When using the `in`, `nin`, `all`, or "
+                                    "`near`-operators you can\'t use a "
+                                    "`Document`, you must wrap your object "
+                                    "in a list (object -> [object]).")
                 elif not hasattr(value, '__iter__'):
-                    raise TypeError('The `in`, `nin`, `all`, or ' \
-                                    '`near`-operators must be applied to an ' \
-                                    'iterable (e.g. a list).')
+                    raise TypeError("The `in`, `nin`, `all`, or "
+                                    "`near`-operators must be applied to an "
+                                    "iterable (e.g. a list).")
                 else:
                     value = [field.prepare_query_value(op, v) for v in value]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,5 +7,5 @@ cover-package=mongoengine
 [flake8]
 ignore=E501,F401,F403,F405,I201
 exclude=build,dist,docs,venv,venv3,.tox,.eggs,tests
-max-complexity=45
+max-complexity=47
 application-import-names=mongoengine,tests

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -4985,10 +4985,8 @@ class QuerySetTest(unittest.TestCase):
         blog_posts = BlogPost.objects(authors__in=[author])
         self.assertEqual(list(blog_posts), [post])
 
-        with self.assertRaises(TypeError):
-            # Using the `__in`-operator with a non-iterable should raise a
-            # TypeError
-            BlogPost.objects(authors__in=author.id).count()
+        # Using the `__in`-operator with a non-iterable should raise a TypeError
+        self.assertRaises(TypeError, BlogPost.objects(authors__in=author.id).count)
 
     def test_in_operator_on_document(self):
         """Ensure that using the `__in` operator on a `Document` raises an
@@ -5012,10 +5010,8 @@ class QuerySetTest(unittest.TestCase):
         blog_posts = BlogPost.objects(authors__in=[author])
         self.assertEqual(list(blog_posts), [post])
 
-        with self.assertRaises(TypeError):
-            # Using the `__in`-operator with a `Document` should raise a
-            # TypeError
-            BlogPost.objects(authors__in=author).count()
+        # Using the `__in`-operator with a `Document` should raise a TypeError
+        self.assertRaises(TypeError, BlogPost.objects(authors__in=author).count)
 
 
 if __name__ == '__main__':

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -4963,6 +4963,60 @@ class QuerySetTest(unittest.TestCase):
         self.assertEqual(i, 249)
         self.assertEqual(j, 249)
 
+    def test_in_operator_on_non_iterable(self):
+        """Ensure that using the `__in` operator on a non-iterable raises an
+        error.
+        """
+        class User(Document):
+            name = StringField()
+
+        class BlogPost(Document):
+            content = StringField()
+            authors = ListField(ReferenceField(User))
+
+        User.drop_collection()
+        BlogPost.drop_collection()
+
+        author = User(name='Test User')
+        author.save()
+        post = BlogPost(content='Had a good coffee today...', authors=[author])
+        post.save()
+
+        blog_posts = BlogPost.objects(authors__in=[author])
+        self.assertEqual(list(blog_posts), [post])
+
+        with self.assertRaises(TypeError):
+            # Using the `__in`-operator with a non-iterable should raise a
+            # TypeError
+            BlogPost.objects(authors__in=author.id).count()
+
+    def test_in_operator_on_document(self):
+        """Ensure that using the `__in` operator on a `Document` raises an
+        error.
+        """
+        class User(Document):
+            name = StringField()
+
+        class BlogPost(Document):
+            content = StringField()
+            authors = ListField(ReferenceField(User))
+
+        User.drop_collection()
+        BlogPost.drop_collection()
+
+        author = User(name='Test User')
+        author.save()
+        post = BlogPost(content='Had a good coffee today...', authors=[author])
+        post.save()
+
+        blog_posts = BlogPost.objects(authors__in=[author])
+        self.assertEqual(list(blog_posts), [post])
+
+        with self.assertRaises(TypeError):
+            # Using the `__in`-operator with a `Document` should raise a
+            # TypeError
+            BlogPost.objects(authors__in=author).count()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Currently doing a query like `BlogPost.objects(authors__in=author).count()`, where `author` is a single MongoEngine-`Document`, raises an obscure error:

```
raise ValidationError(message, errors=errors, field_name=field_name)
mongoengine.errors.ValidationError: u'id' is not a valid ObjectId, it must
be a 12-byte input or a 24-character hex string
```

This pull requests adds a "sanity" check, and raises a TypeError explaining that you need to use an iterable with the `in`-operator.

The correct thing to do is: `BlogPost.objects(authors__in=[author]).count()`, but that's not obvious when you read the `ValidationError` shown above.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1237)

<!-- Reviewable:end -->
