### PR TITLE
Fix iteration within iteration

### DIFF
--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -275,6 +275,8 @@ class BaseQuerySet(object):
         except StopIteration:
             return result
 
+        # If we were able to retrieve the 2nd doc, rewind the cursor and
+        # raise the MultipleObjectsReturned exception.
         queryset.rewind()
         message = u'%d items returned, instead of 1' % queryset.count()
         raise queryset._document.MultipleObjectsReturned(message)

--- a/mongoengine/queryset/queryset.py
+++ b/mongoengine/queryset/queryset.py
@@ -44,10 +44,11 @@ class QuerySet(BaseQuerySet):
         if self._len is not None:
             return self._len
 
+        # Populate the result cache with *all* of the docs in the cursor
         if self._has_more:
-            # populate the cache
             list(self._iter_results())
 
+        # Cache the length of the complete result cache and return it
         self._len = len(self._result_cache)
         return self._len
 


### PR DESCRIPTION
Without these fixes, iterating over a queryset within another iteration would cause the "outer" iteration to only return 100 results.

This PR also fixes #1086 where calling `len(qs)` mid-iteration would cause the same problem.

Thanks to @eli-b and @gordol for inspiration!