### PR TITLE
Fix Python 2.6 tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ Some simple examples of what MongoEngine code looks like:
 Tests
 =====
 To run the test suite, ensure you are running a local instance of MongoDB on
-the standard port and have installed ``nose`` and ``rednose``, and run: ``python setup.py nosetests``.
+the standard port and have ``nose`` installed. Then, run: ``python setup.py nosetests``.
 
 To run the test suite on every supported Python version and every supported PyMongo version,
 you can use ``tox``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,4 @@
 [nosetests]
-rednose = 1
 verbosity = 2
 detailed-errors = 1
 cover-erase = 1

--- a/setup.py
+++ b/setup.py
@@ -53,13 +53,13 @@ CLASSIFIERS = [
 extra_opts = {"packages": find_packages(exclude=["tests", "tests.*"])}
 if sys.version_info[0] == 3:
     extra_opts['use_2to3'] = True
-    extra_opts['tests_require'] = ['nose', 'rednose', 'coverage==3.7.1', 'blinker', 'Pillow>=2.0.0']
+    extra_opts['tests_require'] = ['nose', 'coverage==3.7.1', 'blinker', 'Pillow>=2.0.0']
     if "test" in sys.argv or "nosetests" in sys.argv:
         extra_opts['packages'] = find_packages()
         extra_opts['package_data'] = {"tests": ["fields/mongoengine.png", "fields/mongodb_leaf.png"]}
 else:
     # coverage 4 does not support Python 3.2 anymore
-    extra_opts['tests_require'] = ['nose', 'rednose', 'coverage==3.7.1', 'blinker', 'Pillow>=2.0.0', 'python-dateutil']
+    extra_opts['tests_require'] = ['nose', 'coverage==3.7.1', 'blinker', 'Pillow>=2.0.0', 'python-dateutil']
 
     if sys.version_info[0] == 2 and sys.version_info[1] == 6:
         extra_opts['tests_require'].append('unittest2')

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ commands =
     python setup.py nosetests {posargs}
 deps =
     nose
-    rednose
     mg27: PyMongo<2.8
     mg28: PyMongo>=2.8,<3.0
     mg30: PyMongo>=3.0


### PR DESCRIPTION
Removing `rednose` from the tests fixes Python 2.6 tests. I reported this issue to `rednose` in https://github.com/JBKahn/rednose/issues/9. For now, I think it makes sense to remove this package. Less code = better.

If we merge this PR along with #1390, the build status for this package is *finally* going to be green! 🎆 