### PR TITLE
Speed up checking if we passed missing field

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -72,12 +72,12 @@ class BaseDocument(object):
         # Check if there are undefined fields supplied to the constructor,
         # if so raise an Exception.
         if not self._dynamic and (self._meta.get('strict', True) or _created):
-            _missing_fields_keys = set(values.keys()) - set(
+            _undefined_fields = set(values.keys()) - set(
               self._fields.keys() + ['id', 'pk', '_cls', '_text_score'])
-            if _missing_fields_keys:
+            if _undefined_fields:
                 msg = (
-                    "The fields '{0}' does not exist on the document '{1}'"
-                ).format(_missing_fields_keys, self._class_name)
+                    "The fields '{0}' do not exist on the document '{1}'"
+                ).format(_undefined_fields, self._class_name)
                 raise FieldDoesNotExist(msg)
 
         if self.STRICT and not self._dynamic:

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -72,12 +72,13 @@ class BaseDocument(object):
         # Check if there are undefined fields supplied to the constructor,
         # if so raise an Exception.
         if not self._dynamic and (self._meta.get('strict', True) or _created):
-            for var in values.keys():
-                if var not in self._fields.keys() + ['id', 'pk', '_cls', '_text_score']:
-                    msg = (
-                        "The field '{0}' does not exist on the document '{1}'"
-                    ).format(var, self._class_name)
-                    raise FieldDoesNotExist(msg)
+            _missing_fields_keys = set(values.keys()) - set(
+              self._fields.keys() + ['id', 'pk', '_cls', '_text_score'])
+            if _missing_fields_keys:
+                msg = (
+                    "The fields '{0}' does not exist on the document '{1}'"
+                ).format(_missing_fields_keys, self._class_name)
+                raise FieldDoesNotExist(msg)
 
         if self.STRICT and not self._dynamic:
             self._data = StrictDict.create(allowed_keys=self._fields_ordered)()


### PR DESCRIPTION
Synthetic benchmark showed that `set() - set()` in this case is around twice faster than looping and checking existence. In real life profiling showed less but:

```
../document.py:40 Attribute.__init__  17727  3.436296  20.03336  0.001130
../document.py:40 Attribute.__init__  2820   0.502591  3.044738  0.001080
```
Last column is average time per call so it's ~4% when creating mongoengine objects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongoengine/mongoengine/1346)
<!-- Reviewable:end -->
