### PR TITLE
Fixed docs regarding reverse_delete_rule and delete signals

### DIFF
--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -361,11 +361,6 @@ Its value can take any of the following constants:
    In Django, be sure to put all apps that have such delete rule declarations in
    their :file:`models.py` in the :const:`INSTALLED_APPS` tuple.
 
-
-.. warning::
-   Signals are not triggered when doing cascading updates / deletes - if this
-   is required you must manually handle the update / delete.
-
 Generic reference fields
 ''''''''''''''''''''''''
 A second kind of reference field also exists,

--- a/docs/guide/signals.rst
+++ b/docs/guide/signals.rst
@@ -142,11 +142,4 @@ cleaner looking while still allowing manual execution of the callback::
         modified = DateTimeField()
 
 
-ReferenceFields and Signals
----------------------------
-
-Currently `reverse_delete_rule` does not trigger signals on the other part of
-the relationship.  If this is required you must manually handle the
-reverse deletion.
-
 .. _blinker: http://pypi.python.org/pypi/blinker

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -888,10 +888,6 @@ class ReferenceField(BaseField):
 
         Foo.register_delete_rule(Bar, 'foo', NULLIFY)
 
-    .. note ::
-        `reverse_delete_rule` does not trigger pre / post delete signals to be
-        triggered.
-
     .. versionchanged:: 0.5 added `reverse_delete_rule`
     """
 


### PR DESCRIPTION
Removed obsolete documentation, ever since #105, the `post_delete`, `pre_delete` signals get triggered, even when `reverse_delete_rule` deletes records. Or am i missing something here?

There's even a test which tests exactly for this behaviour, which also was introduced in #105.