### PR TITLE
Fix cursor management

### DIFF
--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -759,7 +759,10 @@ class BaseQuerySet(object):
         queryset = self.clone()
         queryset._limit = n if n != 0 else 1
 
-        # Return the new queryset to allow chaining
+        # If a cursor object has already been created, apply the limit to it.
+        if queryset._cursor_obj:
+            queryset._cursor_obj.limit(queryset._limit)
+
         return queryset
 
     def skip(self, n):
@@ -770,6 +773,11 @@ class BaseQuerySet(object):
         """
         queryset = self.clone()
         queryset._skip = n
+
+        # If a cursor object has already been created, apply the skip to it.
+        if queryset._cursor_obj:
+            queryset._cursor_obj.skip(queryset._skip)
+
         return queryset
 
     def hint(self, index=None):
@@ -787,6 +795,11 @@ class BaseQuerySet(object):
         """
         queryset = self.clone()
         queryset._hint = index
+
+        # If a cursor object has already been created, apply the hint to it.
+        if queryset._cursor_obj:
+            queryset._cursor_obj.hint(queryset._hint)
+
         return queryset
 
     def batch_size(self, size):
@@ -800,6 +813,11 @@ class BaseQuerySet(object):
         """
         queryset = self.clone()
         queryset._batch_size = size
+
+        # If a cursor object has already been created, apply the batch size to it.
+        if queryset._cursor_obj:
+            queryset._cursor_obj.batch_size(queryset._batch_size)
+
         return queryset
 
     def distinct(self, field):

--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -86,6 +86,7 @@ class BaseQuerySet(object):
         self._batch_size = None
         self.only_fields = []
         self._max_time_ms = None
+        self._comment = None
 
     def __call__(self, q_obj=None, class_check=True, read_preference=None,
                  **query):
@@ -726,7 +727,7 @@ class BaseQuerySet(object):
                       '_timeout', '_class_check', '_slave_okay', '_read_preference',
                       '_iter', '_scalar', '_as_pymongo', '_as_pymongo_coerce',
                       '_limit', '_skip', '_hint', '_auto_dereference',
-                      '_search_text', 'only_fields', '_max_time_ms')
+                      '_search_text', 'only_fields', '_max_time_ms', '_comment')
 
         for prop in copy_props:
             val = getattr(self, prop)
@@ -1817,10 +1818,21 @@ class BaseQuerySet(object):
         return code
 
     def _chainable_method(self, method_name, val):
+        """Call a particular method on the PyMongo cursor call a particular chainable method
+        with the provided value.
+        """
         queryset = self.clone()
-        method = getattr(queryset._cursor, method_name)
-        method(val)
+
+        # Get an existing cursor object or create a new one
+        cursor = queryset._cursor
+
+        # Find the requested method on the cursor and call it with the
+        # provided value
+        method = getattr(cursor, method_name)(val)
+
+        # Cache the value on the queryset._{method_name}
         setattr(queryset, '_' + method_name, val)
+
         return queryset
 
     # Deprecated

--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -1745,7 +1745,6 @@ class BaseQuerySet(object):
                     raise err
         return ret
 
-
     def _get_order_by(self, keys):
         """Given a list of MongoEngine-style sort keys, return a list
         of sorting tuples that can be applied to a PyMongo cursor. For
@@ -1886,7 +1885,7 @@ class BaseQuerySet(object):
 
         # Find the requested method on the cursor and call it with the
         # provided value
-        method = getattr(cursor, method_name)(val)
+        getattr(cursor, method_name)(val)
 
         # Cache the value on the queryset._{method_name}
         setattr(queryset, '_' + method_name, val)

--- a/mongoengine/queryset/queryset.py
+++ b/mongoengine/queryset/queryset.py
@@ -136,13 +136,15 @@ class QuerySet(BaseQuerySet):
         return self._len
 
     def no_cache(self):
