### PR TITLE
Improve health of this package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
 - travis_retry pip install coveralls
 - travis_retry pip install flake8
 - travis_retry pip install tox>=1.9
+- travis_retry pip install virtualenv<14.0.0  # virtualenv>=14.0.0 has dropped Python 3.2 support (and pypy3 is based on py32)
 - travis_retry tox -e $(echo py$TRAVIS_PYTHON_VERSION-mg$PYMONGO | tr -d . | sed -e 's/pypypy/pypy/') -- -e test
 
 # Run flake8 for py27

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
 - travis_retry pip install coveralls
 - travis_retry pip install flake8
 - travis_retry pip install tox>=1.9
-- travis_retry pip install virtualenv<14.0.0  # virtualenv>=14.0.0 has dropped Python 3.2 support (and pypy3 is based on py32)
+- travis_retry pip install "virtualenv<14.0.0"  # virtualenv>=14.0.0 has dropped Python 3.2 support (and pypy3 is based on py32)
 - travis_retry tox -e $(echo py$TRAVIS_PYTHON_VERSION-mg$PYMONGO | tr -d . | sed -e 's/pypypy/pypy/') -- -e test
 
 # Run flake8 for py27

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+
 python:
 - '2.6'
 - '2.7'
@@ -7,35 +8,50 @@ python:
 - '3.5'
 - pypy
 - pypy3
+
 env:
 - PYMONGO=2.7
 - PYMONGO=2.8
 - PYMONGO=3.0
 - PYMONGO=dev
+
 matrix:
   fast_finish: true
+
 before_install:
 - travis_retry sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
 - echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' |
   sudo tee /etc/apt/sources.list.d/mongodb.list
 - travis_retry sudo apt-get update
 - travis_retry sudo apt-get install mongodb-org-server
+
 install:
 - sudo apt-get install python-dev python3-dev libopenjpeg-dev zlib1g-dev libjpeg-turbo8-dev
   libtiff4-dev libjpeg8-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev
   python-tk
-# virtualenv>=14.0.0 has dropped Python 3.2 support
-- travis_retry pip install "virtualenv<14.0.0" "tox>=1.9" coveralls
+- travis_retry pip install --upgrade pip
+- travis_retry pip install coveralls
+- travis_retry pip install flake8
+- travis_retry pip install tox>=1.9
 - travis_retry tox -e $(echo py$TRAVIS_PYTHON_VERSION-mg$PYMONGO | tr -d . | sed -e 's/pypypy/pypy/') -- -e test
+
+# Run flake8 for py27
+before_script:
+- if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then tox -e flake8; fi
+
 script:
 - tox -e $(echo py$TRAVIS_PYTHON_VERSION-mg$PYMONGO | tr -d . | sed -e 's/pypypy/pypy/') -- --with-coverage
+
 after_script: coveralls --verbose
+
 notifications:
   irc: irc.freenode.org#mongoengine
+
 branches:
   only:
   - master
   - /^v.*$/
+
 deploy:
   provider: pypi
   user: the_drow

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -1,15 +1,15 @@
-import document
-from document import *
-import fields
-from fields import *
 import connection
 from connection import *
+import document
+from document import *
+import errors
+from errors import *
+import fields
+from fields import *
 import queryset
 from queryset import *
 import signals
 from signals import *
-from errors import *
-import errors
 
 __all__ = (list(document.__all__) + fields.__all__ + connection.__all__ +
            list(queryset.__all__) + signals.__all__ + list(errors.__all__))
@@ -21,5 +21,6 @@ def get_version():
     if isinstance(VERSION[-1], basestring):
         return '.'.join(map(str, VERSION[:-1])) + VERSION[-1]
     return '.'.join(map(str, VERSION))
+
 
 __version__ = get_version()

--- a/mongoengine/base/datastructures.py
+++ b/mongoengine/base/datastructures.py
@@ -1,5 +1,5 @@
-import weakref
 import itertools
+import weakref
 
 from mongoengine.common import _import_class
 from mongoengine.errors import DoesNotExist, MultipleObjectsReturned
@@ -199,8 +199,9 @@ class BaseList(list):
     def _mark_as_changed(self, key=None):
         if hasattr(self._instance, '_mark_as_changed'):
             if key:
