### PR TITLE
[WIP] ListField support for None #1443

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ tests/test_bugfix.py
 htmlcov/
 venv
 venv3
+scratchpad

--- a/.install_mongodb_on_travis.sh
+++ b/.install_mongodb_on_travis.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+
+if [ "$MONGODB" = "2.4" ]; then
+    echo "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen" | sudo tee /etc/apt/sources.list.d/mongodb.list
+    sudo apt-get update
+    sudo apt-get install mongodb-10gen=2.4.14
+    sudo service mongodb start
+elif [ "$MONGODB" = "2.6" ]; then
+    echo "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen" | sudo tee /etc/apt/sources.list.d/mongodb.list
+    sudo apt-get update
+    sudo apt-get install mongodb-org-server=2.6.12
+    # service should be started automatically
+elif [ "$MONGODB" = "3.0" ]; then
+    echo "deb http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb.list
+    sudo apt-get update
+    sudo apt-get install mongodb-org-server=3.0.14
+    # service should be started automatically
+else
+    echo "Invalid MongoDB version, expected 2.4, 2.6, or 3.0."
+    exit 1
+fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,48 @@
+# For full coverage, we'd have to test all supported Python, MongoDB, and
+# PyMongo combinations. However, that would result in an overly long build
+# with a very large number of jobs, hence we only test a subset of all the
+# combinations:
+# * MongoDB v2.4 & v3.0 are only tested against Python v2.7 & v3.5.
+# * MongoDB v2.4 is tested against PyMongo v2.7 & v3.x.
+# * MongoDB v3.0 is tested against PyMongo v3.x.
+# * MongoDB v2.6 is currently the "main" version tested against Python v2.7,
+#   v3.5, PyPy & PyPy3, and PyMongo v2.7, v2.8 & v3.x.
+#
+# Reminder: Update README.rst if you change MongoDB versions we test.
+
 language: python
 
 python:
-- '2.7'
-- '3.3'
-- '3.4'
-- '3.5'
+- 2.7
+- 3.5
 - pypy
 - pypy3
 
 env:
-- PYMONGO=2.7
-- PYMONGO=2.8
-- PYMONGO=3.0
-- PYMONGO=dev
+- MONGODB=2.6 PYMONGO=2.7
+- MONGODB=2.6 PYMONGO=2.8
+- MONGODB=2.6 PYMONGO=3.0
 
 matrix:
+  # Finish the build as soon as one job fails
   fast_finish: true
 
+  include:
+  - python: 2.7
+    env: MONGODB=2.4 PYMONGO=2.7
+  - python: 2.7
+    env: MONGODB=2.4 PYMONGO=3.0
+  - python: 2.7
+    env: MONGODB=3.0 PYMONGO=3.0
+  - python: 3.5
+    env: MONGODB=2.4 PYMONGO=2.7
+  - python: 3.5
+    env: MONGODB=2.4 PYMONGO=3.0
+  - python: 3.5
+    env: MONGODB=3.0 PYMONGO=3.0
+
 before_install:
-- travis_retry sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-- echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' |
-  sudo tee /etc/apt/sources.list.d/mongodb.list
-- travis_retry sudo apt-get update
-- travis_retry sudo apt-get install mongodb-org-server
+- bash .install_mongodb_on_travis.sh
 
 install:
 - sudo apt-get install python-dev python3-dev libopenjpeg-dev zlib1g-dev libjpeg-turbo8-dev
@@ -30,14 +50,17 @@ install:
   python-tk
 - travis_retry pip install --upgrade pip
 - travis_retry pip install coveralls
-- travis_retry pip install flake8
+- travis_retry pip install flake8 flake8-import-order
 - travis_retry pip install tox>=1.9
 - travis_retry pip install "virtualenv<14.0.0"  # virtualenv>=14.0.0 has dropped Python 3.2 support (and pypy3 is based on py32)
 - travis_retry tox -e $(echo py$TRAVIS_PYTHON_VERSION-mg$PYMONGO | tr -d . | sed -e 's/pypypy/pypy/') -- -e test
 
+# Cache dependencies installed via pip
+cache: pip
+
 # Run flake8 for py27
 before_script:
-- if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then tox -e flake8; fi
+- if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then flake8 .; else echo "flake8 only runs on py27"; fi
 
 script:
 - tox -e $(echo py$TRAVIS_PYTHON_VERSION-mg$PYMONGO | tr -d . | sed -e 's/pypypy/pypy/') -- --with-coverage
@@ -45,22 +68,34 @@ script:
 # For now only submit coveralls for Python v2.7. Python v3.x currently shows
 # 0% coverage. That's caused by 'use_2to3', which builds the py3-compatible
 # code in a separate dir and runs tests on that.
-after_script:
+after_success:
 - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then coveralls --verbose; fi
 
 notifications:
   irc: irc.freenode.org#mongoengine
 
+# Only run builds on the master branch and GitHub releases (tagged as vX.Y.Z)
 branches:
   only:
   - master
   - /^v.*$/
 
+# Whenever a new release is created via GitHub, publish it on PyPI.
 deploy:
   provider: pypi
   user: the_drow
   password:
     secure: QMyatmWBnC6ZN3XLW2+fTBDU4LQcp1m/LjR2/0uamyeUzWKdlOoh/Wx5elOgLwt/8N9ppdPeG83ose1jOz69l5G0MUMjv8n/RIcMFSpCT59tGYqn3kh55b0cIZXFT9ar+5cxlif6a5rS72IHm5li7QQyxexJIII6Uxp0kpvUmek=
+
+  # create a source distribution and a pure python wheel for faster installs
+  distributions: "sdist bdist_wheel"
+
+  # only deploy on tagged commits (aka GitHub releases) and only for the
+  # parent repo's builds running Python 2.7 along with dev PyMongo (we run
+  # Travis against many different Python and PyMongo versions and we don't
+  # want the deploy to occur multiple times).
   on:
     tags: true
     repo: MongoEngine/mongoengine
+    condition: "$PYMONGO = 3.0"
+    python: 2.7

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -29,19 +29,20 @@ Style Guide
 -----------
 
 MongoEngine aims to follow `PEP8 <http://www.python.org/dev/peps/pep-0008/>`_
-including 4 space indents. When possible we try to stick to 79 character line limits.
-However, screens got bigger and an ORM has a strong focus on readability and
-if it can help, we accept 119 as maximum line length, in a similar way as
-`django does <https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/#python-style>`_
+including 4 space indents. When possible we try to stick to 79 character line
+limits. However, screens got bigger and an ORM has a strong focus on
+readability and if it can help, we accept 119 as maximum line length, in a
+similar way as `django does
+<https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/#python-style>`_
 
 Testing
 -------
 
 All tests are run on `Travis <http://travis-ci.org/MongoEngine/mongoengine>`_
-and any pull requests are automatically tested by Travis. Any pull requests
-without tests will take longer to be integrated and might be refused.
+and any pull requests are automatically tested. Any pull requests without
+tests will take longer to be integrated and might be refused.
 
-You may also submit a simple failing test as a PullRequest if you don't know
+You may also submit a simple failing test as a pull request if you don't know
 how to fix it, it will be easier for other people to work on it and it may get
 fixed faster.
 
@@ -49,13 +50,18 @@ General Guidelines
 ------------------
 
 - Avoid backward breaking changes if at all possible.
+- If you *have* to introduce a breaking change, make it very clear in your
+  pull request's description. Also, describe how users of this package
+  should adapt to the breaking change in docs/upgrade.rst.
 - Write inline documentation for new classes and methods.
 - Write tests and make sure they pass (make sure you have a mongod
   running on the default port, then execute ``python setup.py nosetests``
   from the cmd line to run the test suite).
-- Ensure tests pass on every Python and PyMongo versions.
-  You can test on these versions locally by executing ``tox``
-- Add enhancements or problematic bug fixes to docs/changelog.rst
+- Ensure tests pass on all supported Python, PyMongo, and MongoDB versions.
+  You can test various Python and PyMongo versions locally by executing
+  ``tox``. For different MongoDB versions, you can rely on our automated
+  Travis tests.
+- Add enhancements or problematic bug fixes to docs/changelog.rst.
 - Add yourself to AUTHORS :)
 
 Documentation
@@ -69,3 +75,6 @@ just make your changes to the inline documentation of the appropriate
 branch and submit a `pull request <https://help.github.com/articles/using-pull-requests>`_.
 You might also use the github `Edit <https://github.com/blog/844-forking-with-the-edit-button>`_
 button.
+
+If you want to test your documentation changes locally, you need to install
+the ``sphinx`` package.

--- a/README.rst
+++ b/README.rst
@@ -19,23 +19,31 @@ MongoEngine
 About
 =====
 MongoEngine is a Python Object-Document Mapper for working with MongoDB.
-Documentation available at https://mongoengine-odm.readthedocs.io - there is currently
-a `tutorial <https://mongoengine-odm.readthedocs.io/tutorial.html>`_, a `user guide
-<https://mongoengine-odm.readthedocs.io/guide/index.html>`_ and an `API reference
-<https://mongoengine-odm.readthedocs.io/apireference.html>`_.
+Documentation is available at https://mongoengine-odm.readthedocs.io - there
+is currently a `tutorial <https://mongoengine-odm.readthedocs.io/tutorial.html>`_,
+a `user guide <https://mongoengine-odm.readthedocs.io/guide/index.html>`_, and
+an `API reference <https://mongoengine-odm.readthedocs.io/apireference.html>`_.
+
+Supported MongoDB Versions
+==========================
+MongoEngine is currently tested against MongoDB v2.4, v2.6, and v3.0. Future
+versions should be supported as well, but aren't actively tested at the moment.
+Make sure to open an issue or submit a pull request if you experience any
+problems with MongoDB v3.2+.
 
 Installation
 ============
 We recommend the use of `virtualenv <https://virtualenv.pypa.io/>`_ and of
 `pip <https://pip.pypa.io/>`_. You can then use ``pip install -U mongoengine``.
-You may also have `setuptools <http://peak.telecommunity.com/DevCenter/setuptools>`_ and thus
-you can use ``easy_install -U mongoengine``. Otherwise, you can download the
+You may also have `setuptools <http://peak.telecommunity.com/DevCenter/setuptools>`_
+and thus you can use ``easy_install -U mongoengine``. Otherwise, you can download the
 source from `GitHub <http://github.com/MongoEngine/mongoengine>`_ and run ``python
 setup.py install``.
 
 Dependencies
 ============
-All of the dependencies can easily be installed via `pip <https://pip.pypa.io/>`_. At the very least, you'll need these two packages to use MongoEngine:
+All of the dependencies can easily be installed via `pip <https://pip.pypa.io/>`_.
+At the very least, you'll need these two packages to use MongoEngine:
 
 - pymongo>=2.7.1
 - six>=1.10.0
@@ -47,10 +55,6 @@ If you utilize a ``DateTimeField``, you might also use a more flexible date pars
 If you need to use an ``ImageField`` or ``ImageGridFsProxy``:
 
 - Pillow>=2.0.0
-
-If you want to generate the documentation (e.g. to contribute to it):
-
-- sphinx
 
 Examples
 ========
@@ -110,11 +114,11 @@ Some simple examples of what MongoEngine code looks like:
 Tests
 =====
 To run the test suite, ensure you are running a local instance of MongoDB on
-the standard port and have ``nose`` installed. Then, run: ``python setup.py nosetests``.
+the standard port and have ``nose`` installed. Then, run ``python setup.py nosetests``.
 
-To run the test suite on every supported Python version and every supported PyMongo version,
-you can use ``tox``.
-tox and each supported Python version should be installed in your environment:
+To run the test suite on every supported Python and PyMongo version, you can
+use ``tox``. You'll need to make sure you have each supported Python version
+installed in your environment and then:
 
 .. code-block:: shell
 
@@ -123,13 +127,16 @@ tox and each supported Python version should be installed in your environment:
     # Run the test suites
     $ tox
 
-If you wish to run one single or selected tests, use the nosetest convention. It will find the folder,
-eventually the file, go to the TestClass specified after the colon and eventually right to the single test.
-Also use the -s argument if you want to print out whatever or access pdb while testing.
+If you wish to run a subset of tests, use the nosetests convention:
 
 .. code-block:: shell
 
-    $ python setup.py nosetests --tests tests/fields/fields.py:FieldTest.test_cls_field -s
+    # Run all the tests in a particular test file
+    $ python setup.py nosetests --tests tests/fields/fields.py
+    # Run only particular test class in that file
+    $ python setup.py nosetests --tests tests/fields/fields.py:FieldTest
+    # Use the -s option if you want to print some debug statements or use pdb
+    $ python setup.py nosetests --tests tests/fields/fields.py:FieldTest -s
 
 Community
 =========

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,8 @@ Changelog
 
 Development
 ===========
-- (Fill this out as you fix issues and develop you features).
+- (Fill this out as you fix issues and develop your features).
+- Fixed using sets in field choices #1481
 - POTENTIAL BREAKING CHANGE: Fixed limit/skip/hint/batch_size chaining #1476
 - POTENTIAL BREAKING CHANGE: Changed a public `QuerySet.clone_into` method to a private `QuerySet._clone_into` #1476
 - Fixed connecting to a replica set with PyMongo 2.x #1436

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,8 @@ Changelog
 Development
 ===========
 - (Fill this out as you fix issues and develop you features).
+- POTENTIAL BREAKING CHANGE: Fixed limit/skip/hint/batch_size chaining #1476
+- POTENTIAL BREAKING CHANGE: Changed a public `QuerySet.clone_into` method to a private `QuerySet._clone_into` #1476
 - Fixed connecting to a replica set with PyMongo 2.x #1436
 - Fixed an obscure error message when filtering by `field__in=non_iterable`. #1237
 

--- a/docs/guide/connecting.rst
+++ b/docs/guide/connecting.rst
@@ -42,13 +42,18 @@ the :attr:`host` to
     will establish connection to ``production`` database using
     ``admin`` username and ``qwerty`` password.
 
-ReplicaSets
-===========
+Replica Sets
+============
 
-MongoEngine supports
-:class:`~pymongo.mongo_replica_set_client.MongoReplicaSetClient`. To use them,
-please use an URI style connection and provide the ``replicaSet`` name
-in the connection kwargs.
+MongoEngine supports connecting to replica sets::
+
+    from mongoengine import connect
+
+    # Regular connect
+    connect('dbname', replicaset='rs-name')
+
+    # MongoDB URI-style connect
+    connect(host='mongodb://localhost/dbname?replicaSet=rs-name')
 
 Read preferences are supported through the connection or via individual
 queries by passing the read_preference ::
@@ -59,76 +64,74 @@ queries by passing the read_preference ::
 Multiple Databases
 ==================
 