-        """Convert to a non_caching queryset
+        """Convert to a non-caching queryset
 
         .. versionadded:: 0.8.3 Convert to non caching queryset
         """
         if self._result_cache is not None:
             raise OperationError('QuerySet already cached')
-        return self.clone_into(QuerySetNoCache(self._document, self._collection))
+
+        return self._clone_into(QuerySetNoCache(self._document,
+                                                self._collection))
 
 
 class QuerySetNoCache(BaseQuerySet):
@@ -153,7 +155,7 @@ class QuerySetNoCache(BaseQuerySet):
 
         .. versionadded:: 0.8.3 Convert to caching queryset
         """
-        return self.clone_into(QuerySet(self._document, self._collection))
+        return self._clone_into(QuerySet(self._document, self._collection))
 
     def __repr__(self):
         """Provides the string representation of the QuerySet

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -171,8 +171,9 @@ class QuerySetTest(unittest.TestCase):
         # Test slice limit and skip on an existing queryset
         people = self.Person.objects
         self.assertEqual(len(people), 3)
-        self.assertEqual(people[1:2], 1)
-        self.assertEqual(people[0].name, 'User B')
+        people2 = people[1:2]
+        self.assertEqual(len(people2), 1)
+        self.assertEqual(people2[0].name, 'User B')
 
         # Test slice limit and skip cursor reset
         qs = self.Person.objects[1:2]

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -106,8 +106,7 @@ class QuerySetTest(unittest.TestCase):
             list(BlogPost.objects(author2__name="test"))
 
     def test_find(self):
-        """Ensure that a query returns a valid set of results.
-        """
+        """Ensure that a query returns a valid set of results."""
         self.Person(name="User A", age=20).save()
         self.Person(name="User B", age=30).save()
 
@@ -134,10 +133,20 @@ class QuerySetTest(unittest.TestCase):
         self.assertEqual(len(people), 1)
         self.assertEqual(people[0].name, 'User A')
 
+        # Test limit on an existing queryset
+        people = self.Person.objects
+        self.assertEqual(len(people), 2)
+        self.assertEqual(len(people.limit(1)), 1)
+
         # Test skip
         people = list(self.Person.objects.skip(1))
         self.assertEqual(len(people), 1)
         self.assertEqual(people[0].name, 'User B')
+
+        # Test skip on an existing queryset
+        people = self.Person.objects
+        self.assertEqual(len(people), 2)
+        self.assertEqual(len(people.skip(1)), 1)
 
         person3 = self.Person(name="User C", age=40)
         person3.save()
@@ -159,6 +168,12 @@ class QuerySetTest(unittest.TestCase):
         self.assertEqual(len(people), 1)
         self.assertEqual(people[0].name, 'User B')
 
+        # Test slice limit and skip on an existing queryset
+        people = self.Person.objects
+        self.assertEqual(len(people), 3)
+        self.assertEqual(people[1:2], 1)
+        self.assertEqual(people[0].name, 'User B')
+
         # Test slice limit and skip cursor reset
         qs = self.Person.objects[1:2]
         # fetch then delete the cursor
@@ -168,6 +183,7 @@ class QuerySetTest(unittest.TestCase):
         self.assertEqual(len(people), 1)
         self.assertEqual(people[0].name, 'User B')
 
+        # Test empty slice
         people = list(self.Person.objects[1:1])
         self.assertEqual(len(people), 0)
 


### PR DESCRIPTION
Fixes #1469 #1475 and reverses an invalid "fix" from #1049 

Main changes:
* `BaseQuerySet.limit/skip/hint/batch_size` are now chained properly.
* `BaseQuerySet.order_by` now allows clearing a previously specified ordering (not just the default ordering as it used to).
* Public `BaseQuerySet.clone_into` method has been renamed to a private `_clone_into` (shouldn't have been public in the first place).
* `BaseQuerySet._get_order_by` method doesn't manipulate the cursor anymore (that was a poorly designed separation of concerns).