### PR TITLE
Added support for long values in FloatFields

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -260,10 +260,14 @@ class FloatField(BaseField):
         return value
 
     def validate(self, value):
-        if isinstance(value, int):
-            value = float(value)
+        if isinstance(value, (int, long)):
+            try:
+                value = float(value)
+            except OverflowError:
+                self.error('The value is too large to be converted to float')
+
         if not isinstance(value, float):
-            self.error('FloatField only accepts float values')
+            self.error('FloatField only accepts float, int and long values')
 
         if self.min_value is not None and value < self.min_value:
             self.error('Float value is too small')

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -8,6 +8,8 @@ import uuid
 import warnings
 from operator import itemgetter
 
+import six
+
 try:
     import dateutil
 except ImportError:
@@ -260,14 +262,14 @@ class FloatField(BaseField):
         return value
 
     def validate(self, value):
-        if isinstance(value, (int, long)):
+        if isinstance(value, six.integer_types):
             try:
                 value = float(value)
             except OverflowError:
                 self.error('The value is too large to be converted to float')
 
         if not isinstance(value, float):
-            self.error('FloatField only accepts float, int and long values')
+            self.error('FloatField only accepts float and integer values')
 
         if self.min_value is not None and value < self.min_value:
             self.error('Float value is too small')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-pymongo>=2.7.1
 nose
+pymongo>=2.7.1
+six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(name='mongoengine',
       long_description=LONG_DESCRIPTION,
       platforms=['any'],
       classifiers=CLASSIFIERS,
-      install_requires=['pymongo>=2.7.1'],
+      install_requires=['pymongo>=2.7.1', 'six'],
       test_suite='nose.collector',
       **extra_opts
 )

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -399,19 +399,35 @@ class FieldTest(unittest.TestCase):
         class Person(Document):
             height = FloatField(min_value=0.1, max_value=3.5)
 
+        class BigPerson(Document):
+            height = FloatField()
+
         person = Person()
         person.height = 1.89
         person.validate()
 
         person.height = '2.0'
         self.assertRaises(ValidationError, person.validate)
+
         person.height = 0.01
         self.assertRaises(ValidationError, person.validate)
+
         person.height = 4.0
         self.assertRaises(ValidationError, person.validate)
 
         person_2 = Person(height='something invalid')
         self.assertRaises(ValidationError, person_2.validate)
+
+        big_person = BigPerson()
+
+        big_person.height = 1L
+        big_person.validate()
+
+        big_person.height = 2 ** 500
+        big_person.validate()
+
+        big_person.height = 2 ** 100000  # Too big for a float value
+        self.assertRaises(ValidationError, big_person.validate)
 
     def test_decimal_validation(self):
         """Ensure that invalid values cannot be assigned to decimal fields.

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import sys
+
+import six
 from nose.plugins.skip import SkipTest
 
 sys.path[0:0] = [""]
@@ -420,8 +422,9 @@ class FieldTest(unittest.TestCase):
 
         big_person = BigPerson()
 
-        big_person.height = 1L
-        big_person.validate()
+        for value, value_type in enumerate(six.integer_types):
+            big_person.height = value_type(value)
+            big_person.validate()
 
         big_person.height = 2 ** 500
         big_person.validate()


### PR DESCRIPTION

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1240)
<!-- Reviewable:end -->

I thought about decimal support too, but large decimals are being converted to float as 'infinity' implicitly. Also, if one uses decimals for some reason, one is likely going to use DecimalField.