### PR TITLE
Update CONTRIBUTING: Adapt supported interpreters

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -20,7 +20,7 @@ post to the `user group <http://groups.google.com/group/mongoengine-users>`
 Supported Interpreters
 ----------------------
 
-MongoEngine supports CPython 2.6 and newer. Language
+MongoEngine supports CPython 2.7 and newer. Language
 features not supported by all interpreters can not be used.
 Please also ensure that your code is properly converted by
 `2to3 <http://docs.python.org/library/2to3.html>`_ for Python 3 support.


### PR DESCRIPTION
Python 2.6 is not supported anymore with version 0.11.0