### PR TITLE
Fix rare case where delete rules might get modified during iteration

### DIFF
--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -392,7 +392,7 @@ class BaseQuerySet(object):
         delete_rules = doc._meta.get('delete_rules') or {}
         # Check for DENY rules before actually deleting/nullifying any other
         # references
-        for rule_entry in delete_rules:
+        for rule_entry in list(delete_rules):
             document_cls, field_name = rule_entry
             if document_cls._meta.get('abstract'):
                 continue
@@ -403,7 +403,7 @@ class BaseQuerySet(object):
                        % (document_cls.__name__, field_name))
                 raise OperationError(msg)
 
-        for rule_entry in delete_rules:
+        for rule_entry in list(delete_rules):
             document_cls, field_name = rule_entry
             if document_cls._meta.get('abstract'):
                 continue


### PR DESCRIPTION
This small fix prevents iterating over a list of `delete_rules` that might get changed while trying to delete other documents linked with a `reverse_delete_rule=CASCADE`.

This is a very specific use case and my WIP test case already grew over 100LOC so I decided to not include it for now. Please let me know if this is something you'd want. I might be able to narrow this down a little.

Using `list(delete_rules)` ensures compatibility with all Python versions, whereas `.keys()` would only work in Python 2.
