### PR TITLE
Delete port from connection settings only if on pymongo 2

### DIFF
--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -128,12 +128,12 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
             connection_class = MongoClient
 
         if 'replicaSet' in conn_settings:
-            # Discard port since it can't be used on MongoReplicaSetClient
-            conn_settings.pop('port', None)
             # Discard replicaSet if not base string
             if not isinstance(conn_settings['replicaSet'], basestring):
                 conn_settings.pop('replicaSet', None)
             if not IS_PYMONGO_3:
+                # Discard port since it can't be used on MongoReplicaSetClient
+                conn_settings.pop('port', None)
                 connection_class = MongoReplicaSetClient
                 conn_settings['hosts_or_uri'] = conn_settings.pop('host', None)
 


### PR DESCRIPTION
Right now the port is dropped from connection settings even if `MongoReplicaSetClient` is not being used.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1323)

<!-- Reviewable:end -->