-                self._instance._mark_as_changed('%s.%s' % (self._name, 
-                    key % len(self)))
+                self._instance._mark_as_changed(
+                    '%s.%s' % (self._name, key % len(self))
+                )
             else:
                 self._instance._mark_as_changed(self._name)
 

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -1,28 +1,28 @@
 import copy
-import operator
 import numbers
+import operator
 from collections import Hashable
 from functools import partial
 
-import pymongo
-from bson import json_util, ObjectId
+from bson import ObjectId, json_util
 from bson.dbref import DBRef
 from bson.son import SON
+import pymongo
 
 from mongoengine import signals
-from mongoengine.common import _import_class
-from mongoengine.errors import (ValidationError, InvalidDocumentError,
-                                LookUpError, FieldDoesNotExist)
-from mongoengine.python_support import PY3, txt_type
-from mongoengine.base.common import get_document, ALLOW_INHERITANCE
+from mongoengine.base.common import ALLOW_INHERITANCE, get_document
 from mongoengine.base.datastructures import (
     BaseDict,
     BaseList,
     EmbeddedDocumentList,
-    StrictDict,
-    SemiStrictDict
+    SemiStrictDict,
+    StrictDict
 )
 from mongoengine.base.fields import ComplexBaseField
+from mongoengine.common import _import_class
+from mongoengine.errors import (FieldDoesNotExist, InvalidDocumentError,
+                                LookUpError, ValidationError)
+from mongoengine.python_support import PY3, txt_type
 
 __all__ = ('BaseDocument', 'NON_FIELD_ERRORS')
 
@@ -73,7 +73,7 @@ class BaseDocument(object):
         # if so raise an Exception.
         if not self._dynamic and (self._meta.get('strict', True) or _created):
             _undefined_fields = set(values.keys()) - set(
-              self._fields.keys() + ['id', 'pk', '_cls', '_text_score'])
+                self._fields.keys() + ['id', 'pk', '_cls', '_text_score'])
             if _undefined_fields:
                 msg = (
                     "The fields '{0}' do not exist on the document '{1}'"
@@ -310,7 +310,7 @@ class BaseDocument(object):
         data = SON()
         data["_id"] = None
         data['_cls'] = self._class_name
-        
+
         # only root fields ['test1.a', 'test2'] => ['test1', 'test2']
         root_fields = set([f.split('.')[0] for f in fields])
 
@@ -333,11 +333,11 @@ class BaseDocument(object):
                         i.replace(key, '') for i in fields
                         if i.startswith(key)]
 
-                    ex_vars['fields'] = embedded_fields 
+                    ex_vars['fields'] = embedded_fields
 
                 if 'use_db_field' in f_inputs:
                     ex_vars['use_db_field'] = use_db_field
-                     
+
                 value = field.to_mongo(value, **ex_vars)
 
             # Handle self generating fields
@@ -566,8 +566,10 @@ class BaseDocument(object):
                     continue
             if isinstance(field, ReferenceField):
                 continue
-            elif (isinstance(data, (EmbeddedDocument, DynamicEmbeddedDocument))
-                  and db_field_name not in changed_fields):
+            elif (
+                isinstance(data, (EmbeddedDocument, DynamicEmbeddedDocument)) and
+                db_field_name not in changed_fields
+            ):
                 # Find all embedded fields that have been changed
                 changed = data._get_changed_fields(inspected)
                 changed_fields += ["%s%s" % (key, k) for k in changed if k]
@@ -608,7 +610,7 @@ class BaseDocument(object):
                         break
                     elif isinstance(d, list) and p.lstrip('-').isdigit():
                         if p[0] == '-':
-                            p = str(len(d)+int(p))
+                            p = str(len(d) + int(p))
                         try:
                             d = d[int(p)]
                         except IndexError:
@@ -644,7 +646,7 @@ class BaseDocument(object):
                 for p in parts:
                     if isinstance(d, list) and p.lstrip('-').isdigit():
                         if p[0] == '-':
-                            p = str(len(d)+int(p))
+                            p = str(len(d) + int(p))
                         d = d[int(p)]
                     elif (hasattr(d, '__getattribute__') and
                           not isinstance(d, dict)):
@@ -775,8 +777,12 @@ class BaseDocument(object):
         # Check to see if we need to include _cls
         allow_inheritance = cls._meta.get('allow_inheritance',
                                           ALLOW_INHERITANCE)
