### PR TITLE
Bug fixed accessing BaseList with negative indices

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -236,3 +236,4 @@ that much better:
  * Luo Peng (https://github.com/RussellLuo)
  * Bryan Bennett (https://github.com/bbenne10)
  * Gilb's Gilb's (https://github.com/gilbsgilbs)
+ * Joshua Nedrud (https://github.com/Neurostack)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ Changes in 0.10.7 - DEV
 - count on ListField of EmbeddedDocumentField fails. #1187
 - Fixed long fields stored as int32 in Python 3. #1253
 - MapField now handles unicodes keys correctly. #1267
+- ListField now handles negative indicies correctly. #1270
 
 Changes in 0.10.6
 =================

--- a/mongoengine/base/datastructures.py
+++ b/mongoengine/base/datastructures.py
@@ -199,7 +199,8 @@ class BaseList(list):
     def _mark_as_changed(self, key=None):
         if hasattr(self._instance, '_mark_as_changed'):
             if key:
-                self._instance._mark_as_changed('%s.%s' % (self._name, key))
+                self._instance._mark_as_changed('%s.%s' % (self._name, 
+                    key % len(self)))
             else:
                 self._instance._mark_as_changed(self._name)
 

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -1160,6 +1160,19 @@ class FieldTest(unittest.TestCase):
         simple = simple.reload()
         self.assertEqual(simple.widgets, [4])
 
+    def test_list_field_with_negative_indices(self):
+        
+        class Simple(Document):
+            widgets = ListField()
+
+        simple = Simple(widgets=[1, 2, 3, 4]).save()
+        simple.widgets[-1] = 5
+        self.assertEqual(['widgets.3'], simple._changed_fields)
+        simple.save()
+
+        simple = simple.reload()
+        self.assertEqual(simple.widgets, [1, 2, 3, 5])
+
     def test_list_field_complex(self):
         """Ensure that the list fields can handle the complex types."""
 


### PR DESCRIPTION
If you `__setitem__` in BaseList with a negative index and then try to save this, you will get an error like: 

    OperationError: Could not save document (cannot use the part (shape of signal.shape.-1) to traverse the element ({shape: [ 0 ]})).

To fix this I rectify negative list indices in BaseList _mark_as_changed as the appropriate positive index. This fixes the above error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1270)
<!-- Reviewable:end -->