### PR TITLE
Upgrade notice for 0.10.7

### DIFF
--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -2,6 +2,13 @@
 Upgrading
 #########
 
+0.10.7
+******
+
+`QuerySet.aggregate_sum` and `QuerySet.aggregate_average` are dropped. Use
+`QuerySet.sum` and `QuerySet.average` instead which use the aggreation framework
+by default from now on.
+
 0.9.0
 *****
 


### PR DESCRIPTION
Hi!

I was a bit confused by this undocumented breaking change from 0.10.6 to 0.10.7. I had to dig into the project commits to understand what actually hapenned. Even the changelog is not that clear. Moreover, old aggregate_* methods could have been backported, pending a major version update (where we expect breaking changes).

Thanks!