-        include_cls = (allow_inheritance and not spec.get('sparse', False) and
-                       spec.get('cls',  True) and '_cls' not in spec['fields'])
+        include_cls = (
+            allow_inheritance and
+            not spec.get('sparse', False) and
+            spec.get('cls', True) and
+            '_cls' not in spec['fields']
+        )
 
         # 733: don't include cls if index_cls is False unless there is an explicit cls with the index
         include_cls = include_cls and (spec.get('cls', False) or cls._meta.get('index_cls', True))

--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -5,12 +5,12 @@ import weakref
 from bson import DBRef, ObjectId, SON
 import pymongo
 
-from mongoengine.common import _import_class
-from mongoengine.errors import ValidationError
 from mongoengine.base.common import ALLOW_INHERITANCE
 from mongoengine.base.datastructures import (
     BaseDict, BaseList, EmbeddedDocumentList
 )
+from mongoengine.common import _import_class
+from mongoengine.errors import ValidationError
 
 __all__ = ("BaseField", "ComplexBaseField",
            "ObjectIdField", "GeoJsonBaseField")
@@ -85,13 +85,13 @@ class BaseField(object):
         self.null = null
         self.sparse = sparse
         self._owner_document = None
-        
+
         # Detect and report conflicts between metadata and base properties.
         conflicts = set(dir(self)) & set(kwargs)
         if conflicts:
             raise TypeError("%s already has attribute(s): %s" % (
-                self.__class__.__name__, ', '.join(conflicts) ))
-        
+                self.__class__.__name__, ', '.join(conflicts)))
+
         # Assign metadata to the instance
         # This efficient method is available because no __slots__ are defined.
         self.__dict__.update(kwargs)
@@ -169,11 +169,11 @@ class BaseField(object):
         f_inputs = self.to_mongo.__code__.co_varnames
         ex_vars = {}
         if 'fields' in f_inputs:
-            ex_vars['fields'] = fields 
+            ex_vars['fields'] = fields
 
         if 'use_db_field' in f_inputs:
             ex_vars['use_db_field'] = use_db_field
-             
+
         return self.to_mongo(value, **ex_vars)
 
     def prepare_query_value(self, op, value):
@@ -205,7 +205,6 @@ class BaseField(object):
         # Choices which are types other than Documents
         elif value not in choice_list:
             self.error('Value must be one of %s' % unicode(choice_list))
-
 
     def _validate(self, value, **kwargs):
         # Check the Choices Constraint

--- a/mongoengine/base/metaclasses.py
+++ b/mongoengine/base/metaclasses.py
@@ -14,8 +14,7 @@ __all__ = ('DocumentMetaclass', 'TopLevelDocumentMetaclass')
 
 
 class DocumentMetaclass(type):
-    """Metaclass for all documents.
-    """
+    """Metaclass for all documents."""
 
     # TODO lower complexity of this method
     def __new__(cls, name, bases, attrs):
@@ -163,7 +162,7 @@ class DocumentMetaclass(type):
         # copies __func__ into im_func and __self__ into im_self for
         # classmethod objects in Document derived classes.
         if PY3:
-            for key, val in new_class.__dict__.items():
+            for val in new_class.__dict__.values():
                 if isinstance(val, classmethod):
                     f = val.__get__(new_class)
                     if hasattr(f, '__func__') and not hasattr(f, 'im_func'):

--- a/mongoengine/base/metaclasses.py
+++ b/mongoengine/base/metaclasses.py
@@ -1,5 +1,7 @@
 import warnings
 
+from mongoengine.base.common import ALLOW_INHERITANCE, _document_registry
+from mongoengine.base.fields import BaseField, ComplexBaseField, ObjectIdField
 from mongoengine.common import _import_class
 from mongoengine.errors import InvalidDocumentError
 from mongoengine.python_support import PY3
@@ -7,8 +9,6 @@ from mongoengine.queryset import (DO_NOTHING, DoesNotExist,
                                   MultipleObjectsReturned,
                                   QuerySetManager)
 
-from mongoengine.base.common import _document_registry, ALLOW_INHERITANCE
-from mongoengine.base.fields import BaseField, ComplexBaseField, ObjectIdField
 
 __all__ = ('DocumentMetaclass', 'TopLevelDocumentMetaclass')
 