-Multiple database support was added in MongoEngine 0.6. To use multiple
-databases you can use :func:`~mongoengine.connect` and provide an `alias` name
-for the connection - if no `alias` is provided then "default" is used.
+To use multiple databases you can use :func:`~mongoengine.connect` and provide
+an `alias` name for the connection - if no `alias` is provided then "default"
+is used.
 
 In the background this uses :func:`~mongoengine.register_connection` to
 store the data and you can register all aliases up front if required.
 
 Individual documents can also support multiple databases by providing a
-`db_alias` in their meta data.  This allows :class:`~pymongo.dbref.DBRef` objects
-to point across databases and collections.  Below is an example schema, using
-3 different databases to store data::
+`db_alias` in their meta data. This allows :class:`~pymongo.dbref.DBRef`
+objects to point across databases and collections. Below is an example schema,
+using 3 different databases to store data::
 
         class User(Document):
             name = StringField()
 
-            meta = {"db_alias": "user-db"}
+            meta = {'db_alias': 'user-db'}
 
         class Book(Document):
             name = StringField()
 
-            meta = {"db_alias": "book-db"}
+            meta = {'db_alias': 'book-db'}
 
         class AuthorBooks(Document):
             author = ReferenceField(User)
             book = ReferenceField(Book)
 
-            meta = {"db_alias": "users-books-db"}
+            meta = {'db_alias': 'users-books-db'}
 
 
 Context Managers
 ================
-Sometimes you may want to switch the database or collection to query against
-for a class.
+Sometimes you may want to switch the database or collection to query against.
 For example, archiving older data into a separate database for performance
 reasons or writing functions that dynamically choose collections to write
-document to.
+a document to.
 
 Switch Database
 ---------------
 The :class:`~mongoengine.context_managers.switch_db` context manager allows
 you to change the database alias for a given class allowing quick and easy
-access the same User document across databases::
+access to the same User document across databases::
 
     from mongoengine.context_managers import switch_db
 
     class User(Document):
         name = StringField()
 
-        meta = {"db_alias": "user-db"}
+        meta = {'db_alias': 'user-db'}
 
     with switch_db(User, 'archive-user-db') as User:
-        User(name="Ross").save()  # Saves the 'archive-user-db'
+        User(name='Ross').save()  # Saves the 'archive-user-db'
 
 
 Switch Collection
 -----------------
 The :class:`~mongoengine.context_managers.switch_collection` context manager
 allows you to change the collection for a given class allowing quick and easy
-access the same Group document across collection::
+access to the same Group document across collection::
 
         from mongoengine.context_managers import switch_collection
 
         class Group(Document):
             name = StringField()
 
-        Group(name="test").save()  # Saves in the default db
+        Group(name='test').save()  # Saves in the default db
 
         with switch_collection(Group, 'group2000') as Group:
-            Group(name="hello Group 2000 collection!").save()  # Saves in group2000 collection
-
+            Group(name='hello Group 2000 collection!').save()  # Saves in group2000 collection
 
 
 .. note:: Make sure any aliases have been registered with

--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -150,7 +150,7 @@ arguments can be set on all fields:
     .. note:: If set, this field is also accessible through the `pk` field.
 
 :attr:`choices` (Default: None)
-    An iterable (e.g. a list or tuple) of choices to which the value of this
+    An iterable (e.g. list, tuple or set) of choices to which the value of this
     field should be limited.
 
     Can be either be a nested tuples of value (stored in mongo) and a
@@ -214,8 +214,8 @@ document class as the first argument::
 
 Dictionary Fields
 -----------------
-Often, an embedded document may be used instead of a dictionary – generally 
-embedded documents are recommended as dictionaries don’t support validation 
+Often, an embedded document may be used instead of a dictionary – generally
+embedded documents are recommended as dictionaries don’t support validation
 or custom field types. However, sometimes you will not know the structure of what you want to
 store; in this situation a :class:`~mongoengine.fields.DictField` is appropriate::
 

--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -361,11 +361,6 @@ Its value can take any of the following constants:
    In Django, be sure to put all apps that have such delete rule declarations in
    their :file:`models.py` in the :const:`INSTALLED_APPS` tuple.
 
-
-.. warning::
-   Signals are not triggered when doing cascading updates / deletes - if this
-   is required you must manually handle the update / delete.
-
 Generic reference fields
 ''''''''''''''''''''''''
 A second kind of reference field also exists,

--- a/docs/guide/installing.rst
+++ b/docs/guide/installing.rst
@@ -2,13 +2,13 @@
 Installing MongoEngine
 ======================
 
-To use MongoEngine, you will need to download `MongoDB <http://mongodb.org/>`_
+To use MongoEngine, you will need to download `MongoDB <http://mongodb.com/>`_
 and ensure it is running in an accessible location. You will also need
 `PyMongo <http://api.mongodb.org/python>`_ to use MongoEngine, but if you
 install MongoEngine using setuptools, then the dependencies will be handled for
 you.
 
-MongoEngine is available on PyPI, so to use it you can use :program:`pip`:
+MongoEngine is available on PyPI, so you can use :program:`pip`:
 
 .. code-block:: console
 

--- a/docs/guide/signals.rst
+++ b/docs/guide/signals.rst
@@ -142,11 +142,4 @@ cleaner looking while still allowing manual execution of the callback::
         modified = DateTimeField()
 
 
-ReferenceFields and Signals
----------------------------
-
-Currently `reverse_delete_rule` does not trigger signals on the other part of
-the relationship.  If this is required you must manually handle the
-reverse deletion.
-
 .. _blinker: http://pypi.python.org/pypi/blinker

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -3,11 +3,10 @@ Tutorial
 ========
 
 This tutorial introduces **MongoEngine** by means of example --- we will walk
-through how to create a simple **Tumblelog** application. A Tumblelog is a type
-of blog where posts are not constrained to being conventional text-based posts.
-As well as text-based entries, users may post images, links, videos, etc. For
-simplicity's sake, we'll stick to text, image and link entries in our
-application. As the purpose of this tutorial is to introduce MongoEngine, we'll
+through how to create a simple **Tumblelog** application. A tumblelog is a
+blog that supports mixed media content, including text, images, links, video,
+audio, etc. For simplicity's sake, we'll stick to text, image, and link
+entries. As the purpose of this tutorial is to introduce MongoEngine, we'll
 focus on the data-modelling side of the application, leaving out a user
 interface.
 
@@ -16,14 +15,14 @@ Getting started
 
 Before we start, make sure that a copy of MongoDB is running in an accessible
 location --- running it locally will be easier, but if that is not an option
-then it may be run on a remote server. If you haven't installed mongoengine,
+then it may be run on a remote server. If you haven't installed MongoEngine,
 simply use pip to install it like so::
 
     $ pip install mongoengine
 
 Before we can start using MongoEngine, we need to tell it how to connect to our
 instance of :program:`mongod`. For this we use the :func:`~mongoengine.connect`
-function. If running locally the only argument we need to provide is the name
+function. If running locally, the only argument we need to provide is the name
 of the MongoDB database to use::
 
     from mongoengine import *
@@ -39,18 +38,18 @@ Defining our documents
 MongoDB is *schemaless*, which means that no schema is enforced by the database
 --- we may add and remove fields however we want and MongoDB won't complain.
 This makes life a lot easier in many regards, especially when there is a change
-to the data model. However, defining schemata for our documents can help to
-iron out bugs involving incorrect types or missing fields, and also allow us to
+to the data model. However, defining schemas for our documents can help to iron
+out bugs involving incorrect types or missing fields, and also allow us to
 define utility methods on our documents in the same way that traditional
 :abbr:`ORMs (Object-Relational Mappers)` do.
 
 In our Tumblelog application we need to store several different types of
-information.  We will need to have a collection of **users**, so that we may
+information. We will need to have a collection of **users**, so that we may
 link posts to an individual. We also need to store our different types of
 **posts** (eg: text, image and link) in the database. To aid navigation of our
 Tumblelog, posts may have **tags** associated with them, so that the list of
 posts shown to the user may be limited to posts that have been assigned a
-specific tag.  Finally, it would be nice if **comments** could be added to
+specific tag. Finally, it would be nice if **comments** could be added to
 posts. We'll start with **users**, as the other document models are slightly
 more involved.
 
@@ -78,7 +77,7 @@ Now we'll think about how to store the rest of the information. If we were
 using a relational database, we would most likely have a table of **posts**, a
 table of **comments** and a table of **tags**.  To associate the comments with
 individual posts, we would put a column in the comments table that contained a
-foreign key to the posts table.  We'd also need a link table to provide the
+foreign key to the posts table. We'd also need a link table to provide the
 many-to-many relationship between posts and tags. Then we'd need to address the
 problem of storing the specialised post-types (text, image and link). There are
 several ways we can achieve this, but each of them have their problems --- none
@@ -96,7 +95,7 @@ using* the new fields we need to support video posts. This fits with the
 Object-Oriented principle of *inheritance* nicely. We can think of
 :class:`Post` as a base class, and :class:`TextPost`, :class:`ImagePost` and
 :class:`LinkPost` as subclasses of :class:`Post`. In fact, MongoEngine supports
-this kind of modelling out of the box --- all you need do is turn on inheritance
+this kind of modeling out of the box --- all you need do is turn on inheritance
 by setting :attr:`allow_inheritance` to True in the :attr:`meta`::
 
     class Post(Document):
