### PR TITLE
Fix filtering by embedded_doc=None

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -577,7 +577,7 @@ class EmbeddedDocumentField(BaseField):
         return self.document_type._fields.get(member_name)
 
     def prepare_query_value(self, op, value):
-        if not isinstance(value, self.document_type):
+        if value is not None and not isinstance(value, self.document_type):
             value = self.document_type._from_son(value)
         super(EmbeddedDocumentField, self).prepare_query_value(op, value)
         return self.to_mongo(value)

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -1239,7 +1239,8 @@ class QuerySetTest(unittest.TestCase):
             self.assertFalse('$orderby' in q.get_ops()[0]['query'])
 
     def test_find_embedded(self):
-        """Ensure that an embedded document is properly returned from a query.
+        """Ensure that an embedded document is properly returned from
+        a query.
         """
         class User(EmbeddedDocument):
             name = StringField()
@@ -1250,15 +1251,30 @@ class QuerySetTest(unittest.TestCase):
 
         BlogPost.drop_collection()
 
-        post = BlogPost(content='Had a good coffee today...')
-        post.author = User(name='Test User')
-        post.save()
+        BlogPost.objects.create(
+            author=User(name='Test User'),
+            content='Had a good coffee today...'
+        )
 
         result = BlogPost.objects.first()
         self.assertTrue(isinstance(result.author, User))
         self.assertEqual(result.author.name, 'Test User')
 
+    def test_find_empty_embedded(self):
+        """Ensure that you can save and find an empty embedded document."""
+        class User(EmbeddedDocument):
+            name = StringField()
+
+        class BlogPost(Document):
+            content = StringField()
+            author = EmbeddedDocumentField(User)
+
         BlogPost.drop_collection()
+
+        BlogPost.objects.create(content='Anonymous post...')
+
+        result = BlogPost.objects.get(author=None)
+        self.assertEqual(result.author, None)
 
     def test_find_dict_item(self):
         """Ensure that DictField items may be found.


### PR DESCRIPTION
Previously filtering by `embedded_doc=None` would raise an `AttributeError` in `EmbeddedDocumentField.prepare_query_value`.

Inspired by #1163 (thanks @decklord!).