@@ -17,6 +17,7 @@ class DocumentMetaclass(type):
     """Metaclass for all documents.
     """
 
+    # TODO lower complexity of this method
     def __new__(cls, name, bases, attrs):
         flattened_bases = cls._get_bases(bases)
         super_new = super(DocumentMetaclass, cls).__new__

--- a/mongoengine/dereference.py
+++ b/mongoengine/dereference.py
@@ -1,15 +1,14 @@
 from bson import DBRef, SON
 
-from mongoengine.python_support import txt_type
-
-from base import (
+from .base import (
     BaseDict, BaseList, EmbeddedDocumentList,
     TopLevelDocumentMetaclass, get_document
 )
-from fields import (ReferenceField, ListField, DictField, MapField)
-from connection import get_db
-from queryset import QuerySet
-from document import Document, EmbeddedDocument
+from .connection import get_db
+from .document import Document, EmbeddedDocument
+from .fields import DictField, ListField, MapField, ReferenceField
+from .python_support import txt_type
+from .queryset import QuerySet
 
 
 class DeReference(object):

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -8,6 +8,9 @@ import uuid
 import warnings
 from operator import itemgetter
 
+from bson import Binary, DBRef, ObjectId, SON
+import gridfs
+import pymongo
 import six
 
 try:
@@ -17,22 +20,18 @@ except ImportError:
 else:
     import dateutil.parser
 
-import pymongo
-import gridfs
-from bson import Binary, DBRef, SON, ObjectId
 try:
     from bson.int64 import Int64
 except ImportError:
     Int64 = long
 
-from mongoengine.errors import ValidationError, DoesNotExist
-from mongoengine.python_support import (PY3, bin_type, txt_type,
-                                        str_types, StringIO)
-from base import (BaseField, ComplexBaseField, ObjectIdField, GeoJsonBaseField,
-                  get_document, BaseDocument)
-from queryset import DO_NOTHING, QuerySet
-from document import Document, EmbeddedDocument
-from connection import get_db, DEFAULT_CONNECTION_NAME
+from .base import (BaseDocument, BaseField, ComplexBaseField, GeoJsonBaseField,
+                   ObjectIdField, get_document)
+from .connection import DEFAULT_CONNECTION_NAME, get_db
+from .document import Document, EmbeddedDocument
+from .errors import DoesNotExist, ValidationError
+from .python_support import PY3, StringIO, bin_type, str_types, txt_type
+from .queryset import DO_NOTHING, QuerySet
 
 try:
     from PIL import Image, ImageOps
@@ -1015,11 +1014,10 @@ class ReferenceField(BaseField):
 
         if self.document_type._meta.get('abstract') and \
                 not isinstance(value, self.document_type):
-            self.error('%s is not an instance of abstract reference'
-                    ' type %s' % (value._class_name,
-                        self.document_type._class_name)
-                    )
-
+            self.error(
+                '%s is not an instance of abstract reference type %s' % (
+                    self.document_type._class_name)
+            )
 
     def lookup_member(self, member_name):
         return self.document_type._fields.get(member_name)
@@ -1126,7 +1124,7 @@ class CachedReferenceField(BaseField):
             new_fields = [f for f in self.fields if f in fields]
         else:
             new_fields = self.fields
-            
+
         value.update(dict(document.to_mongo(use_db_field, fields=new_fields)))
         return value
 

--- a/mongoengine/queryset/__init__.py
+++ b/mongoengine/queryset/__init__.py
@@ -1,6 +1,6 @@
-from mongoengine.errors import (DoesNotExist, MultipleObjectsReturned,
-                                InvalidQueryError, OperationError,
-                                NotUniqueError)
+from mongoengine.errors import (DoesNotExist, InvalidQueryError,
+                                MultipleObjectsReturned, NotUniqueError,
+                                OperationError)
 from mongoengine.queryset.field_list import *
 from mongoengine.queryset.manager import *
 from mongoengine.queryset.queryset import *

--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -7,20 +7,19 @@ import pprint
 import re
 import warnings
 
-from bson import SON
+from bson import SON, json_util
 from bson.code import Code
-from bson import json_util
 import pymongo
 import pymongo.errors
 from pymongo.common import validate_read_preference
 
 from mongoengine import signals
+from mongoengine.base.common import get_document
+from mongoengine.common import _import_class
 from mongoengine.connection import get_db
 from mongoengine.context_managers import switch_db
-from mongoengine.common import _import_class
-from mongoengine.base.common import get_document
-from mongoengine.errors import (OperationError, NotUniqueError,
-                                InvalidQueryError, LookUpError)
+from mongoengine.errors import (InvalidQueryError, LookUpError,
+                                NotUniqueError, OperationError)
 from mongoengine.python_support import IS_PYMONGO_3
 from mongoengine.queryset import transform
 from mongoengine.queryset.field_list import QueryFieldList
@@ -155,10 +154,8 @@ class BaseQuerySet(object):
         # forse load cursor
         # self._cursor
 
-
     def __getitem__(self, key):
-        """Support skip and limit using getitem and slicing syntax.
-        """
+        """Support skip and limit using getitem and slicing syntax."""
         queryset = self.clone()
 
         # Slice provided
@@ -529,8 +526,9 @@ class BaseQuerySet(object):
         .. versionadded:: 0.10.2
         """
 
-        atomic_update = self.update(multi=False, upsert=True, write_concern=write_concern,
-                             full_result=True, **update)
+        atomic_update = self.update(multi=False, upsert=True,
+                                    write_concern=write_concern,
+                                    full_result=True, **update)
 
         if atomic_update['updatedExisting']:
             document = self.get()

--- a/mongoengine/queryset/queryset.py
+++ b/mongoengine/queryset/queryset.py
@@ -1,6 +1,6 @@
 from mongoengine.errors import OperationError
-from mongoengine.queryset.base import (BaseQuerySet, DO_NOTHING, NULLIFY,
-                                       CASCADE, DENY, PULL)
+from mongoengine.queryset.base import (BaseQuerySet, CASCADE, DENY, DO_NOTHING,
+                                       NULLIFY, PULL)
 
 __all__ = ('QuerySet', 'QuerySetNoCache', 'DO_NOTHING', 'NULLIFY', 'CASCADE',
            'DENY', 'PULL')

--- a/mongoengine/queryset/transform.py
+++ b/mongoengine/queryset/transform.py
@@ -1,11 +1,11 @@
 from collections import defaultdict
 
-import pymongo
 from bson import SON
+import pymongo
 
 from mongoengine.base.fields import UPDATE_OPERATORS
-from mongoengine.connection import get_connection
 from mongoengine.common import _import_class
+from mongoengine.connection import get_connection
 from mongoengine.errors import InvalidQueryError
 from mongoengine.python_support import IS_PYMONGO_3
 
@@ -108,8 +108,11 @@ def query(_doc_cls=None, **kwargs):
             elif op in ('match', 'elemMatch'):
                 ListField = _import_class('ListField')
                 EmbeddedDocumentField = _import_class('EmbeddedDocumentField')
-                if (isinstance(value, dict) and isinstance(field, ListField) and
-                    isinstance(field.field, EmbeddedDocumentField)):
+                if (
+                    isinstance(value, dict) and
+                    isinstance(field, ListField) and
+                    isinstance(field.field, EmbeddedDocumentField)
+                ):
                     value = query(field.field.document_type, **value)
                 else:
                     value = field.prepare_query_value(op, value)

--- a/mongoengine/signals.py
+++ b/mongoengine/signals.py
@@ -29,7 +29,7 @@ except ImportError:
                                'because the blinker library is '
                                'not installed.')
 
-        send = lambda *a, **kw: None
+        send = lambda *a, **kw: None  # noqa
         connect = disconnect = has_receivers_for = receivers_for = \
             temporarily_connected_to = _fail
         del _fail

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 nose
 pymongo>=2.7.1
 six==1.10.0
+flake8
+flake8-import-order

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,5 +9,5 @@ tests = tests
 [flake8]
 ignore=E501,F401,F403,F405,I201
 exclude=build,dist,docs,venv,.tox,.eggs
-max-complexity=23
+max-complexity=25
 application-import-names=mongoengine,tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,6 @@ tests = tests
 
 [flake8]
 ignore=E501,F401,F403,F405,I201
-exclude=build,dist,docs,venv,.tox,.eggs
+exclude=build,dist,docs,venv,.tox,.eggs,tests
 max-complexity=25
 application-import-names=mongoengine,tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,5 +9,5 @@ tests = tests
 [flake8]
 ignore=E501,F401,F403,F405,I201
 exclude=build,dist,docs,venv,.tox,.eggs,tests
-max-complexity=25
+max-complexity=42
 application-import-names=mongoengine,tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,5 +9,5 @@ tests = tests
 [flake8]
 ignore=E501,F401,F403,F405,I201
 exclude=build,dist,docs,venv,.tox,.eggs
-max-complexity=10
+max-complexity=23
 application-import-names=mongoengine,tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,9 @@ cover-erase = 1
 cover-branches = 1
 cover-package = mongoengine
 tests = tests
+
+[flake8]
+ignore=E501,F401,F403,F405,I201
+exclude=build,dist,docs,venv,.tox,.eggs
+max-complexity=10
+application-import-names=mongoengine,tests

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 # Hack to silence atexit traceback in newer python versions
 try:
@@ -8,8 +8,10 @@ try:
 except ImportError:
     pass
 
-DESCRIPTION = 'MongoEngine is a Python Object-Document ' + \
-'Mapper for working with MongoDB.'
+DESCRIPTION = (
+    'MongoEngine is a Python Object-Document '
+    'Mapper for working with MongoDB.'
+)
 
 try:
     with open('README.rst') as fin:
@@ -22,6 +24,7 @@ def get_version(version_tuple):
     if not isinstance(version_tuple[-1], int):
         return '.'.join(map(str, version_tuple[:-1])) + version_tuple[-1]
     return '.'.join(map(str, version_tuple))
+
 
 # Dirty hack to get version number from monogengine/__init__.py - we can't
 # import it as it depends on PyMongo and PyMongo isn't installed until this
@@ -64,21 +67,22 @@ else:
     if sys.version_info[0] == 2 and sys.version_info[1] == 6:
         extra_opts['tests_require'].append('unittest2')
 
-setup(name='mongoengine',
-      version=VERSION,
-      author='Harry Marr',
-      author_email='harry.marr@{nospam}gmail.com',
-      maintainer="Ross Lawley",
-      maintainer_email="ross.lawley@{nospam}gmail.com",
-      url='http://mongoengine.org/',
-      download_url='https://github.com/MongoEngine/mongoengine/tarball/master',
-      license='MIT',
-      include_package_data=True,
-      description=DESCRIPTION,
-      long_description=LONG_DESCRIPTION,
-      platforms=['any'],
-      classifiers=CLASSIFIERS,
-      install_requires=['pymongo>=2.7.1', 'six'],
-      test_suite='nose.collector',
-      **extra_opts
+setup(
+    name='mongoengine',
+    version=VERSION,
+    author='Harry Marr',
+    author_email='harry.marr@{nospam}gmail.com',
+    maintainer="Ross Lawley",
+    maintainer_email="ross.lawley@{nospam}gmail.com",
+    url='http://mongoengine.org/',
+    download_url='https://github.com/MongoEngine/mongoengine/tarball/master',
+    license='MIT',
+    include_package_data=True,
+    description=DESCRIPTION,
+    long_description=LONG_DESCRIPTION,
+    platforms=['any'],
+    classifiers=CLASSIFIERS,
+    install_requires=['pymongo>=2.7.1', 'six'],
+    test_suite='nose.collector',
+    **extra_opts
 )

--- a/tests/document/indexes.py
+++ b/tests/document/indexes.py
@@ -844,7 +844,12 @@ class IndexesTest(unittest.TestCase):
 
         self.assertEqual({'text': 'OK', '_id': {'term': 'ok', 'name': 'n'}},
                          report.to_mongo())
-        self.assertEqual(report, ReportDictField.objects.get(pk=my_key))
+
+        # We can't directly call ReportDictField.objects.get(pk=my_key),
+        # because dicts are unordered, and if the order in MongoDB is
+        # different than the one in `my_key`, this test will fail.
+        self.assertEqual(report, ReportDictField.objects.get(pk__name=my_key['name']))
+        self.assertEqual(report, ReportDictField.objects.get(pk__term=my_key['term']))
 
     def test_string_indexes(self):
 

--- a/tests/queryset/transform.py
+++ b/tests/queryset/transform.py
@@ -1,11 +1,7 @@
-import sys
-sys.path[0:0] = [""]
-
 import unittest
 
 from mongoengine import *
-from mongoengine.queryset import Q
-from mongoengine.queryset import transform
+from mongoengine.queryset import Q, transform
 
 __all__ = ("TransformTest",)
 
@@ -41,8 +37,8 @@ class TransformTest(unittest.TestCase):
         DicDoc.drop_collection()
         Doc.drop_collection()
 
+        DicDoc().save()
         doc = Doc().save()
-        dic_doc = DicDoc().save()
 
         for k, v in (("set", "$set"), ("set_on_insert", "$setOnInsert"), ("push", "$push")):
             update = transform.update(DicDoc, **{"%s__dictField__test" % k: doc})
@@ -54,7 +50,6 @@ class TransformTest(unittest.TestCase):
 
         update = transform.update(DicDoc, pull__dictField__test=doc)
         self.assertTrue(isinstance(update["$pull"]["dictField"]["test"], dict))
-
 
     def test_query_field_name(self):
         """Ensure that the correct field name is used when querying.
@@ -156,26 +151,33 @@ class TransformTest(unittest.TestCase):
         class Doc(Document):
             meta = {'allow_inheritance': False}
 
-        raw_query = Doc.objects(__raw__={'deleted': False,
-                                'scraped': 'yes',
-                                '$nor': [{'views.extracted': 'no'},
-                                         {'attachments.views.extracted':'no'}]
-                                })._query
+        raw_query = Doc.objects(__raw__={
+            'deleted': False,
+            'scraped': 'yes',
+            '$nor': [
+                {'views.extracted': 'no'},
+                {'attachments.views.extracted': 'no'}
+            ]
+        })._query
 
-        expected = {'deleted': False, 'scraped': 'yes',
-                    '$nor': [{'views.extracted': 'no'},
-                             {'attachments.views.extracted': 'no'}]}
-        self.assertEqual(expected, raw_query)
+        self.assertEqual(raw_query, {
+            'deleted': False,
+            'scraped': 'yes',
+            '$nor': [
+                {'views.extracted': 'no'},
+                {'attachments.views.extracted': 'no'}
+            ]
+        })
 
     def test_geojson_PointField(self):
         class Location(Document):
             loc = PointField()
 
         update = transform.update(Location, set__loc=[1, 2])
-        self.assertEqual(update, {'$set': {'loc': {"type": "Point", "coordinates": [1,2]}}})
+        self.assertEqual(update, {'$set': {'loc': {"type": "Point", "coordinates": [1, 2]}}})
 
-        update = transform.update(Location, set__loc={"type": "Point", "coordinates": [1,2]})
-        self.assertEqual(update, {'$set': {'loc': {"type": "Point", "coordinates": [1,2]}}})
+        update = transform.update(Location, set__loc={"type": "Point", "coordinates": [1, 2]})
+        self.assertEqual(update, {'$set': {'loc': {"type": "Point", "coordinates": [1, 2]}}})
 
     def test_geojson_LineStringField(self):
         class Location(Document):
@@ -237,6 +239,7 @@ class TransformTest(unittest.TestCase):
         # I *meant* to execute location__within_box=box
         events = Event.objects(location__within=box)
         self.assertRaises(InvalidQueryError, lambda: events.count())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/queryset/visitor.py
+++ b/tests/queryset/visitor.py
@@ -1,14 +1,12 @@
-import sys
-sys.path[0:0] = [""]
-
+import datetime
+import re
 import unittest
 
 from bson import ObjectId
-from datetime import datetime
 
 from mongoengine import *
-from mongoengine.queryset import Q
 from mongoengine.errors import InvalidQueryError
+from mongoengine.queryset import Q
 
 __all__ = ("QTest",)
 
@@ -132,12 +130,12 @@ class QTest(unittest.TestCase):
         TestDoc(x=10).save()
         TestDoc(y=True).save()
 
-        self.assertEqual(query,
-        {'$and': [
-            {'$or': [{'x': {'$gt': 0}}, {'x': {'$exists': False}}]},
-            {'$or': [{'x': {'$lt': 100}}, {'y': True}]}
-        ]})
-
+        self.assertEqual(query, {
+            '$and': [
+                {'$or': [{'x': {'$gt': 0}}, {'x': {'$exists': False}}]},
+                {'$or': [{'x': {'$lt': 100}}, {'y': True}]}
+            ]
+        })
         self.assertEqual(2, TestDoc.objects(q1 & q2).count())
 
     def test_or_and_or_combination(self):
@@ -157,15 +155,14 @@ class QTest(unittest.TestCase):
         q2 = (Q(x__lt=100) & (Q(y=False) | Q(y__exists=False)))
         query = (q1 | q2).to_query(TestDoc)
 
-        self.assertEqual(query,
-            {'$or': [
+        self.assertEqual(query, {
+            '$or': [
                 {'$and': [{'x': {'$gt': 0}},
                           {'$or': [{'y': True}, {'y': {'$exists': False}}]}]},
                 {'$and': [{'x': {'$lt': 100}},
                           {'$or': [{'y': False}, {'y': {'$exists': False}}]}]}
-            ]}
-        )
-
+            ]
+        })
         self.assertEqual(2, TestDoc.objects(q1 | q2).count())
 
     def test_multiple_occurence_in_field(self):
@@ -215,19 +212,19 @@ class QTest(unittest.TestCase):
 
         BlogPost.drop_collection()
 
-        post1 = BlogPost(title='Test 1', publish_date=datetime(2010, 1, 8), published=False)
+        post1 = BlogPost(title='Test 1', publish_date=datetime.datetime(2010, 1, 8), published=False)
         post1.save()
 
-        post2 = BlogPost(title='Test 2', publish_date=datetime(2010, 1, 15), published=True)
+        post2 = BlogPost(title='Test 2', publish_date=datetime.datetime(2010, 1, 15), published=True)
         post2.save()
 
         post3 = BlogPost(title='Test 3', published=True)
         post3.save()
 
-        post4 = BlogPost(title='Test 4', publish_date=datetime(2010, 1, 8))
+        post4 = BlogPost(title='Test 4', publish_date=datetime.datetime(2010, 1, 8))
         post4.save()
 
-        post5 = BlogPost(title='Test 1', publish_date=datetime(2010, 1, 15))
+        post5 = BlogPost(title='Test 1', publish_date=datetime.datetime(2010, 1, 15))
         post5.save()
 
         post6 = BlogPost(title='Test 1', published=False)
@@ -250,7 +247,7 @@ class QTest(unittest.TestCase):
         self.assertTrue(all(obj.id in posts for obj in published_posts))
 
         # Check Q object combination
-        date = datetime(2010, 1, 10)
+        date = datetime.datetime(2010, 1, 10)
         q = BlogPost.objects(Q(publish_date__lte=date) | Q(published=True))
         posts = [post.id for post in q]
 
@@ -273,8 +270,10 @@ class QTest(unittest.TestCase):
         # Test invalid query objs
         def wrong_query_objs():
             self.Person.objects('user1')
+
         def wrong_query_objs_filter():
             self.Person.objects('user1')
+
         self.assertRaises(InvalidQueryError, wrong_query_objs)
         self.assertRaises(InvalidQueryError, wrong_query_objs_filter)
 
@@ -284,7 +283,6 @@ class QTest(unittest.TestCase):
         person = self.Person(name='Guido van Rossum')
         person.save()
 
-        import re
         obj = self.Person.objects(Q(name=re.compile('^Gui'))).first()
         self.assertEqual(obj, person)
         obj = self.Person.objects(Q(name=re.compile('^gui'))).first()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-envlist = {py26,py27,py33,py34,py35,pypy,pypy3}-{mg27,mg28}
-#envlist = {py26,py27,py33,py34,pypy,pypy3}-{mg27,mg28,mg30,mgdev}
+envlist = {py26,py27,py33,py34,py35,pypy,pypy3}-{mg27,mg28},flake8
 
 [testenv]
 commands =
@@ -14,3 +13,10 @@ deps =
 setenv =
     PYTHON_EGG_CACHE = {envdir}/python-eggs
 passenv = windir
+
+[testenv:flake8]
+deps =
+    flake8
+    flake8-import-order
+commands =
+   flake8


### PR DESCRIPTION
Includes running flake8 and flake8-import-order during the travis run (only for Python 2.7 for now) and all the tweaks necessary to make it pass.

None of the logic has changed, so this should be safe to merge once the tests pass.