@@ -128,8 +127,8 @@ link table, we can just store a list of tags in each post. So, for both
 efficiency and simplicity's sake, we'll store the tags as strings directly
 within the post, rather than storing references to tags in a separate
 collection. Especially as tags are generally very short (often even shorter
-than a document's id), this denormalisation won't impact very strongly on the
-size of our database. So let's take a look that the code our modified
+than a document's id), this denormalization won't impact the size of the
+database very strongly. Let's take a look at the code of our modified
 :class:`Post` class::
 
     class Post(Document):
@@ -141,7 +140,7 @@ The :class:`~mongoengine.fields.ListField` object that is used to define a Post'
 takes a field object as its first argument --- this means that you can have
 lists of any type of field (including lists).
 
-.. note:: We don't need to modify the specialised post types as they all
+.. note:: We don't need to modify the specialized post types as they all
     inherit from :class:`Post`.
 
 Comments
@@ -149,7 +148,7 @@ Comments
 
 A comment is typically associated with *one* post. In a relational database, to
 display a post with its comments, we would have to retrieve the post from the
-database, then query the database again for the comments associated with the
+database and then query the database again for the comments associated with the
 post. This works, but there is no real reason to be storing the comments
 separately from their associated posts, other than to work around the
 relational model. Using MongoDB we can store the comments as a list of
@@ -219,8 +218,8 @@ Now that we've got our user in the database, let's add a couple of posts::
     post2.tags = ['mongoengine']
     post2.save()
 
-.. note:: If you change a field on a object that has already been saved, then
-    call :meth:`save` again, the document will be updated.
+.. note:: If you change a field on an object that has already been saved and
+    then call :meth:`save` again, the document will be updated.
 
 Accessing our data
 ==================
@@ -232,17 +231,17 @@ used to access the documents in the database collection associated with that
 class. So let's see how we can get our posts' titles::
 
     for post in Post.objects:
-        print post.title
+        print(post.title)
 
 Retrieving type-specific information
 ------------------------------------
 
-This will print the titles of our posts, one on each line. But What if we want
+This will print the titles of our posts, one on each line. But what if we want
 to access the type-specific data (link_url, content, etc.)? One way is simply
 to use the :attr:`objects` attribute of a subclass of :class:`Post`::
 
     for post in TextPost.objects:
-        print post.content
+        print(post.content)
 
 Using TextPost's :attr:`objects` attribute only returns documents that were
 created using :class:`TextPost`. Actually, there is a more general rule here:
@@ -259,16 +258,14 @@ instances of :class:`Post` --- they were instances of the subclass of
 practice::
 
     for post in Post.objects:
-        print post.title
-        print '=' * len(post.title)
+        print(post.title)
+        print('=' * len(post.title))
 
         if isinstance(post, TextPost):
-            print post.content
+            print(post.content)
 
         if isinstance(post, LinkPost):
-            print 'Link:', post.link_url
-
-        print
+            print('Link: {}'.format(post.link_url))
 
 This would print the title of each post, followed by the content if it was a
 text post, and "Link: <url>" if it was a link post.
@@ -283,7 +280,7 @@ your query.  Let's adjust our query so that only posts with the tag "mongodb"
 are returned::
 
     for post in Post.objects(tags='mongodb'):
-        print post.title
+        print(post.title)
 
 There are also methods available on :class:`~mongoengine.queryset.QuerySet`
 objects that allow different results to be returned, for example, calling
@@ -292,11 +289,11 @@ the first matched by the query you provide. Aggregation functions may also be
 used on :class:`~mongoengine.queryset.QuerySet` objects::
 
     num_posts = Post.objects(tags='mongodb').count()
-    print 'Found %d posts with tag "mongodb"' % num_posts
+    print('Found {} posts with tag "mongodb"'.format(num_posts))
 
-Learning more about mongoengine
+Learning more about MongoEngine
 -------------------------------
 
-If you got this far you've made a great start, so well done!  The next step on
-your mongoengine journey is the `full user guide <guide/index.html>`_, where you
-can learn indepth about how to use mongoengine and mongodb.
+If you got this far you've made a great start, so well done! The next step on
+your MongoEngine journey is the `full user guide <guide/index.html>`_, where
+you can learn in-depth about how to use MongoEngine and MongoDB.

--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -2,6 +2,20 @@
 Upgrading
 #########
 
+Development
+***********
+(Fill this out whenever you introduce breaking changes to MongoEngine)
+
+This release includes various fixes for the `BaseQuerySet` methods and how they
+are chained together. Since version 0.10.1 applying limit/skip/hint/batch_size
+to an already-existing queryset wouldn't modify the underlying PyMongo cursor.
+This has been fixed now, so you'll need to make sure that your code didn't rely
+on the broken implementation.
+
+Additionally, a public `BaseQuerySet.clone_into` has been renamed to a private
+`_clone_into`. If you directly used that method in your code, you'll need to
+rename its occurrences.
+
 0.11.0
 ******
 This release includes a major rehaul of MongoEngine's code quality and

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -702,13 +702,13 @@ class BaseDocument(object):
             field._auto_dereference = _auto_dereference
             if field.db_field in data:
                 value = data[field.db_field]
-                try:
-                    data[field_name] = (value if value is None
+                ## try:
+                data[field_name] = (value if value is None
                                         else field.to_python(value))
-                    if field_name != field.db_field:
+                if field_name != field.db_field:
                         del data[field.db_field]
-                except (AttributeError, ValueError) as e:
-                    errors_dict[field_name] = e
+                ## except (AttributeError, ValueError) as e:
+                ##    errors_dict[field_name] = e
 
         if errors_dict:
             errors = '\n'.join(['%s - %s' % (k, v)
@@ -720,6 +720,8 @@ class BaseDocument(object):
         # In STRICT documents, remove any keys that aren't in cls._fields
         if cls.STRICT:
             data = {k: v for k, v in data.iteritems() if k in cls._fields}
+
+        print("raw_data", data)
 
         obj = cls(__auto_convert=False, _created=created, __only_fields=only_fields, **data)
         obj._changed_fields = changed_fields

--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -193,7 +193,8 @@ class BaseField(object):
         EmbeddedDocument = _import_class('EmbeddedDocument')
 
         choice_list = self.choices
-        if isinstance(choice_list[0], (list, tuple)):
+        if isinstance(next(iter(choice_list)), (list, tuple)):
+            # next(iter) is useful for sets
             choice_list = [k for k, _ in choice_list]
 
         # Choices which are other types of Documents

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -51,7 +51,9 @@ def register_connection(alias, name=None, host=None, port=None,
         MONGODB-CR (MongoDB Challenge Response protocol) for older servers.
     :param is_mock: explicitly use mongomock for this connection
         (can also be done by using `mongomock://` as db host prefix)
-    :param kwargs: allow ad-hoc parameters to be passed into the pymongo driver
+    :param kwargs: ad-hoc parameters to be passed into the pymongo driver,
+        for example maxpoolsize, tz_aware, etc. See the documentation
+        for pymongo's `MongoClient` for a full list.
 
     .. versionchanged:: 0.10.6 - added mongomock support
     """
@@ -241,8 +243,11 @@ def connect(db=None, alias=DEFAULT_CONNECTION_NAME, **kwargs):
     running on the default port on localhost. If authentication is needed,
     provide username and password arguments as well.
 
-    Multiple databases are supported by using aliases.  Provide a separate
+    Multiple databases are supported by using aliases. Provide a separate
     `alias` to connect to a different instance of :program:`mongod`.
+
+    See the docstring for `register_connection` for more details about all
+    supported kwargs.
 
     .. versionchanged:: 0.6 - added multiple database support.
     """

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -888,10 +888,6 @@ class ReferenceField(BaseField):
 
         Foo.register_delete_rule(Bar, 'foo', NULLIFY)
 
-    .. note ::
-        `reverse_delete_rule` does not trigger pre / post delete signals to be
-        triggered.
-
     .. versionchanged:: 0.5 added `reverse_delete_rule`
     """
 

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -559,10 +559,10 @@ class EmbeddedDocumentField(BaseField):
         """
         # handle "None" first (None = no data to post; in a list this creates a null)
         if value is None:
-            if self.required and not getattr(self, '_auto_gen', False):
+            if self.required:
                 raise ValidationError('Field is required', field_name=self.name)
             return
-        # otherwise, it should be an embeeded document
+        # otherwise, it should be an embedded document
         # Using isinstance also works for subclasses of self.document
         if not isinstance(value, self.document_type):
             self.error('Invalid embedded document instance provided to an '

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -2057,17 +2057,3 @@ class MultiPolygonField(GeoJsonBaseField):
     .. versionadded:: 0.9
     """
     _type = 'MultiPolygon'
-
-
-class MissingType(object):
-    __slots__ = () # save a few bytes
-
-    def __repr__(self):
-        return 'Missing'
-
-    def __bool__(self):
-        return False
-
-    __nonzero__=__bool__
-
-Missing = MissingType()

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -139,12 +139,12 @@ class URLField(StringField):
         # Check first if the scheme is valid
         scheme = value.split('://')[0].lower()
         if scheme not in self.schemes:
-            self.error('Invalid scheme {} in URL: {}'.format(scheme, value))
+            self.error(u'Invalid scheme {} in URL: {}'.format(scheme, value))
             return
 
         # Then check full URL
         if not self.url_regex.match(value):
-            self.error('Invalid URL: {}'.format(value))
+            self.error(u'Invalid URL: {}'.format(value))
             return
 
 

--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -286,7 +286,7 @@ class BaseQuerySet(object):
 
         .. versionadded:: 0.4
         """
-        return self._document(**kwargs).save()
+        return self._document(**kwargs).save(force_insert=True)
 
     def first(self):
         """Retrieve the first object matching the query."""

--- a/mongoengine/queryset/queryset.py
+++ b/mongoengine/queryset/queryset.py
@@ -136,13 +136,15 @@ class QuerySet(BaseQuerySet):
         return self._len
 
     def no_cache(self):
-        """Convert to a non_caching queryset
+        """Convert to a non-caching queryset
 
         .. versionadded:: 0.8.3 Convert to non caching queryset
         """
         if self._result_cache is not None:
             raise OperationError('QuerySet already cached')
-        return self.clone_into(QuerySetNoCache(self._document, self._collection))
+
+        return self._clone_into(QuerySetNoCache(self._document,
+                                                self._collection))
 
 
 class QuerySetNoCache(BaseQuerySet):
@@ -153,7 +155,7 @@ class QuerySetNoCache(BaseQuerySet):
 
         .. versionadded:: 0.8.3 Convert to caching queryset
         """
-        return self.clone_into(QuerySet(self._document, self._collection))
+        return self._clone_into(QuerySet(self._document, self._collection))
 
     def __repr__(self):
         """Provides the string representation of the QuerySet

--- a/tests/document/instance.py
+++ b/tests/document/instance.py
@@ -28,8 +28,6 @@ TEST_IMAGE_PATH = os.path.join(os.path.dirname(__file__),
 __all__ = ("InstanceTest",)
 
 
-
-
 class InstanceTest(unittest.TestCase):
 
     def setUp(self):
@@ -72,8 +70,7 @@ class InstanceTest(unittest.TestCase):
             self.assertEqual(field._instance, instance)
 
     def test_capped_collection(self):
-        """Ensure that capped collections work properly.
-        """
+        """Ensure that capped collections work properly."""
         class Log(Document):
             date = DateTimeField(default=datetime.now)
             meta = {
@@ -181,8 +178,7 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual('<Article: привет мир>', repr(doc))
 
     def test_repr_none(self):
-        """Ensure None values handled correctly
-        """
+        """Ensure None values are handled correctly."""
         class Article(Document):
             title = StringField()
 
@@ -190,25 +186,23 @@ class InstanceTest(unittest.TestCase):
                 return None
 
         doc = Article(title=u'привет мир')
-
         self.assertEqual('<Article: None>', repr(doc))
 
     def test_queryset_resurrects_dropped_collection(self):
         self.Person.drop_collection()
-
         self.assertEqual([], list(self.Person.objects()))
 
+        # Ensure works correctly with inhertited classes
         class Actor(self.Person):
             pass
 
-        # Ensure works correctly with inhertited classes
         Actor.objects()
         self.Person.drop_collection()
         self.assertEqual([], list(Actor.objects()))
 
     def test_polymorphic_references(self):
-        """Ensure that the correct subclasses are returned from a query when
-        using references / generic references
+        """Ensure that the correct subclasses are returned from a query
+        when using references / generic references
         """
         class Animal(Document):
             meta = {'allow_inheritance': True}
@@ -258,9 +252,6 @@ class InstanceTest(unittest.TestCase):
         classes = [a.__class__ for a in Zoo.objects.first().animals]
         self.assertEqual(classes, [Animal, Fish, Mammal, Dog, Human])
 
-        Zoo.drop_collection()
-        Animal.drop_collection()
-
     def test_reference_inheritance(self):
         class Stats(Document):
             created = DateTimeField(default=datetime.now)
@@ -287,8 +278,7 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(list_stats, CompareStats.objects.first().stats)
 
     def test_db_field_load(self):
-        """Ensure we load data correctly
-        """
+        """Ensure we load data correctly from the right db field."""
         class Person(Document):
             name = StringField(required=True)
             _rank = StringField(required=False, db_field="rank")
@@ -307,8 +297,7 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(Person.objects.get(name="Fred").rank, "Private")
 
     def test_db_embedded_doc_field_load(self):
-        """Ensure we load embedded document data correctly
-        """
+        """Ensure we load embedded document data correctly."""
         class Rank(EmbeddedDocument):
             title = StringField(required=True)
 
@@ -333,8 +322,7 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(Person.objects.get(name="Fred").rank, "Private")
 
     def test_custom_id_field(self):
-        """Ensure that documents may be created with custom primary keys.
-        """
+        """Ensure that documents may be created with custom primary keys."""
         class User(Document):
             username = StringField(primary_key=True)
             name = StringField()
@@ -382,10 +370,7 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(user_son['_id'], 'mongo')
         self.assertTrue('username' not in user_son['_id'])
 
-        User.drop_collection()
-
     def test_document_not_registered(self):
-
         class Place(Document):
             name = StringField()
 
@@ -407,7 +392,6 @@ class InstanceTest(unittest.TestCase):
             list(Place.objects.all())
 
     def test_document_registry_regressions(self):
-
         class Location(Document):
             name = StringField()
             meta = {'allow_inheritance': True}
@@ -421,18 +405,16 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(Area, get_document("Location.Area"))
 
     def test_creation(self):
-        """Ensure that document may be created using keyword arguments.
-        """
+        """Ensure that document may be created using keyword arguments."""
         person = self.Person(name="Test User", age=30)
         self.assertEqual(person.name, "Test User")
         self.assertEqual(person.age, 30)
 
     def test_to_dbref(self):
-        """Ensure that you can get a dbref of a document"""
+        """Ensure that you can get a dbref of a document."""
         person = self.Person(name="Test User", age=30)
         self.assertRaises(OperationError, person.to_dbref)
         person.save()
-
         person.to_dbref()
 
     def test_save_abstract_document(self):
@@ -445,8 +427,7 @@ class InstanceTest(unittest.TestCase):
             Doc(name='aaa').save()
 
     def test_reload(self):
-        """Ensure that attributes may be reloaded.
-        """
+        """Ensure that attributes may be reloaded."""
         person = self.Person(name="Test User", age=20)
         person.save()
 
@@ -479,7 +460,6 @@ class InstanceTest(unittest.TestCase):
         doc = Animal(superphylum='Deuterostomia')
         doc.save()
         doc.reload()
-        Animal.drop_collection()
 
     def test_reload_sharded_nested(self):
         class SuperPhylum(EmbeddedDocument):
@@ -493,11 +473,9 @@ class InstanceTest(unittest.TestCase):
         doc = Animal(superphylum=SuperPhylum(name='Deuterostomia'))
         doc.save()
         doc.reload()
-        Animal.drop_collection()
 
     def test_reload_referencing(self):
-        """Ensures reloading updates weakrefs correctly
-        """
+        """Ensures reloading updates weakrefs correctly."""
         class Embedded(EmbeddedDocument):
             dict_field = DictField()
             list_field = ListField()
@@ -569,8 +547,7 @@ class InstanceTest(unittest.TestCase):
             self.assertFalse("Threw wrong exception")
 
     def test_reload_of_non_strict_with_special_field_name(self):
-        """Ensures reloading works for documents with meta strict == False
-        """
+        """Ensures reloading works for documents with meta strict == False."""
         class Post(Document):
             meta = {
                 'strict': False
@@ -591,8 +568,7 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(post.items, ["more lorem", "even more ipsum"])
 
     def test_dictionary_access(self):
-        """Ensure that dictionary-style field access works properly.
-        """
+        """Ensure that dictionary-style field access works properly."""
         person = self.Person(name='Test User', age=30, job=self.Job())
         self.assertEqual(person['name'], 'Test User')
 
@@ -634,8 +610,7 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(sub_doc.to_mongo().keys(), ['id'])
 
     def test_embedded_document(self):
-        """Ensure that embedded documents are set up correctly.
-        """
+        """Ensure that embedded documents are set up correctly."""
         class Comment(EmbeddedDocument):
             content = StringField()
 
@@ -643,8 +618,7 @@ class InstanceTest(unittest.TestCase):
         self.assertFalse('id' in Comment._fields)
 
     def test_embedded_document_instance(self):
-        """Ensure that embedded documents can reference parent instance
-        """
+        """Ensure that embedded documents can reference parent instance."""
         class Embedded(EmbeddedDocument):
             string = StringField()
 
@@ -652,6 +626,7 @@ class InstanceTest(unittest.TestCase):
             embedded_field = EmbeddedDocumentField(Embedded)
 
         Doc.drop_collection()
+
         doc = Doc(embedded_field=Embedded(string="Hi"))
         self.assertHasInstance(doc.embedded_field, doc)
 
@@ -661,7 +636,8 @@ class InstanceTest(unittest.TestCase):
 
     def test_embedded_document_complex_instance(self):
         """Ensure that embedded documents in complex fields can reference
-        parent instance"""
+        parent instance.
+        """
         class Embedded(EmbeddedDocument):
             string = StringField()
 
@@ -677,8 +653,7 @@ class InstanceTest(unittest.TestCase):
         self.assertHasInstance(doc.embedded_field[0], doc)
 
     def test_embedded_document_complex_instance_no_use_db_field(self):
-        """Ensure that use_db_field is propagated to list of Emb Docs
-        """
+        """Ensure that use_db_field is propagated to list of Emb Docs."""
         class Embedded(EmbeddedDocument):
             string = StringField(db_field='s')
 
@@ -690,7 +665,6 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(d['embedded_field'], [{'string': 'Hi'}])
 
     def test_instance_is_set_on_setattr(self):
-
         class Email(EmbeddedDocument):
             email = EmailField()
 
@@ -698,6 +672,7 @@ class InstanceTest(unittest.TestCase):
             email = EmbeddedDocumentField(Email)
 
         Account.drop_collection()
+
         acc = Account()
         acc.email = Email(email='test@example.com')
         self.assertHasInstance(acc._data["email"], acc)
@@ -707,7 +682,6 @@ class InstanceTest(unittest.TestCase):
         self.assertHasInstance(acc1._data["email"], acc1)
 
     def test_instance_is_set_on_setattr_on_embedded_document_list(self):
-
         class Email(EmbeddedDocument):
             email = EmailField()
 
@@ -853,32 +827,28 @@ class InstanceTest(unittest.TestCase):
         self.assertDbEqual([dict(other_doc.to_mongo()), dict(doc.to_mongo())])
 
     def test_save(self):
-        """Ensure that a document may be saved in the database.
-        """
+        """Ensure that a document may be saved in the database."""
+
         # Create person object and save it to the database
         person = self.Person(name='Test User', age=30)
         person.save()
+
         # Ensure that the object is in the database
         collection = self.db[self.Person._get_collection_name()]
         person_obj = collection.find_one({'name': 'Test User'})
         self.assertEqual(person_obj['name'], 'Test User')
         self.assertEqual(person_obj['age'], 30)
         self.assertEqual(person_obj['_id'], person.id)
-        # Test skipping validation on save
 
+        # Test skipping validation on save
         class Recipient(Document):
             email = EmailField(required=True)
 
         recipient = Recipient(email='root@localhost')
         self.assertRaises(ValidationError, recipient.save)
-
-        try:
-            recipient.save(validate=False)
-        except ValidationError:
-            self.fail()
+        recipient.save(validate=False)
 
     def test_save_to_a_value_that_equates_to_false(self):
-
         class Thing(EmbeddedDocument):
             count = IntField()
 
@@ -898,7 +868,6 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(user.thing.count, 0)
 
     def test_save_max_recursion_not_hit(self):
-
         class Person(Document):
             name = StringField()
             parent = ReferenceField('self')
@@ -924,7 +893,6 @@ class InstanceTest(unittest.TestCase):
         p0.save()
 
     def test_save_max_recursion_not_hit_with_file_field(self):
-
         class Foo(Document):
             name = StringField()
             picture = FileField()
@@ -948,7 +916,6 @@ class InstanceTest(unittest.TestCase):
             self.assertEqual(b.picture, b.bar.picture, b.bar.bar.picture)
 
     def test_save_cascades(self):
-
         class Person(Document):
             name = StringField()
             parent = ReferenceField('self')
@@ -971,7 +938,6 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(p1.name, p.parent.name)
 
     def test_save_cascade_kwargs(self):
-
         class Person(Document):
             name = StringField()
             parent = ReferenceField('self')
@@ -992,7 +958,6 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(p1.name, p2.parent.name)
 
     def test_save_cascade_meta_false(self):
-
         class Person(Document):
             name = StringField()
             parent = ReferenceField('self')
@@ -1021,7 +986,6 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(p1.name, p.parent.name)
 
     def test_save_cascade_meta_true(self):
-
         class Person(Document):
             name = StringField()
             parent = ReferenceField('self')
@@ -1046,7 +1010,6 @@ class InstanceTest(unittest.TestCase):
         self.assertNotEqual(p1.name, p.parent.name)
 
     def test_save_cascades_generically(self):
-
         class Person(Document):
             name = StringField()
             parent = GenericReferenceField()
@@ -1072,7 +1035,6 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(p1.name, p.parent.name)
 
     def test_save_atomicity_condition(self):
-
         class Widget(Document):
             toggle = BooleanField(default=False)
             count = IntField(default=0)
@@ -1150,7 +1112,8 @@ class InstanceTest(unittest.TestCase):
 
     def test_update(self):
         """Ensure that an existing document is updated instead of be
-        overwritten."""
+        overwritten.
+        """
         # Create person object and save it to the database
         person = self.Person(name='Test User', age=30)
         person.save()
@@ -1254,7 +1217,6 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(2, self.Person.objects.count())
 
     def test_can_save_if_not_included(self):
-
         class EmbeddedDoc(EmbeddedDocument):
             pass
 
@@ -1341,10 +1303,7 @@ class InstanceTest(unittest.TestCase):
             doc2.update(set__name=doc1.name)
 
     def test_embedded_update(self):
-        """
-        Test update on `EmbeddedDocumentField` fields
-        """
-
+        """Test update on `EmbeddedDocumentField` fields."""
         class Page(EmbeddedDocument):
             log_message = StringField(verbose_name="Log message",
                                       required=True)
@@ -1365,11 +1324,9 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(site.page.log_message, "Error: Dummy message")
 
     def test_embedded_update_db_field(self):
+        """Test update on `EmbeddedDocumentField` fields when db_field
+        is other than default.
         """
-        Test update on `EmbeddedDocumentField` fields when db_field is other
-        than default.
-        """
-
         class Page(EmbeddedDocument):
             log_message = StringField(verbose_name="Log message",
                                       db_field="page_log_message",
@@ -1392,9 +1349,7 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(site.page.log_message, "Error: Dummy message")
 
     def test_save_only_changed_fields(self):
-        """Ensure save only sets / unsets changed fields
-        """
-
+        """Ensure save only sets / unsets changed fields."""
         class User(self.Person):
             active = BooleanField(default=True)
 
@@ -1514,8 +1469,8 @@ class InstanceTest(unittest.TestCase):
             self.assertEqual(q, 3)
 
     def test_set_unset_one_operation(self):
-        """Ensure that $set and $unset actions are performed in the same
-        operation.
+        """Ensure that $set and $unset actions are performed in the
+        same operation.
         """
         class FooBar(Document):
             foo = StringField(default=None)
@@ -1536,9 +1491,7 @@ class InstanceTest(unittest.TestCase):
             self.assertEqual(1, q)
 
     def test_save_only_changed_fields_recursive(self):
-        """Ensure save only sets / unsets changed fields
-        """
-
+        """Ensure save only sets / unsets changed fields."""
         class Comment(EmbeddedDocument):
             published = BooleanField(default=True)
 
@@ -1578,8 +1531,7 @@ class InstanceTest(unittest.TestCase):
         self.assertFalse(person.comments_dict['first_post'].published)
 
     def test_delete(self):
-        """Ensure that document may be deleted using the delete method.
-        """
+        """Ensure that document may be deleted using the delete method."""
         person = self.Person(name="Test User", age=30)
         person.save()
         self.assertEqual(self.Person.objects.count(), 1)
@@ -1587,33 +1539,34 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(self.Person.objects.count(), 0)
 
     def test_save_custom_id(self):
-        """Ensure that a document may be saved with a custom _id.
-        """
+        """Ensure that a document may be saved with a custom _id."""
+
         # Create person object and save it to the database
         person = self.Person(name='Test User', age=30,
                              id='497ce96f395f2f052a494fd4')
         person.save()
+
         # Ensure that the object is in the database with the correct _id
         collection = self.db[self.Person._get_collection_name()]
         person_obj = collection.find_one({'name': 'Test User'})
         self.assertEqual(str(person_obj['_id']), '497ce96f395f2f052a494fd4')
 
     def test_save_custom_pk(self):
-        """
-        Ensure that a document may be saved with a custom _id using pk alias.
+        """Ensure that a document may be saved with a custom _id using
+        pk alias.
         """
         # Create person object and save it to the database
         person = self.Person(name='Test User', age=30,
                              pk='497ce96f395f2f052a494fd4')
         person.save()
+
         # Ensure that the object is in the database with the correct _id
         collection = self.db[self.Person._get_collection_name()]
         person_obj = collection.find_one({'name': 'Test User'})
         self.assertEqual(str(person_obj['_id']), '497ce96f395f2f052a494fd4')
 
     def test_save_list(self):
-        """Ensure that a list field may be properly saved.
-        """
+        """Ensure that a list field may be properly saved."""
         class Comment(EmbeddedDocument):
             content = StringField()
 
@@ -1635,8 +1588,6 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(post_obj['tags'], tags)
         for comment_obj, comment in zip(post_obj['comments'], comments):
             self.assertEqual(comment_obj['content'], comment['content'])
-
-        BlogPost.drop_collection()
 
     def test_list_search_by_embedded(self):
         class User(Document):
@@ -1697,8 +1648,8 @@ class InstanceTest(unittest.TestCase):
             list(Page.objects.filter(comments__user=u3)))
 
     def test_save_embedded_document(self):
-        """Ensure that a document with an embedded document field may be
-        saved in the database.
+        """Ensure that a document with an embedded document field may
+        be saved in the database.
         """
         class EmployeeDetails(EmbeddedDocument):
             position = StringField()
@@ -1717,13 +1668,13 @@ class InstanceTest(unittest.TestCase):
         employee_obj = collection.find_one({'name': 'Test Employee'})
         self.assertEqual(employee_obj['name'], 'Test Employee')
         self.assertEqual(employee_obj['age'], 50)
+
         # Ensure that the 'details' embedded object saved correctly
         self.assertEqual(employee_obj['details']['position'], 'Developer')
 
     def test_embedded_update_after_save(self):
-        """
-        Test update of `EmbeddedDocumentField` attached to a newly saved
-        document.
+        """Test update of `EmbeddedDocumentField` attached to a newly
+        saved document.
         """
         class Page(EmbeddedDocument):
             log_message = StringField(verbose_name="Log message",
@@ -1744,8 +1695,8 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(site.page.log_message, "Error: Dummy message")
 
     def test_updating_an_embedded_document(self):
-        """Ensure that a document with an embedded document field may be
-        saved in the database.
+        """Ensure that a document with an embedded document field may
+        be saved in the database.
         """
         class EmployeeDetails(EmbeddedDocument):
             position = StringField()
@@ -1780,7 +1731,6 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(promoted_employee.details, None)
 
     def test_object_mixins(self):
-
         class NameMixin(object):
             name = StringField()
 
@@ -1819,9 +1769,9 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(t.count, 12)
 
     def test_save_reference(self):
-        """Ensure that a document reference field may be saved in the database.
+        """Ensure that a document reference field may be saved in the
+        database.
         """
-
         class BlogPost(Document):
             meta = {'collection': 'blogpost_1'}
             content = StringField()
@@ -1852,8 +1802,6 @@ class InstanceTest(unittest.TestCase):
         author = list(self.Person.objects(name='Test User'))[-1]
         self.assertEqual(author.age, 25)
 
-        BlogPost.drop_collection()
-
     def test_duplicate_db_fields_raise_invalid_document_error(self):
         """Ensure a InvalidDocumentError is thrown if duplicate fields
         declare the same db_field.
@@ -1864,7 +1812,7 @@ class InstanceTest(unittest.TestCase):
                 name2 = StringField(db_field='name')
 
     def test_invalid_son(self):
-        """Raise an error if loading invalid data"""
+        """Raise an error if loading invalid data."""
         class Occurrence(EmbeddedDocument):
             number = IntField()
 
@@ -1887,9 +1835,9 @@ class InstanceTest(unittest.TestCase):
             Word._from_son('this is not a valid SON dict')
 
     def test_reverse_delete_rule_cascade_and_nullify(self):
-        """Ensure that a referenced document is also deleted upon deletion.
+        """Ensure that a referenced document is also deleted upon
+        deletion.
         """
-
         class BlogPost(Document):
             content = StringField()
             author = ReferenceField(self.Person, reverse_delete_rule=CASCADE)
@@ -1944,7 +1892,8 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(Book.objects.count(), 0)
 
     def test_reverse_delete_rule_with_shared_id_among_collections(self):
-        """Ensure that cascade delete rule doesn't mix id among collections.
+        """Ensure that cascade delete rule doesn't mix id among
+        collections.
         """
         class User(Document):
             id = IntField(primary_key=True)
@@ -1975,10 +1924,9 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(Book.objects.get(), book_2)
 
     def test_reverse_delete_rule_with_document_inheritance(self):
-        """Ensure that a referenced document is also deleted upon deletion
-        of a child document.
+        """Ensure that a referenced document is also deleted upon
+        deletion of a child document.
         """
-
         class Writer(self.Person):
             pass
 
@@ -2010,10 +1958,9 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(BlogPost.objects.count(), 0)
 
     def test_reverse_delete_rule_cascade_and_nullify_complex_field(self):
-        """Ensure that a referenced document is also deleted upon deletion for
-        complex fields.
+        """Ensure that a referenced document is also deleted upon
+        deletion for complex fields.
         """
-
         class BlogPost(Document):
             content = StringField()
             authors = ListField(ReferenceField(
@@ -2022,7 +1969,6 @@ class InstanceTest(unittest.TestCase):
                 self.Person, reverse_delete_rule=NULLIFY))
 
         self.Person.drop_collection()
-
         BlogPost.drop_collection()
 
         author = self.Person(name='Test User')
@@ -2046,10 +1992,10 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(BlogPost.objects.count(), 0)
 
     def test_reverse_delete_rule_cascade_triggers_pre_delete_signal(self):
-        """ ensure the pre_delete signal is triggered upon a cascading deletion
-        setup a blog post with content, an author and editor
-        delete the author which triggers deletion of blogpost via cascade
-        blog post's pre_delete signal alters an editor attribute
+        """Ensure the pre_delete signal is triggered upon a cascading
+        deletion setup a blog post with content, an author and editor
+        delete the author which triggers deletion of blogpost via
+        cascade blog post's pre_delete signal alters an editor attribute.
         """
         class Editor(self.Person):
             review_queue = IntField(default=0)
@@ -2077,6 +2023,7 @@ class InstanceTest(unittest.TestCase):
 
         # delete the author, the post is also deleted due to the CASCADE rule
         author.delete()
+
         # the pre-delete signal should have decremented the editor's queue
         editor = Editor.objects(name='Max P.').get()
         self.assertEqual(editor.review_queue, 0)
@@ -2085,7 +2032,6 @@ class InstanceTest(unittest.TestCase):
         """Ensure that Bi-Directional relationships work with
         reverse_delete_rule
         """
-
         class Bar(Document):
             content = StringField()
             foo = ReferenceField('Foo')
@@ -2131,8 +2077,8 @@ class InstanceTest(unittest.TestCase):
                 mother = ReferenceField('Person', reverse_delete_rule=DENY)
 
     def test_reverse_delete_rule_cascade_recurs(self):
-        """Ensure that a chain of documents is also deleted upon cascaded
-        deletion.
+        """Ensure that a chain of documents is also deleted upon
+        cascaded deletion.
         """
         class BlogPost(Document):
             content = StringField()
@@ -2162,15 +2108,10 @@ class InstanceTest(unittest.TestCase):
         author.delete()
         self.assertEqual(Comment.objects.count(), 0)
 
-        self.Person.drop_collection()
-        BlogPost.drop_collection()
-        Comment.drop_collection()
-
     def test_reverse_delete_rule_deny(self):
-        """Ensure that a document cannot be referenced if there are still
-        documents referring to it.
+        """Ensure that a document cannot be referenced if there are
+        still documents referring to it.
         """
-
         class BlogPost(Document):
             content = StringField()
             author = ReferenceField(self.Person, reverse_delete_rule=DENY)
@@ -2198,11 +2139,7 @@ class InstanceTest(unittest.TestCase):
         author.delete()
         self.assertEqual(self.Person.objects.count(), 1)
 
-        self.Person.drop_collection()
-        BlogPost.drop_collection()
-
     def subclasses_and_unique_keys_works(self):
-
         class A(Document):
             pass
 
@@ -2218,12 +2155,9 @@ class InstanceTest(unittest.TestCase):
 
         self.assertEqual(A.objects.count(), 2)
         self.assertEqual(B.objects.count(), 1)
-        A.drop_collection()
-        B.drop_collection()
 
     def test_document_hash(self):
-        """Test document in list, dict, set
-        """
+        """Test document in list, dict, set."""
         class User(Document):
             pass
 
@@ -2266,11 +2200,9 @@ class InstanceTest(unittest.TestCase):
 
         # in Set
         all_user_set = set(User.objects.all())
-
         self.assertTrue(u1 in all_user_set)
 
     def test_picklable(self):
-
         pickle_doc = PickleTest(number=1, string="One", lists=['1', '2'])
         pickle_doc.embedded = PickleEmbedded()
         pickled_doc = pickle.dumps(pickle_doc)  # make sure pickling works even before the doc is saved
@@ -2296,7 +2228,6 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(pickle_doc.lists, ["1", "2", "3"])
 
     def test_regular_document_pickle(self):
-
         pickle_doc = PickleTest(number=1, string="One", lists=['1', '2'])
         pickled_doc = pickle.dumps(pickle_doc)  # make sure pickling works even before the doc is saved
         pickle_doc.save()
@@ -2319,7 +2250,6 @@ class InstanceTest(unittest.TestCase):
         fixtures.PickleTest = PickleTest
 
     def test_dynamic_document_pickle(self):
-
         pickle_doc = PickleDynamicTest(
             name="test", number=1, string="One", lists=['1', '2'])
         pickle_doc.embedded = PickleDynamicEmbedded(foo="Bar")
@@ -2358,7 +2288,6 @@ class InstanceTest(unittest.TestCase):
                 validate = DictField()
 
     def test_mutating_documents(self):
-
         class B(EmbeddedDocument):
             field1 = StringField(default='field1')
 
@@ -2366,6 +2295,7 @@ class InstanceTest(unittest.TestCase):
             b = EmbeddedDocumentField(B, default=lambda: B())
 
         A.drop_collection()
+
         a = A()
         a.save()
         a.reload()
@@ -2389,12 +2319,13 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(a.b.field2.c_field, 'new value')
 
     def test_can_save_false_values(self):
-        """Ensures you can save False values on save"""
+        """Ensures you can save False values on save."""
         class Doc(Document):
             foo = StringField()
             archived = BooleanField(default=False, required=True)
 
         Doc.drop_collection()
+
         d = Doc()
         d.save()
         d.archived = False
@@ -2403,11 +2334,12 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(Doc.objects(archived=False).count(), 1)
 
     def test_can_save_false_values_dynamic(self):
-        """Ensures you can save False values on dynamic docs"""
+        """Ensures you can save False values on dynamic docs."""
         class Doc(DynamicDocument):
             foo = StringField()
 
         Doc.drop_collection()
+
         d = Doc()
         d.save()
         d.archived = False
@@ -2447,7 +2379,7 @@ class InstanceTest(unittest.TestCase):
             Collection.update = orig_update
 
     def test_db_alias_tests(self):
-        """ DB Alias tests """
+        """DB Alias tests."""
         # mongoenginetest - Is default connection alias from setUp()
         # Register Aliases
         register_connection('testdb-1', 'mongoenginetest2')
@@ -2509,8 +2441,7 @@ class InstanceTest(unittest.TestCase):
             get_db("testdb-3")[AuthorBooks._get_collection_name()])
 
     def test_db_alias_overrides(self):
-        """db_alias can be overriden
-        """
+        """Test db_alias can be overriden."""
         # Register a connection with db_alias testdb-2
         register_connection('testdb-2', 'mongoenginetest2')
 
@@ -2534,8 +2465,7 @@ class InstanceTest(unittest.TestCase):
                          B._get_collection().database.name)
 
     def test_db_alias_propagates(self):
-        """db_alias propagates?
-        """
+        """db_alias propagates?"""
         register_connection('testdb-1', 'mongoenginetest2')
 
         class A(Document):
@@ -2548,8 +2478,7 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual('testdb-1', B._meta.get('db_alias'))
 
     def test_db_ref_usage(self):
-        """ DB Ref usage  in dict_fields"""
-
+        """DB Ref usage in dict_fields."""
         class User(Document):
             name = StringField()
 
@@ -2784,7 +2713,6 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(user.thing._data['data'], [1, 2, 3])
 
     def test_spaces_in_keys(self):
-
         class Embedded(DynamicEmbeddedDocument):
             pass
 
@@ -2873,7 +2801,6 @@ class InstanceTest(unittest.TestCase):
             log.machine = "127.0.0.1"
 
     def test_kwargs_simple(self):
-
         class Embedded(EmbeddedDocument):
             name = StringField()
 
@@ -2893,7 +2820,6 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(classic_doc._data, dict_doc._data)
 
     def test_kwargs_complex(self):
-
         class Embedded(EmbeddedDocument):
             name = StringField()
 
@@ -2916,36 +2842,35 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(classic_doc._data, dict_doc._data)
 
     def test_positional_creation(self):
-        """Ensure that document may be created using positional arguments.
-        """
+        """Ensure that document may be created using positional arguments."""
         person = self.Person("Test User", 42)
         self.assertEqual(person.name, "Test User")
         self.assertEqual(person.age, 42)
 
     def test_mixed_creation(self):
-        """Ensure that document may be created using mixed arguments.
-        """
+        """Ensure that document may be created using mixed arguments."""
         person = self.Person("Test User", age=42)
         self.assertEqual(person.name, "Test User")
         self.assertEqual(person.age, 42)
 
     def test_positional_creation_embedded(self):
-        """Ensure that embedded document may be created using positional arguments.
+        """Ensure that embedded document may be created using positional
+        arguments.
         """
         job = self.Job("Test Job", 4)
         self.assertEqual(job.name, "Test Job")
         self.assertEqual(job.years, 4)
 
     def test_mixed_creation_embedded(self):
-        """Ensure that embedded document may be created using mixed arguments.
+        """Ensure that embedded document may be created using mixed
+        arguments.
         """
         job = self.Job("Test Job", years=4)
         self.assertEqual(job.name, "Test Job")
         self.assertEqual(job.years, 4)
 
     def test_mixed_creation_dynamic(self):
-        """Ensure that document may be created using mixed arguments.
-        """
+        """Ensure that document may be created using mixed arguments."""
         class Person(DynamicDocument):
             name = StringField()
 
@@ -2954,14 +2879,14 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(person.age, 42)
 
     def test_bad_mixed_creation(self):
-        """Ensure that document gives correct error when duplicating arguments
+        """Ensure that document gives correct error when duplicating
+        arguments.
         """
         with self.assertRaises(TypeError):
             return self.Person("Test User", 42, name="Bad User")
 
     def test_data_contains_id_field(self):
-        """Ensure that asking for _data returns 'id'
-        """
+        """Ensure that asking for _data returns 'id'."""
         class Person(Document):
             name = StringField()
 
@@ -2973,7 +2898,6 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(person._data.get('id'), person.id)
 
     def test_complex_nesting_document_and_embedded_document(self):
-
         class Macro(EmbeddedDocument):
             value = DynamicField(default="UNDEFINED")
 
@@ -3016,7 +2940,6 @@ class InstanceTest(unittest.TestCase):
             system.nodes["node"].parameters["param"].macros["test"].value)
 
     def test_embedded_document_equality(self):
-
         class Test(Document):
             field = StringField(required=True)
 
@@ -3202,8 +3125,7 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(idx, 2)
 
     def test_falsey_pk(self):
-        """Ensure that we can create and update a document with Falsey PK.
-        """
+        """Ensure that we can create and update a document with Falsey PK."""
         class Person(Document):
             age = IntField(primary_key=True)
             height = FloatField()

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -1085,6 +1085,7 @@ class FieldTest(MongoDBTestCase):
 
         class BlogPost(Document):
             variable_list = ListField()
+            dynamic_list = ListField(DynamicField())
             embedded_list = EmbeddedDocumentListField(Comment)
             string_list = ListField(StringField())
             url_list = ListField(URLField())
@@ -1096,7 +1097,6 @@ class FieldTest(MongoDBTestCase):
             boolean_list = ListField(BooleanField())
             datetime_list = ListField(DateTimeField())
             complexdatetime_list = ListField(ComplexDateTimeField())
-            dynamic_list = ListField(DynamicField())
             sorted_list = SortedListField(StringField())
             dict_list = ListField(DictField())
             map_list = ListField(MapField(StringField()))
@@ -1123,12 +1123,24 @@ class FieldTest(MongoDBTestCase):
         post = BlogPost()
         post.save()
 
+
+
+
+        #
+        # variable list: ListField()
+        #
         post.variable_list = [1, "two", None, 4.5]
+        post.dynamic_list = [1, "two", None, 4.5]
         self.assertEqual(post.variable_list, [1, "two", None, 4.5])
+        self.assertEqual(post.dynamic_list, [1, "two", None, 4.5])
         post.save()
         post.reload()
         self.assertEqual(post.variable_list, [1, "two", None, 4.5])
+        self.assertEqual(post.dynamic_list, [1, "two", None, 4.5])
 
+        #
+        # embedded document list: EmbeddedDocumentListField()
+        #
         comment_one = Comment()
         comment_one.author = "Joe"
         comment_two = Comment()
@@ -1139,11 +1151,144 @@ class FieldTest(MongoDBTestCase):
         post.reload()
         self.assertEqual(post.embedded_list, [comment_one, None, comment_two])
 
+        #
+        # string list: ListField(StringField())
+        #
         post.string_list = ["one", "two", None, "four"]
         self.assertEqual(post.string_list, ["one", "two", None, "four"])
         post.save()
         post.reload()
         self.assertEqual(post.string_list, ["one", "two", None, "four"])
+
+        #
+        # URL list: ListField(URLField())
+        #
+        post.url_list = [None, "https://www.google.com"]
+        self.assertEqual(post.url_list, [None, "https://www.google.com"])
+        post.save()
+        post.reload()
+        self.assertEqual(post.url_list, [None, "https://www.google.com"])
+
+        #
+        # email list: ListField(EmailField())
+        #
+        post.email_list = [None, "jerry@example.com"]
+        self.assertEqual(post.email_list, [None, "jerry@example.com"])
+        post.save()
+        post.reload()
+        self.assertEqual(post.email_list, [None, "jerry@example.com"])
+
+        #
+        # integer list: ListField(IntField())
+        #
+        post.int_list = [4, None, -500]
+        self.assertEqual(post.x_list, [4, None, -500])
+        post.save()
+        post.reload()
+        self.assertEqual(post.x_list, [4, None, -500])
+
+        #
+        # long integer list: ListField(ListField())
+        #
+        post.long_list = [4, None, 999999999]
+        self.assertEqual(post.long_list, [4, None, 999999999])
+        post.save()
+        post.reload()
+        self.assertEqual(post.long_list, [4, None, 999999999])
+
+        #
+        # floating point number list: ListField(FloatField())
+        #
+        post.float_list = [4.25, None, -0.005]
+        self.assertEqual(post.float_list, [4.25, None, -0.005])
+        post.save()
+        post.reload()
+        self.assertEqual(post.float_list, [4.25, None, -0.005])
+
+        #
+        # decimal list: ListField(DecimalField())
+        # TODO:  check 'force_string' variant also
+        #
+        post.decimal_list = [Decimal("4.25"), None, Decimal("-0.005")]
+        self.assertEqual(post.decimal_list, [Decimal("4.25"), None, Decimal("-0.005")])
+        post.save()
+        post.reload()
+        self.assertEqual(post.decimal_list, [Decimal("4.25"), None, Decimal("-0.005")])
+
+        #
+        # boolean list: ListField(BooleanField())
+        #
+        post.boolean_list = [True, None, False]
+        self.assertEqual(post.boolean_list, [True, None, False])
+        post.save()
+        post.reload()
+        self.assertEqual(post.boolean_list, [True, None, False])
+
+        #
+        # datetime list: ListField(DateTimeField())
+        #
+        moment = datetime.datetime.now()
+        post.datetime_list = [None, moment]
+        self.assertEqual(post.datetime_list, [None, moment])
+        post.save()
+        post.reload()
+        self.assertEqual(post.datetime_list, [None, moment])
+
+        #
+        # complex datetime list: ListField(ComplexDateTimeField())
+        #
+        post.complex_datetime_list = [None, "2017,03,15,03,44,55,999001"]
+        self.assertEqual(post.complex_datetime_list, [None, "2017,03,15,03,44,55,999001"])
+        post.save()
+        post.reload()
+        self.assertEqual(post.complex_datetime_list, [None, "2017,03,15,03,44,55,999001"])
+
+        #
+        # sorted list: SortedListField(<any field>)
+        #
+        post.sorted_list = [6, 3, None, 2, 4]
+        self.assertEqual(post.sorted_list, [6, 3, None, 2, 4])
+        post.save()
+        post.reload()
+        self.assertEqual(post.sorted_list, [2, 3, 4, 6, None])
+
+        #
+        # dictionary list: ListField(DictField())
+        #
+        post.dict_list = [None, {"x": 3}]
+        self.assertEqual(post.dict_list, [None, {"x": 3}])
+        post.save()
+        post.reload()
+        self.assertEqual(post.dict_list, [None, {"x": 3}])
+
+        #
+        # map list: ListField(MapField(<any field>))
+        #
+        post.map_list = [None, {"x": "a", "y": "b"}]
+        self.assertEqual(post.map_list, [None, {"x": "a", "y": "b"}])
+        post.save()
+        post.reload()
+        self.assertEqual(post.map_list, [None, {"x": "a", "y": "b"}])
+
+        #
+        # binary number list: ListField(BinaryField())
+        #
+        BLOB = six.b('\xe6\x00\xc4\xff\x07')
+        post.binary_list = [None, BLOB]
+        self.assertEqual(post.binary_list, [None, BLOB])
+        post.save()
+        post.reload()
+        self.assertEqual(post.binary_list, [None, BLOB])
+
+        #
+        # Object Id list: ListField(ObjectIdField())
+        #
+        oid = ObjectId()
+        post.oid_list = [None, oid]
+        self.assertEqual(post.oid_list, [None, oid])
+        post.save()
+        post.reload()
+        self.assertEqual(post.oid_list, [None, oid])
 
   
     def test_list_field_manipulative_operators(self):

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -1077,6 +1077,75 @@ class FieldTest(MongoDBTestCase):
         post.save()
         self.assertEqual(BlogPost.objects(info=['1', '2', '3', '4', '1', '2', '3', '4']).count(), 1)
 
+    def test_list_field_null_support(self):
+        """Ensure that ListField supports None and 'null' entries.
+        """
+        class Comment(EmbeddedDocument):
+            author = StringField()
+
+        class BlogPost(Document):
+            variable_list = ListField()
+            embedded_list = EmbeddedDocumentListField(Comment)
+            string_list = ListField(StringField())
+            url_list = ListField(URLField())
+            email_list = ListField(EmailField())
+            int_list = ListField(IntField())
+            long_list = ListField(LongField())
+            float_list = ListField(FloatField())
+            decimal_list = ListField(DecimalField())
+            boolean_list = ListField(BooleanField())
+            datetime_list = ListField(DateTimeField())
+            complexdatetime_list = ListField(ComplexDateTimeField())
+            dynamic_list = ListField(DynamicField())
+            sorted_list = SortedListField(StringField())
+            dict_list = ListField(DictField())
+            map_list = ListField(MapField(StringField()))
+            binary_list = ListField(BinaryField())
+            oid_list = ListField(ObjectIdField())
+
+        # not covered:
+        #   ReferenceField
+        #   GenericReferenceField
+        #   CachedReferenceField
+        #   FileField
+        #   ImageField
+        #   SequenceField
+        #   GeoPointField
+        #   PointField
+        #   LineStringField
+        #   PolygonField
+        #   MultiPointField
+        #   MultiLineStringField
+        #   MultiPolygonField
+
+        BlogPost.drop_collection()
+
+        post = BlogPost()
+        post.save()
+
+        post.variable_list = [1, "two", None, 4.5]
+        self.assertEqual(post.variable_list, [1, "two", None, 4.5])
+        post.save()
+        post.reload()
+        self.assertEqual(post.variable_list, [1, "two", None, 4.5])
+
+        comment_one = Comment()
+        comment_one.author = "Joe"
+        comment_two = Comment()
+        comment_two.author = "Larry"
+        post.embedded_list = [comment_one, None, comment_two]
+        self.assertEqual(post.embedded_list, [comment_one, None, comment_two])
+        post.save()
+        post.reload()
+        self.assertEqual(post.embedded_list, [comment_one, None, comment_two])
+
+        post.string_list = ["one", "two", None, "four"]
+        self.assertEqual(post.string_list, ["one", "two", None, "four"])
+        post.save()
+        post.reload()
+        self.assertEqual(post.string_list, ["one", "two", None, "four"])
+
+  
     def test_list_field_manipulative_operators(self):
         """Ensure that ListField works with standard list operators that manipulate the list.
         """

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -341,10 +341,11 @@ class FieldTest(MongoDBTestCase):
         person.validate()
 
     def test_url_validation(self):
-        """Ensure that URLFields validate urls properly.
-        """
+        """Ensure that URLFields validate urls properly."""
         class Link(Document):
             url = URLField()
+
+        Link.drop_collection()
 
         link = Link()
         link.url = 'google'
@@ -352,6 +353,27 @@ class FieldTest(MongoDBTestCase):
 
         link.url = 'http://www.google.com:8080'
         link.validate()
+
+    def test_unicode_url_validation(self):
+        """Ensure unicode URLs are validated properly."""
+        class Link(Document):
+            url = URLField()
+
+        Link.drop_collection()
+
+        link = Link()
+        link.url = u'http://привет.com'
+
+        # TODO fix URL validation - this *IS* a valid URL
+        # For now we just want to make sure that the error message is correct
+        try:
+            link.validate()
+            self.assertTrue(False)
+        except ValidationError as e:
+            self.assertEqual(
+                unicode(e),
+                u"ValidationError (Link:None) (Invalid URL: http://\u043f\u0440\u0438\u0432\u0435\u0442.com: ['url'])"
+            )
 
     def test_url_scheme_validation(self):
         """Ensure that URLFields validate urls with specific schemes properly.

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -218,9 +218,9 @@ class FieldTest(MongoDBTestCase):
         self.assertTrue(isinstance(ret.comp_dt_fld, datetime.datetime))
 
     def test_not_required_handles_none_from_database(self):
-        """Ensure that every fields can handle null values from the database.
+        """Ensure that every field can handle null values from the
+        database.
         """
-
         class HandleNoneFields(Document):
             str_fld = StringField(required=True)
             int_fld = IntField(required=True)
@@ -4031,12 +4031,13 @@ class FieldTest(MongoDBTestCase):
         self.assertTrue(isinstance(doc.some_long, six.integer_types))
 
 
-class EmbeddedDocumentListFieldTestCase(unittest.TestCase):
+class EmbeddedDocumentListFieldTestCase(MongoDBTestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        cls.db = connect(db='EmbeddedDocumentListFieldTestCase')
-
+    def setUp(self):
+        """
+        Create two BlogPost entries in the database, each with
+        several EmbeddedDocuments.
+        """
         class Comments(EmbeddedDocument):
             author = StringField()
             message = StringField()
@@ -4044,14 +4045,11 @@ class EmbeddedDocumentListFieldTestCase(unittest.TestCase):
         class BlogPost(Document):
             comments = EmbeddedDocumentListField(Comments)
 
-        cls.Comments = Comments
-        cls.BlogPost = BlogPost
+        BlogPost.drop_collection()
 
-    def setUp(self):
-        """
-        Create two BlogPost entries in the database, each with
-        several EmbeddedDocuments.
-        """
+        self.Comments = Comments
+        self.BlogPost = BlogPost
+
         self.post1 = self.BlogPost(comments=[
             self.Comments(author='user1', message='message1'),
             self.Comments(author='user2', message='message1')
@@ -4062,13 +4060,6 @@ class EmbeddedDocumentListFieldTestCase(unittest.TestCase):
             self.Comments(author='user2', message='message3'),
             self.Comments(author='user3', message='message1')
         ]).save()
-
-    def tearDown(self):
-        self.BlogPost.drop_collection()
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.db.drop_database('EmbeddedDocumentListFieldTestCase')
 
     def test_no_keyword_filter(self):
         """
@@ -4436,11 +4427,11 @@ class EmbeddedDocumentListFieldTestCase(unittest.TestCase):
         class B(Document):
             my_list = ListField(EmbeddedDocumentField(EmbeddedWithSparseUnique))
 
-        B(my_list=[]).save()
-        B(my_list=[]).save()
-
         A.drop_collection()
         B.drop_collection()
+
+        B(my_list=[]).save()
+        B(my_list=[]).save()
 
     def test_filtered_delete(self):
         """
@@ -4477,6 +4468,8 @@ class EmbeddedDocumentListFieldTestCase(unittest.TestCase):
         class CustomData(Document):
             a_field = IntField()
             c_field = IntField(custom_data=custom_data)
+
+        CustomData.drop_collection()
 
         a1 = CustomData(a_field=1, c_field=2).save()
         self.assertEqual(2, a1.c_field)

--- a/tests/fields/file_tests.py
+++ b/tests/fields/file_tests.py
@@ -18,15 +18,13 @@ try:
 except ImportError:
     HAS_PIL = False
 
+from tests.utils import MongoDBTestCase
+
 TEST_IMAGE_PATH = os.path.join(os.path.dirname(__file__), 'mongoengine.png')
 TEST_IMAGE2_PATH = os.path.join(os.path.dirname(__file__), 'mongodb_leaf.png')
 
 
-class FileTest(unittest.TestCase):
-
-    def setUp(self):
-        connect(db='mongoenginetest')
-        self.db = get_db()
+class FileTest(MongoDBTestCase):
 
     def tearDown(self):
         self.db.drop_collection('fs.files')

--- a/tests/queryset/geo.py
+++ b/tests/queryset/geo.py
@@ -1,104 +1,138 @@
-from datetime import datetime, timedelta
+import datetime
 import unittest
 
-from pymongo.errors import OperationFailure
 from mongoengine import *
-from mongoengine.connection import get_connection
-from nose.plugins.skip import SkipTest
+
+from tests.utils import MongoDBTestCase, needs_mongodb_v3
 
 
 __all__ = ("GeoQueriesTest",)
 
 
-class GeoQueriesTest(unittest.TestCase):
+class GeoQueriesTest(MongoDBTestCase):
 
-    def setUp(self):
-        connect(db='mongoenginetest')
-
-    def test_geospatial_operators(self):
-        """Ensure that geospatial queries are working.
-        """
+    def _create_event_data(self, point_field_class=GeoPointField):
+        """Create some sample data re-used in many of the tests below."""
         class Event(Document):
             title = StringField()
             date = DateTimeField()
-            location = GeoPointField()
+            location = point_field_class()
 
             def __unicode__(self):
                 return self.title
 
+        self.Event = Event
+
         Event.drop_collection()
 
-        event1 = Event(title="Coltrane Motion @ Double Door",
-                       date=datetime.now() - timedelta(days=1),
-                       location=[-87.677137, 41.909889]).save()
-        event2 = Event(title="Coltrane Motion @ Bottom of the Hill",
-                       date=datetime.now() - timedelta(days=10),
-                       location=[-122.4194155, 37.7749295]).save()
-        event3 = Event(title="Coltrane Motion @ Empty Bottle",
-                       date=datetime.now(),
-                       location=[-87.686638, 41.900474]).save()
+        event1 = Event.objects.create(
+            title="Coltrane Motion @ Double Door",
+            date=datetime.datetime.now() - datetime.timedelta(days=1),
+            location=[-87.677137, 41.909889])
+        event2 = Event.objects.create(
+            title="Coltrane Motion @ Bottom of the Hill",
+            date=datetime.datetime.now() - datetime.timedelta(days=10),
+            location=[-122.4194155, 37.7749295])
+        event3 = Event.objects.create(
+            title="Coltrane Motion @ Empty Bottle",
+            date=datetime.datetime.now(),
+            location=[-87.686638, 41.900474])
+
+        return event1, event2, event3
+
+    def test_near(self):
+        """Make sure the "near" operator works."""
+        event1, event2, event3 = self._create_event_data()
 
         # find all events "near" pitchfork office, chicago.
         # note that "near" will show the san francisco event, too,
         # although it sorts to last.
-        events = Event.objects(location__near=[-87.67892, 41.9120459])
+        events = self.Event.objects(location__near=[-87.67892, 41.9120459])
         self.assertEqual(events.count(), 3)
         self.assertEqual(list(events), [event1, event3, event2])
 
+        # ensure ordering is respected by "near"
+        events = self.Event.objects(location__near=[-87.67892, 41.9120459])
+        events = events.order_by("-date")
+        self.assertEqual(events.count(), 3)
+        self.assertEqual(list(events), [event3, event1, event2])
+
+    def test_near_and_max_distance(self):
+        """Ensure the "max_distance" operator works alongside the "near"
+        operator.
+        """
+        event1, event2, event3 = self._create_event_data()
+
+        # find events within 10 degrees of san francisco
+        point = [-122.415579, 37.7566023]
+        events = self.Event.objects(location__near=point,
+                                    location__max_distance=10)
+        self.assertEqual(events.count(), 1)
+        self.assertEqual(events[0], event2)
+
+    # $minDistance was added in MongoDB v2.6, but continued being buggy
+    # until v3.0; skip for older versions
+    @needs_mongodb_v3
+    def test_near_and_min_distance(self):
+        """Ensure the "min_distance" operator works alongside the "near"
+        operator.
+        """
+        event1, event2, event3 = self._create_event_data()
+
+        # find events at least 10 degrees away of san francisco
+        point = [-122.415579, 37.7566023]
+        events = self.Event.objects(location__near=point,
+                                    location__min_distance=10)
+        self.assertEqual(events.count(), 2)
+
+    def test_within_distance(self):
+        """Make sure the "within_distance" operator works."""
+        event1, event2, event3 = self._create_event_data()
+
         # find events within 5 degrees of pitchfork office, chicago
         point_and_distance = [[-87.67892, 41.9120459], 5]
-        events = Event.objects(location__within_distance=point_and_distance)
+        events = self.Event.objects(
+            location__within_distance=point_and_distance)
         self.assertEqual(events.count(), 2)
         events = list(events)
         self.assertTrue(event2 not in events)
         self.assertTrue(event1 in events)
         self.assertTrue(event3 in events)
 
-        # ensure ordering is respected by "near"
-        events = Event.objects(location__near=[-87.67892, 41.9120459])
-        events = events.order_by("-date")
-        self.assertEqual(events.count(), 3)
-        self.assertEqual(list(events), [event3, event1, event2])
-
-        # find events within 10 degrees of san francisco
-        point = [-122.415579, 37.7566023]
-        events = Event.objects(location__near=point, location__max_distance=10)
-        self.assertEqual(events.count(), 1)
-        self.assertEqual(events[0], event2)
-
-        # find events at least 10 degrees away of san francisco
-        point = [-122.415579, 37.7566023]
-        events = Event.objects(location__near=point, location__min_distance=10)
-        # The following real test passes on MongoDB 3 but minDistance seems
-        # buggy on older MongoDB versions
-        if get_connection().server_info()['versionArray'][0] > 2:
-            self.assertEqual(events.count(), 2)
-        else:
-            self.assertTrue(events.count() >= 2)
-
         # find events within 10 degrees of san francisco
         point_and_distance = [[-122.415579, 37.7566023], 10]
-        events = Event.objects(location__within_distance=point_and_distance)
+        events = self.Event.objects(
+            location__within_distance=point_and_distance)
         self.assertEqual(events.count(), 1)
         self.assertEqual(events[0], event2)
 
         # find events within 1 degree of greenpoint, broolyn, nyc, ny
         point_and_distance = [[-73.9509714, 40.7237134], 1]
-        events = Event.objects(location__within_distance=point_and_distance)
+        events = self.Event.objects(
+            location__within_distance=point_and_distance)
         self.assertEqual(events.count(), 0)
 
         # ensure ordering is respected by "within_distance"
         point_and_distance = [[-87.67892, 41.9120459], 10]
-        events = Event.objects(location__within_distance=point_and_distance)
+        events = self.Event.objects(
+            location__within_distance=point_and_distance)
         events = events.order_by("-date")
         self.assertEqual(events.count(), 2)
         self.assertEqual(events[0], event3)
 
+    def test_within_box(self):
+        """Ensure the "within_box" operator works."""
+        event1, event2, event3 = self._create_event_data()
+
         # check that within_box works
         box = [(-125.0, 35.0), (-100.0, 40.0)]
-        events = Event.objects(location__within_box=box)
+        events = self.Event.objects(location__within_box=box)
         self.assertEqual(events.count(), 1)
         self.assertEqual(events[0].id, event2.id)
+
+    def test_within_polygon(self):
+        """Ensure the "within_polygon" operator works."""
+        event1, event2, event3 = self._create_event_data()
 
         polygon = [
             (-87.694445, 41.912114),
@@ -107,7 +141,7 @@ class GeoQueriesTest(unittest.TestCase):
             (-87.654276, 41.911731),
             (-87.656164, 41.898061),
         ]
-        events = Event.objects(location__within_polygon=polygon)
+        events = self.Event.objects(location__within_polygon=polygon)
         self.assertEqual(events.count(), 1)
         self.assertEqual(events[0].id, event1.id)
 
@@ -116,13 +150,151 @@ class GeoQueriesTest(unittest.TestCase):
             (-1.225891, 52.792797),
             (-4.40094, 53.389881)
         ]
-        events = Event.objects(location__within_polygon=polygon2)
+        events = self.Event.objects(location__within_polygon=polygon2)
         self.assertEqual(events.count(), 0)
 
-    def test_geo_spatial_embedded(self):
+    def test_2dsphere_near(self):
+        """Make sure the "near" operator works with a PointField, which
+        corresponds to a 2dsphere index.
+        """
+        event1, event2, event3 = self._create_event_data(
+            point_field_class=PointField
+        )
 
+        # find all events "near" pitchfork office, chicago.
+        # note that "near" will show the san francisco event, too,
+        # although it sorts to last.
+        events = self.Event.objects(location__near=[-87.67892, 41.9120459])
+        self.assertEqual(events.count(), 3)
+        self.assertEqual(list(events), [event1, event3, event2])
+
+        # ensure ordering is respected by "near"
+        events = self.Event.objects(location__near=[-87.67892, 41.9120459])
+        events = events.order_by("-date")
+        self.assertEqual(events.count(), 3)
+        self.assertEqual(list(events), [event3, event1, event2])
+
+    def test_2dsphere_near_and_max_distance(self):
+        """Ensure the "max_distance" operator works alongside the "near"
+        operator with a 2dsphere index.
+        """
+        event1, event2, event3 = self._create_event_data(
+            point_field_class=PointField
+        )
+
+        # find events within 10km of san francisco
+        point = [-122.415579, 37.7566023]
+        events = self.Event.objects(location__near=point,
+                                    location__max_distance=10000)
+        self.assertEqual(events.count(), 1)
+        self.assertEqual(events[0], event2)
+
+        # find events within 1km of greenpoint, broolyn, nyc, ny
+        events = self.Event.objects(location__near=[-73.9509714, 40.7237134],
+                                    location__max_distance=1000)
+        self.assertEqual(events.count(), 0)
+
+        # ensure ordering is respected by "near"
+        events = self.Event.objects(
+            location__near=[-87.67892, 41.9120459],
+            location__max_distance=10000
+        ).order_by("-date")
+        self.assertEqual(events.count(), 2)
+        self.assertEqual(events[0], event3)
+
+    def test_2dsphere_geo_within_box(self):
+        """Ensure the "geo_within_box" operator works with a 2dsphere
+        index.
+        """
+        event1, event2, event3 = self._create_event_data(
+            point_field_class=PointField
+        )
+
+        # check that within_box works
+        box = [(-125.0, 35.0), (-100.0, 40.0)]
+        events = self.Event.objects(location__geo_within_box=box)
+        self.assertEqual(events.count(), 1)
+        self.assertEqual(events[0].id, event2.id)
+
+    def test_2dsphere_geo_within_polygon(self):
+        """Ensure the "geo_within_polygon" operator works with a
+        2dsphere index.
+        """
+        event1, event2, event3 = self._create_event_data(
+            point_field_class=PointField
+        )
+
+        polygon = [
+            (-87.694445, 41.912114),
+            (-87.69084, 41.919395),
+            (-87.681742, 41.927186),
+            (-87.654276, 41.911731),
+            (-87.656164, 41.898061),
+        ]
+        events = self.Event.objects(location__geo_within_polygon=polygon)
+        self.assertEqual(events.count(), 1)
+        self.assertEqual(events[0].id, event1.id)
+
+        polygon2 = [
+            (-1.742249, 54.033586),
+            (-1.225891, 52.792797),
+            (-4.40094, 53.389881)
+        ]
+        events = self.Event.objects(location__geo_within_polygon=polygon2)
+        self.assertEqual(events.count(), 0)
+
+    # $minDistance was added in MongoDB v2.6, but continued being buggy
+    # until v3.0; skip for older versions
+    @needs_mongodb_v3
+    def test_2dsphere_near_and_min_max_distance(self):
+        """Ensure "min_distace" and "max_distance" operators work well
+        together with the "near" operator in a 2dsphere index.
+        """
+        event1, event2, event3 = self._create_event_data(
+            point_field_class=PointField
+        )
+
+        # ensure min_distance and max_distance combine well
+        events = self.Event.objects(
+            location__near=[-87.67892, 41.9120459],
+            location__min_distance=1000,
+            location__max_distance=10000
+        ).order_by("-date")
+        self.assertEqual(events.count(), 1)
+        self.assertEqual(events[0], event3)
+
+        # ensure ordering is respected by "near" with "min_distance"
+        events = self.Event.objects(
+            location__near=[-87.67892, 41.9120459],
+            location__min_distance=10000
+        ).order_by("-date")
+        self.assertEqual(events.count(), 1)
+        self.assertEqual(events[0], event2)
+
+    def test_2dsphere_geo_within_center(self):
+        """Make sure the "geo_within_center" operator works with a
+        2dsphere index.
+        """
+        event1, event2, event3 = self._create_event_data(
+            point_field_class=PointField
+        )
+
+        # find events within 5 degrees of pitchfork office, chicago
+        point_and_distance = [[-87.67892, 41.9120459], 2]
+        events = self.Event.objects(
+            location__geo_within_center=point_and_distance)
+        self.assertEqual(events.count(), 2)
+        events = list(events)
+        self.assertTrue(event2 not in events)
+        self.assertTrue(event1 in events)
+        self.assertTrue(event3 in events)
+
+    def _test_embedded(self, point_field_class):
+        """Helper test method ensuring given point field class works
+        well in an embedded document.
+        """
         class Venue(EmbeddedDocument):
-            location = GeoPointField()
+            location = point_field_class()
             name = StringField()
 
         class Event(Document):
@@ -148,16 +320,18 @@ class GeoQueriesTest(unittest.TestCase):
         self.assertEqual(events.count(), 3)
         self.assertEqual(list(events), [event1, event3, event2])
 
-    def test_spherical_geospatial_operators(self):
-        """Ensure that spherical geospatial queries are working
-        """
-        # Needs MongoDB > 2.6.4 https://jira.mongodb.org/browse/SERVER-14039
-        connection = get_connection()
-        info = connection.test.command('buildInfo')
-        mongodb_version = tuple([int(i) for i in info['version'].split('.')])
-        if mongodb_version < (2, 6, 4):
-            raise SkipTest("Need MongoDB version 2.6.4+")
+    def test_geo_spatial_embedded(self):
+        """Make sure GeoPointField works properly in an embedded document."""
+        self._test_embedded(point_field_class=GeoPointField)
 
+    def test_2dsphere_point_embedded(self):
+        """Make sure PointField works properly in an embedded document."""
+        self._test_embedded(point_field_class=PointField)
+
+    # Needs MongoDB > 2.6.4 https://jira.mongodb.org/browse/SERVER-14039
+    @needs_mongodb_v3
+    def test_spherical_geospatial_operators(self):
+        """Ensure that spherical geospatial queries are working."""
         class Point(Document):
             location = GeoPointField()
 
@@ -177,7 +351,10 @@ class GeoQueriesTest(unittest.TestCase):
 
         # Same behavior for _within_spherical_distance
         points = Point.objects(
-            location__within_spherical_distance=[[-122, 37.5], 60 / earth_radius]
+            location__within_spherical_distance=[
+                [-122, 37.5],
+                60 / earth_radius
+            ]
         )
         self.assertEqual(points.count(), 2)
 
@@ -194,14 +371,9 @@ class GeoQueriesTest(unittest.TestCase):
         # Test query works with min_distance, being farer from one point
         points = Point.objects(location__near_sphere=[-122, 37.8],
                                location__min_distance=60 / earth_radius)
-        # The following real test passes on MongoDB 3 but minDistance seems
-        # buggy on older MongoDB versions
-        if get_connection().server_info()['versionArray'][0] > 2:
-            self.assertEqual(points.count(), 1)
-            far_point = points.first()
-            self.assertNotEqual(close_point, far_point)
-        else:
-            self.assertTrue(points.count() >= 1)
+        self.assertEqual(points.count(), 1)
+        far_point = points.first()
+        self.assertNotEqual(close_point, far_point)
 
         # Finds both points, but orders the north point first because it's
         # closer to the reference point to the north.
@@ -220,141 +392,15 @@ class GeoQueriesTest(unittest.TestCase):
         # Finds only one point because only the first point is within 60km of
         # the reference point to the south.
         points = Point.objects(
-            location__within_spherical_distance=[[-122, 36.5], 60/earth_radius])
+            location__within_spherical_distance=[
+                [-122, 36.5],
+                60 / earth_radius
+            ]
+        )
         self.assertEqual(points.count(), 1)
         self.assertEqual(points[0].id, south_point.id)
 
-    def test_2dsphere_point(self):
-
-        class Event(Document):
-            title = StringField()
-            date = DateTimeField()
-            location = PointField()
-
-            def __unicode__(self):
-                return self.title
-
-        Event.drop_collection()
-
-        event1 = Event(title="Coltrane Motion @ Double Door",
-                       date=datetime.now() - timedelta(days=1),
-                       location=[-87.677137, 41.909889])
-        event1.save()
-        event2 = Event(title="Coltrane Motion @ Bottom of the Hill",
-                       date=datetime.now() - timedelta(days=10),
-                       location=[-122.4194155, 37.7749295]).save()
-        event3 = Event(title="Coltrane Motion @ Empty Bottle",
-                       date=datetime.now(),
-                       location=[-87.686638, 41.900474]).save()
-
-        # find all events "near" pitchfork office, chicago.
-        # note that "near" will show the san francisco event, too,
-        # although it sorts to last.
-        events = Event.objects(location__near=[-87.67892, 41.9120459])
-        self.assertEqual(events.count(), 3)
-        self.assertEqual(list(events), [event1, event3, event2])
-
-        # find events within 5 degrees of pitchfork office, chicago
-        point_and_distance = [[-87.67892, 41.9120459], 2]
-        events = Event.objects(location__geo_within_center=point_and_distance)
-        self.assertEqual(events.count(), 2)
-        events = list(events)
-        self.assertTrue(event2 not in events)
-        self.assertTrue(event1 in events)
-        self.assertTrue(event3 in events)
-
-        # ensure ordering is respected by "near"
-        events = Event.objects(location__near=[-87.67892, 41.9120459])
-        events = events.order_by("-date")
-        self.assertEqual(events.count(), 3)
-        self.assertEqual(list(events), [event3, event1, event2])
-
-        # find events within 10km of san francisco
-        point = [-122.415579, 37.7566023]
-        events = Event.objects(location__near=point, location__max_distance=10000)
-        self.assertEqual(events.count(), 1)
-        self.assertEqual(events[0], event2)
-
-        # find events within 1km of greenpoint, broolyn, nyc, ny
-        events = Event.objects(location__near=[-73.9509714, 40.7237134], location__max_distance=1000)
-        self.assertEqual(events.count(), 0)
-
-        # ensure ordering is respected by "near"
-        events = Event.objects(location__near=[-87.67892, 41.9120459],
-                               location__max_distance=10000).order_by("-date")
-        self.assertEqual(events.count(), 2)
-        self.assertEqual(events[0], event3)
-
-        # ensure min_distance and max_distance combine well
-        events = Event.objects(location__near=[-87.67892, 41.9120459],
-                               location__min_distance=1000,
-                               location__max_distance=10000).order_by("-date")
-        self.assertEqual(events.count(), 1)
-        self.assertEqual(events[0], event3)
-
-        # ensure ordering is respected by "near"
-        events = Event.objects(location__near=[-87.67892, 41.9120459],
-                               # location__min_distance=10000
-                               location__min_distance=10000).order_by("-date")
-        self.assertEqual(events.count(), 1)
-        self.assertEqual(events[0], event2)
-
-        # check that within_box works
-        box = [(-125.0, 35.0), (-100.0, 40.0)]
-        events = Event.objects(location__geo_within_box=box)
-        self.assertEqual(events.count(), 1)
-        self.assertEqual(events[0].id, event2.id)
-
-        polygon = [
-            (-87.694445, 41.912114),
-            (-87.69084, 41.919395),
-            (-87.681742, 41.927186),
-            (-87.654276, 41.911731),
-            (-87.656164, 41.898061),
-        ]
-        events = Event.objects(location__geo_within_polygon=polygon)
-        self.assertEqual(events.count(), 1)
-        self.assertEqual(events[0].id, event1.id)
-
-        polygon2 = [
-            (-1.742249, 54.033586),
-            (-1.225891, 52.792797),
-            (-4.40094, 53.389881)
-        ]
-        events = Event.objects(location__geo_within_polygon=polygon2)
-        self.assertEqual(events.count(), 0)
-
-    def test_2dsphere_point_embedded(self):
-
-        class Venue(EmbeddedDocument):
-            location = GeoPointField()
-            name = StringField()
-
-        class Event(Document):
-            title = StringField()
-            venue = EmbeddedDocumentField(Venue)
-
-        Event.drop_collection()
-
-        venue1 = Venue(name="The Rock", location=[-87.677137, 41.909889])
-        venue2 = Venue(name="The Bridge", location=[-122.4194155, 37.7749295])
-
-        event1 = Event(title="Coltrane Motion @ Double Door",
-                       venue=venue1).save()
-        event2 = Event(title="Coltrane Motion @ Bottom of the Hill",
-                       venue=venue2).save()
-        event3 = Event(title="Coltrane Motion @ Empty Bottle",
-                       venue=venue1).save()
-
-        # find all events "near" pitchfork office, chicago.
-        # note that "near" will show the san francisco event, too,
-        # although it sorts to last.
-        events = Event.objects(venue__location__near=[-87.67892, 41.9120459])
-        self.assertEqual(events.count(), 3)
-        self.assertEqual(list(events), [event1, event3, event2])
-
     def test_linestring(self):
-
         class Road(Document):
             name = StringField()
             line = LineStringField()
@@ -410,7 +456,6 @@ class GeoQueriesTest(unittest.TestCase):
         self.assertEqual(1, roads)
 
     def test_polygon(self):
-
         class Road(Document):
             name = StringField()
             poly = PolygonField()
@@ -506,6 +551,7 @@ class GeoQueriesTest(unittest.TestCase):
         Location.objects.update(set__poly=[[[40, 4], [40, 6], [41, 6], [40, 4]]])
         loc = Location.objects.as_pymongo()[0]
         self.assertEqual(loc["poly"], {"type": "Polygon", "coordinates": [[[40, 4], [40, 6], [41, 6], [40, 4]]]})
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -106,58 +106,111 @@ class QuerySetTest(unittest.TestCase):
             list(BlogPost.objects(author2__name="test"))
 
     def test_find(self):
-        """Ensure that a query returns a valid set of results.
-        """
-        self.Person(name="User A", age=20).save()
-        self.Person(name="User B", age=30).save()
+        """Ensure that a query returns a valid set of results."""
+        user_a = self.Person.objects.create(name='User A', age=20)
+        user_b = self.Person.objects.create(name='User B', age=30)
 
         # Find all people in the collection
         people = self.Person.objects
         self.assertEqual(people.count(), 2)
         results = list(people)
+
         self.assertTrue(isinstance(results[0], self.Person))
         self.assertTrue(isinstance(results[0].id, (ObjectId, str, unicode)))
-        self.assertEqual(results[0].name, "User A")
+
+        self.assertEqual(results[0], user_a)
+        self.assertEqual(results[0].name, 'User A')
         self.assertEqual(results[0].age, 20)
-        self.assertEqual(results[1].name, "User B")
+
+        self.assertEqual(results[1], user_b)
+        self.assertEqual(results[1].name, 'User B')
         self.assertEqual(results[1].age, 30)
 
-        # Use a query to filter the people found to just person1
+        # Filter people by age
         people = self.Person.objects(age=20)
         self.assertEqual(people.count(), 1)
         person = people.next()
+        self.assertEqual(person, user_a)
         self.assertEqual(person.name, "User A")
         self.assertEqual(person.age, 20)
 
-        # Test limit
+    def test_limit(self):
+        """Ensure that QuerySet.limit works as expected."""
+        user_a = self.Person.objects.create(name='User A', age=20)
+        user_b = self.Person.objects.create(name='User B', age=30)
+
+        # Test limit on a new queryset
         people = list(self.Person.objects.limit(1))
         self.assertEqual(len(people), 1)
-        self.assertEqual(people[0].name, 'User A')
+        self.assertEqual(people[0], user_a)
 
-        # Test skip
+        # Test limit on an existing queryset
+        people = self.Person.objects
+        self.assertEqual(len(people), 2)
+        people2 = people.limit(1)
+        self.assertEqual(len(people), 2)
+        self.assertEqual(len(people2), 1)
+        self.assertEqual(people2[0], user_a)
+
+        # Test chaining of only after limit
+        person = self.Person.objects().limit(1).only('name').first()
+        self.assertEqual(person, user_a)
+        self.assertEqual(person.name, 'User A')
+        self.assertEqual(person.age, None)
+
+    def test_skip(self):
+        """Ensure that QuerySet.skip works as expected."""
+        user_a = self.Person.objects.create(name='User A', age=20)
+        user_b = self.Person.objects.create(name='User B', age=30)
+
+        # Test skip on a new queryset
         people = list(self.Person.objects.skip(1))
         self.assertEqual(len(people), 1)
-        self.assertEqual(people[0].name, 'User B')
+        self.assertEqual(people[0], user_b)
 
-        person3 = self.Person(name="User C", age=40)
-        person3.save()
+        # Test skip on an existing queryset
+        people = self.Person.objects
+        self.assertEqual(len(people), 2)
+        people2 = people.skip(1)
+        self.assertEqual(len(people), 2)
+        self.assertEqual(len(people2), 1)
+        self.assertEqual(people2[0], user_b)
+
+        # Test chaining of only after skip
+        person = self.Person.objects().skip(1).only('name').first()
+        self.assertEqual(person, user_b)
+        self.assertEqual(person.name, 'User B')
+        self.assertEqual(person.age, None)
+
+    def test_slice(self):
+        """Ensure slicing a queryset works as expected."""
+        user_a = self.Person.objects.create(name='User A', age=20)
+        user_b = self.Person.objects.create(name='User B', age=30)
+        user_c = self.Person.objects.create(name="User C", age=40)
 
         # Test slice limit
         people = list(self.Person.objects[:2])
         self.assertEqual(len(people), 2)
-        self.assertEqual(people[0].name, 'User A')
-        self.assertEqual(people[1].name, 'User B')
+        self.assertEqual(people[0], user_a)
+        self.assertEqual(people[1], user_b)
 
         # Test slice skip
         people = list(self.Person.objects[1:])
         self.assertEqual(len(people), 2)
-        self.assertEqual(people[0].name, 'User B')
-        self.assertEqual(people[1].name, 'User C')
+        self.assertEqual(people[0], user_b)
+        self.assertEqual(people[1], user_c)
 
         # Test slice limit and skip
         people = list(self.Person.objects[1:2])
         self.assertEqual(len(people), 1)
-        self.assertEqual(people[0].name, 'User B')
+        self.assertEqual(people[0], user_b)
+
+        # Test slice limit and skip on an existing queryset
+        people = self.Person.objects
+        self.assertEqual(len(people), 3)
+        people2 = people[1:2]
+        self.assertEqual(len(people2), 1)
+        self.assertEqual(people2[0], user_b)
 
         # Test slice limit and skip cursor reset
         qs = self.Person.objects[1:2]
@@ -168,6 +221,7 @@ class QuerySetTest(unittest.TestCase):
         self.assertEqual(len(people), 1)
         self.assertEqual(people[0].name, 'User B')
 
+        # Test empty slice
         people = list(self.Person.objects[1:1])
         self.assertEqual(len(people), 0)
 
@@ -186,12 +240,6 @@ class QuerySetTest(unittest.TestCase):
                          "%s" % self.Person.objects[1:3])
         self.assertEqual("[<Person: Person object>, <Person: Person object>]",
                          "%s" % self.Person.objects[51:53])
-
-        # Test only after limit
-        self.assertEqual(self.Person.objects().limit(2).only('name')[0].age, None)
-
-        # Test only after skip
-        self.assertEqual(self.Person.objects().skip(2).only('name')[0].age, None)
 
     def test_find_one(self):
         """Ensure that a query using find_one returns a valid result.
@@ -1226,6 +1274,7 @@ class QuerySetTest(unittest.TestCase):
 
         BlogPost.drop_collection()
 
+        # default ordering should be used by default
         with db_ops_tracker() as q:
             BlogPost.objects.filter(title='whatever').first()
             self.assertEqual(len(q.get_ops()), 1)
@@ -1234,8 +1283,25 @@ class QuerySetTest(unittest.TestCase):
                 {'published_date': -1}
             )
 
+        # calling order_by() should clear the default ordering
         with db_ops_tracker() as q:
             BlogPost.objects.filter(title='whatever').order_by().first()
+            self.assertEqual(len(q.get_ops()), 1)
+            self.assertFalse('$orderby' in q.get_ops()[0]['query'])
+
+        # calling an explicit order_by should use a specified sort
+        with db_ops_tracker() as q:
+            BlogPost.objects.filter(title='whatever').order_by('published_date').first()
+            self.assertEqual(len(q.get_ops()), 1)
+            self.assertEqual(
+                q.get_ops()[0]['query']['$orderby'],
+                {'published_date': 1}
+            )
+
+        # calling order_by() after an explicit sort should clear it
+        with db_ops_tracker() as q:
+            qs = BlogPost.objects.filter(title='whatever').order_by('published_date')
+            qs.order_by().first()
             self.assertEqual(len(q.get_ops()), 1)
             self.assertFalse('$orderby' in q.get_ops()[0]['query'])
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -285,8 +285,7 @@ class ConnectionTest(unittest.TestCase):
         self.assertTrue(isinstance(conn, pymongo.mongo_client.MongoClient))
 
     def test_connection_kwargs(self):
-        """Ensure that connection kwargs get passed to pymongo.
-        """
+        """Ensure that connection kwargs get passed to pymongo."""
         connect('mongoenginetest', alias='t1', tz_aware=True)
         conn = get_connection('t1')
 
@@ -295,6 +294,32 @@ class ConnectionTest(unittest.TestCase):
         connect('mongoenginetest2', alias='t2')
         conn = get_connection('t2')
         self.assertFalse(get_tz_awareness(conn))
+
+    def test_connection_pool_via_kwarg(self):
+        """Ensure we can specify a max connection pool size using
+        a connection kwarg.
+        """
+        # Use "max_pool_size" or "maxpoolsize" depending on PyMongo version
+        # (former was changed to the latter as described in
+        # https://jira.mongodb.org/browse/PYTHON-854).
+        # TODO remove once PyMongo < 3.0 support is dropped
+        if pymongo.version_tuple[0] >= 3:
+            pool_size_kwargs = {'maxpoolsize': 100}
+        else:
+            pool_size_kwargs = {'max_pool_size': 100}
+
+        conn = connect('mongoenginetest', alias='max_pool_size_via_kwarg', **pool_size_kwargs)
+        self.assertEqual(conn.max_pool_size, 100)
+
+    def test_connection_pool_via_uri(self):
+        """Ensure we can specify a max connection pool size using
+        an option in a connection URI.
+        """
+        if pymongo.version_tuple[0] == 2 and pymongo.version_tuple[1] < 9:
+            raise SkipTest('maxpoolsize as a URI option is only supported in PyMongo v2.9+')
+
+        conn = connect(host='mongodb://localhost/test?maxpoolsize=100', alias='max_pool_size_via_uri')
+        self.assertEqual(conn.max_pool_size, 100)
 
     def test_write_concern(self):
         """Ensure write concern can be specified in connect() via

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -35,8 +35,7 @@ class ConnectionTest(unittest.TestCase):
         mongoengine.connection._dbs = {}
 
     def test_connect(self):
-        """Ensure that the connect() method works properly.
-        """
+        """Ensure that the connect() method works properly."""
         connect('mongoenginetest')
 
         conn = get_connection()
@@ -146,8 +145,7 @@ class ConnectionTest(unittest.TestCase):
         self.assertEqual(expected_connection, actual_connection)
 
     def test_connect_uri(self):
-        """Ensure that the connect() method works properly with uri's
-        """
+        """Ensure that the connect() method works properly with URIs."""
         c = connect(db='mongoenginetest', alias='admin')
         c.admin.system.users.remove({})
         c.mongoenginetest.system.users.remove({})
@@ -227,9 +225,8 @@ class ConnectionTest(unittest.TestCase):
         self.assertRaises(OperationFailure, get_db)
 
     def test_connect_uri_with_authsource(self):
-        """Ensure that the connect() method works well with
-        the option `authSource` in URI.
-        This feature was introduced in MongoDB 2.4 and removed in 2.6
+        """Ensure that the connect() method works well with `authSource`
+        option in the URI.
         """
         # Create users
         c = connect('mongoenginetest')
@@ -238,30 +235,31 @@ class ConnectionTest(unittest.TestCase):
 
         # Authentication fails without "authSource"
         if IS_PYMONGO_3:
-            test_conn = connect('mongoenginetest', alias='test1',
-                                host='mongodb://username2:password@localhost/mongoenginetest')
+            test_conn = connect(
+                'mongoenginetest', alias='test1',
+                host='mongodb://username2:password@localhost/mongoenginetest'
+            )
             self.assertRaises(OperationFailure, test_conn.server_info)
         else:
             self.assertRaises(
-                MongoEngineConnectionError, connect, 'mongoenginetest',
-                alias='test1',
+                MongoEngineConnectionError,
+                connect, 'mongoenginetest', alias='test1',
                 host='mongodb://username2:password@localhost/mongoenginetest'
             )
             self.assertRaises(MongoEngineConnectionError, get_db, 'test1')
 
         # Authentication succeeds with "authSource"
-        connect(
+        authd_conn = connect(
             'mongoenginetest', alias='test2',
             host=('mongodb://username2:password@localhost/'
                   'mongoenginetest?authSource=admin')
         )
-        # This will fail starting from MongoDB 2.6+
         db = get_db('test2')
         self.assertTrue(isinstance(db, pymongo.database.Database))
         self.assertEqual(db.name, 'mongoenginetest')
 
         # Clear all users
-        c.admin.system.users.remove({})
+        authd_conn.admin.system.users.remove({})
 
     def test_register_connection(self):
         """Ensure that connections with different aliases may be registered.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,22 @@
+import unittest
+
+from mongoengine import connect
+from mongoengine.connection import get_db
+
+MONGO_TEST_DB = 'mongoenginetest'
+
+
+class MongoDBTestCase(unittest.TestCase):
+    """Base class for tests that need a mongodb connection
+    db is being dropped automatically
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls._connection = connect(db=MONGO_TEST_DB)
+        cls._connection.drop_database(MONGO_TEST_DB)
+        cls.db = get_db()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._connection.drop_database(MONGO_TEST_DB)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,11 @@
 import unittest
 
+from nose.plugins.skip import SkipTest
+
 from mongoengine import connect
-from mongoengine.connection import get_db
+from mongoengine.connection import get_db, get_connection
+from mongoengine.python_support import IS_PYMONGO_3
+
 
 MONGO_TEST_DB = 'mongoenginetest'
 
@@ -20,3 +24,55 @@ class MongoDBTestCase(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls._connection.drop_database(MONGO_TEST_DB)
+
+
+def get_mongodb_version():
+    """Return the version tuple of the MongoDB server that the default
+    connection is connected to.
+    """
+    return tuple(get_connection().server_info()['versionArray'])
+
+def _decorated_with_ver_requirement(func, ver_tuple):
+    """Return a given function decorated with the version requirement
+    for a particular MongoDB version tuple.
+    """
+    def _inner(*args, **kwargs):
+        mongodb_ver = get_mongodb_version()
+        if mongodb_ver >= ver_tuple:
+            return func(*args, **kwargs)
+
+        raise SkipTest('Needs MongoDB v{}+'.format(
+            '.'.join([str(v) for v in ver_tuple])
+        ))
+
+    _inner.__name__ = func.__name__
+    _inner.__doc__ = func.__doc__
+
+    return _inner
+
+def needs_mongodb_v26(func):
+    """Raise a SkipTest exception if we're working with MongoDB version
+    lower than v2.6.
+    """
+    return _decorated_with_ver_requirement(func, (2, 6))
+
+def needs_mongodb_v3(func):
+    """Raise a SkipTest exception if we're working with MongoDB version
+    lower than v3.0.
+    """
+    return _decorated_with_ver_requirement(func, (3, 0))
+
+def skip_pymongo3(f):
+    """Raise a SkipTest exception if we're running a test against
+    PyMongo v3.x.
+    """
+    def _inner(*args, **kwargs):
+        if IS_PYMONGO_3:
+            raise SkipTest("Useless with PyMongo 3+")
+        return f(*args, **kwargs)
+
+    _inner.__name__ = f.__name__
+    _inner.__doc__ = f.__doc__
+
+    return _inner
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py26,py27,py33,py34,py35,pypy,pypy3}-{mg27,mg28},flake8
+envlist = {py27,py35,pypy,pypy3}-{mg27,mg28,mg30}
 
 [testenv]
 commands =
@@ -7,16 +7,7 @@ commands =
 deps =
     nose
     mg27: PyMongo<2.8
-    mg28: PyMongo>=2.8,<3.0
+    mg28: PyMongo>=2.8,<2.9
     mg30: PyMongo>=3.0
-    mgdev: https://github.com/mongodb/mongo-python-driver/tarball/master
 setenv =
     PYTHON_EGG_CACHE = {envdir}/python-eggs
-passenv = windir
-
-[testenv:flake8]
-deps =
-    flake8
-    flake8-import-order
-commands =
-   flake8


### PR DESCRIPTION
Adding support for `null` entries within a `ListField` or an `EmbeddedDocumentListField`; which will be seen as a pythonic `None`. For that matter, any field should support `null` unless it is marked with a `required=True` keyword argument.