### PR TITLE
Fix AttributeError when initializing EmbeddedDocuments

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -237,3 +237,4 @@ that much better:
  * Bryan Bennett (https://github.com/bbenne10)
  * Gilb's Gilb's (https://github.com/gilbsgilbs)
  * Joshua Nedrud (https://github.com/Neurostack)
+ * Shu Shen (https://github.com/shushen)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ Changes in 0.10.7 - DEV
 - Fixed long fields stored as int32 in Python 3. #1253
 - MapField now handles unicodes keys correctly. #1267
 - ListField now handles negative indicies correctly. #1270
+- Fixed AttributeError when initializing EmbeddedDocument with positional args. #681
 
 Changes in 0.10.6
 =================

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -51,7 +51,7 @@ class BaseDocument(object):
             # We only want named arguments.
             field = iter(self._fields_ordered)
             # If its an automatic id field then skip to the first defined field
-            if self._auto_id_field:
+            if getattr(self, '_auto_id_field', False):
                 next(field)
             for value in args:
                 name = next(field)

--- a/tests/document/instance.py
+++ b/tests/document/instance.py
@@ -2928,6 +2928,20 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(person.name, "Test User")
         self.assertEqual(person.age, 42)
 
+    def test_positional_creation_embedded(self):
+        """Ensure that embedded document may be created using positional arguments.
+        """
+        job = self.Job("Test Job", 4)
+        self.assertEqual(job.name, "Test Job")
+        self.assertEqual(job.years, 4)
+
+    def test_mixed_creation_embedded(self):
+        """Ensure that embedded document may be created using mixed arguments.
+        """
+        job = self.Job("Test Job", years=4)
+        self.assertEqual(job.name, "Test Job")
+        self.assertEqual(job.years, 4)
+
     def test_mixed_creation_dynamic(self):
         """Ensure that document may be created using mixed arguments.
         """


### PR DESCRIPTION
When an EmbeddedDocument is initialized with positional arguments, the
document attempts to read _auto_id_field attribute which may not exist
and would throw an AttributeError exception and fail the initialization.

This change and the test is based on the discussion in issue #681 and
PR #777 with a number of community members.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1277)
<!-- Reviewable:end -->