### PR TITLE
add failing test for modify with exclude then save

### DIFF
--- a/tests/queryset/modify.py
+++ b/tests/queryset/modify.py
@@ -13,6 +13,12 @@ class Doc(Document):
     value = IntField()
 
 
+class DocTwo(Document):
+    id = IntField(primary_key=True)
+    value1 = IntField(default=-1)
+    value2 = IntField(default=-1)
+
+
 class FindAndModifyTest(unittest.TestCase):
 
     def setUp(self):
@@ -21,6 +27,9 @@ class FindAndModifyTest(unittest.TestCase):
 
     def assertDbEqual(self, docs):
         self.assertEqual(list(Doc._collection.find().sort("id")), docs)
+
+    def assertDbTwoEqual(self, docs):
+        self.assertEqual(list(DocTwo._collection.find().sort("id")), docs)
 
     def test_modify(self):
         Doc(id=0, value=0).save()
@@ -96,6 +105,19 @@ class FindAndModifyTest(unittest.TestCase):
         old_doc = Doc.objects(id=1).only("id").modify(set__value=-1)
         self.assertEqual(old_doc.to_mongo(), {"_id": 1})
         self.assertDbEqual([{"_id": 0, "value": 0}, {"_id": 1, "value": -1}])
+
+    def test_modify_with_exclude_then_save(self):
+        DocTwo(id=0, value1=1, value2=1).save()
+
+        doc = DocTwo.objects(id=0).exclude("value1").modify(set__value2=2)
+
+        # value1 is -1 (the default) on the object, but still 1 in the database
+        self.assertEqual(doc.value1, -1)
+        self.assertDbTwoEqual([{"_id": 0, "value1": 1, "value2": 2}])
+
+        # calling save() on the object incorrectly writes the default value of value1 to the database
+        doc.save()
+        self.assertDbTwoEqual([{"_id": 0, "value1": 1, "value2": 2}])
 
 
 if __name__ == '__main__':

--- a/tests/queryset/modify.py
+++ b/tests/queryset/modify.py
@@ -119,6 +119,19 @@ class FindAndModifyTest(unittest.TestCase):
         doc.save()
         self.assertDbTwoEqual([{"_id": 0, "value1": 1, "value2": 2}])
 
+    def test_first_with_exclude_then_save(self):
+        DocTwo(id=0, value1=1, value2=1).save()
+
+        doc = DocTwo.objects(id=0).exclude("value1").first()
+
+        # value1 is -1 (the default) on the object, but still 1 in the database
+        self.assertEqual(doc.value1, -1)
+        self.assertDbTwoEqual([{"_id": 0, "value1": 1, "value2": 1}])
+
+        # calling save() on the object incorrectly writes the default value of value1 to the database
+        doc.save()
+        self.assertDbTwoEqual([{"_id": 0, "value1": 1, "value2": 1}])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In this failing test, I exclude some field from a queryset, then update and return a document using `modify()`. If I save that document, the excluded field will be saved to the database as its default value (instead of not being modified).

I haven't been able to find a fix.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1306)

<!-- Reviewable:end -->
