### PR TITLE
Handle unicode keys in DictField/MapField

### DIFF
--- a/mongoengine/dereference.py
+++ b/mongoengine/dereference.py
@@ -9,6 +9,8 @@ from connection import get_db
 from queryset import QuerySet
 from document import Document, EmbeddedDocument
 
+from .python_support import txt_type
+
 
 class DeReference(object):
     def __call__(self, items, max_depth=1, instance=None, name=None):
@@ -226,7 +228,7 @@ class DeReference(object):
                         data[k]._data[field_name] = self.object_map.get(
                             (v['_ref'].collection, v['_ref'].id), v)
                     elif isinstance(v, (dict, list, tuple)) and depth <= self.max_depth:
-                        item_name = "{0}.{1}.{2}".format(name, k, field_name)
+                        item_name = txt_type("{0}.{1}.{2}").format(name, k, field_name)
                         data[k]._data[field_name] = self._attach_objects(v, depth, instance=instance, name=item_name)
             elif isinstance(v, (dict, list, tuple)) and depth <= self.max_depth:
                 item_name = '%s.%s' % (name, k) if name else name


### PR DESCRIPTION
Using unicode keys in DictField/MapField cause an encoding error while trying to compute item_name by concatenating name, k and field_name.