### PR TITLE
Bugfix/inadequate son handling

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -17,7 +17,7 @@ from mongoengine.base.datastructures import (BaseDict, BaseList,
 from mongoengine.base.fields import ComplexBaseField
 from mongoengine.common import _import_class
 from mongoengine.errors import (FieldDoesNotExist, InvalidDocumentError,
-                                LookUpError, OperationError, ValidationError)
+                                LookUpError, OperationError, ValidationError, InvalidQueryError)
 
 __all__ = ('BaseDocument',)
 
@@ -674,6 +674,10 @@ class BaseDocument(object):
         """
         if not only_fields:
             only_fields = []
+
+        if not isinstance(son, dict):
+            raise InvalidQueryError("A '%s'-typed query value was expected, but '%s' was seen." % (cls._class_name,
+                                                                                                   str(son)))
 
         # Get the class name from the document, falling back to the given
         # class if unavailable

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -16,8 +16,8 @@ from mongoengine.base.datastructures import (BaseDict, BaseList,
                                              SemiStrictDict, StrictDict)
 from mongoengine.base.fields import ComplexBaseField
 from mongoengine.common import _import_class
-from mongoengine.errors import (FieldDoesNotExist, InvalidDocumentError,
-                                LookUpError, OperationError, ValidationError, InvalidQueryError)
+from mongoengine.errors import (FieldDoesNotExist, InvalidDocumentError, InvalidQueryError,
+                                LookUpError, OperationError, ValidationError)
 
 __all__ = ('BaseDocument',)
 

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -675,7 +675,7 @@ class BaseDocument(object):
         if not only_fields:
             only_fields = []
 
-        if not isinstance(son, dict):
+        if son and not isinstance(son, dict):
             raise InvalidQueryError("A '%s'-typed query value was expected, but '%s' was seen." % (cls._class_name,
                                                                                                    str(son)))
 

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -16,8 +16,7 @@ from mongoengine.base.datastructures import (BaseDict, BaseList,
                                              SemiStrictDict, StrictDict)
 from mongoengine.base.fields import ComplexBaseField
 from mongoengine.common import _import_class
-from mongoengine.errors import (FieldDoesNotExist, InvalidDocumentError, InvalidQueryError,
-                                LookUpError, OperationError, ValidationError)
+from mongoengine.errors import (FieldDoesNotExist, InvalidDocumentError, LookUpError, OperationError, ValidationError)
 
 __all__ = ('BaseDocument',)
 
@@ -676,8 +675,7 @@ class BaseDocument(object):
             only_fields = []
 
         if son and not isinstance(son, dict):
-            raise InvalidQueryError("A '%s'-typed query value was expected, but '%s' was seen." % (cls._class_name,
-                                                                                                   str(son)))
+            raise ValueError("The source SON object needs to be of type 'dict'")
 
         # Get the class name from the document, falling back to the given
         # class if unavailable

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -28,7 +28,7 @@ from mongoengine.base import (BaseDocument, BaseField, ComplexBaseField,
                               GeoJsonBaseField, ObjectIdField, get_document)
 from mongoengine.connection import DEFAULT_CONNECTION_NAME, get_db
 from mongoengine.document import Document, EmbeddedDocument
-from mongoengine.errors import DoesNotExist, ValidationError
+from mongoengine.errors import DoesNotExist, InvalidQueryError, ValidationError
 from mongoengine.python_support import StringIO
 from mongoengine.queryset import DO_NOTHING, QuerySet
 
@@ -566,7 +566,11 @@ class EmbeddedDocumentField(BaseField):
 
     def prepare_query_value(self, op, value):
         if value is not None and not isinstance(value, self.document_type):
-            value = self.document_type._from_son(value)
+            try:
+                value = self.document_type._from_son(value)
+            except ValueError:
+                raise InvalidQueryError("Querying the embedded document '%s' failed, due to an invalid query value" %
+                                        (self.document_type._class_name,))
         super(EmbeddedDocumentField, self).prepare_query_value(op, value)
         return self.to_mongo(value)
 

--- a/tests/document/instance.py
+++ b/tests/document/instance.py
@@ -1860,6 +1860,10 @@ class InstanceTest(unittest.TestCase):
                 'occurs': {"hello": None}
             })
 
+        # Tests for issue #1438: https://github.com/MongoEngine/mongoengine/issues/1438
+        with self.assertRaises(InvalidQueryError):
+            Word._from_son('this is not a valid SON dict')
+
     def test_reverse_delete_rule_cascade_and_nullify(self):
         """Ensure that a referenced document is also deleted upon deletion.
         """

--- a/tests/document/instance.py
+++ b/tests/document/instance.py
@@ -1861,7 +1861,7 @@ class InstanceTest(unittest.TestCase):
             })
 
         # Tests for issue #1438: https://github.com/MongoEngine/mongoengine/issues/1438
-        with self.assertRaises(InvalidQueryError):
+        with self.assertRaises(ValueError):
             Word._from_son('this is not a valid SON dict')
 
     def test_reverse_delete_rule_cascade_and_nullify(self):


### PR DESCRIPTION
This PR attempts to fix #1438. 
It adds a check of the passed SON value.

If the SON was neither a dict or None, the raised error was an `AttributeError`, independent of the given value. The error was raised, since the (native) value did not provide a `get(..)` method. 