### PR TITLE
Issue #1472 - duplication in primary key (_id) raising an exception now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ tests/test_bugfix.py
 htmlcov/
 venv
 venv3
+scratchpad

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -394,7 +394,10 @@ class Document(BaseDocument):
         if force_insert:
             return collection.insert(doc, **write_concern)
 
-        object_id = collection.save(doc, **write_concern)
+        #object_id = collection.save(doc, **write_concern)
+        # instead of using SAVE as in previous line, which has been deprecated in pymongo:
+        result = collection.insert_one(doc)
+        object_id = result.inserted_id
 
         # In PyMongo 3.0, the save() call calls internally the _update() call
         # but they forget to return the _id value passed back, therefore getting it back here

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -394,10 +394,7 @@ class Document(BaseDocument):
         if force_insert:
             return collection.insert(doc, **write_concern)
 
-        #object_id = collection.save(doc, **write_concern)
-        # instead of using SAVE as in previous line, which has been deprecated in pymongo:
-        result = collection.insert_one(doc)
-        object_id = result.inserted_id
+        object_id = collection.save(doc, **write_concern)
 
         # In PyMongo 3.0, the save() call calls internally the _update() call
         # but they forget to return the _id value passed back, therefore getting it back here

--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -286,7 +286,7 @@ class BaseQuerySet(object):
 
         .. versionadded:: 0.4
         """
-        return self._document(**kwargs).save()
+        return self._document(**kwargs).save(force_insert=True)
 
     def first(self):
         """Retrieve the first object matching the query."""

--- a/tests/document/indexes.py
+++ b/tests/document/indexes.py
@@ -792,6 +792,27 @@ class IndexesTest(unittest.TestCase):
 
         User.drop_collection()
 
+    def test_unique_and_primary_create(self):
+        """Create a new record with a duplicate primary key
+        throws an exception
+        """
+
+        class User(Document):
+            name = StringField(primary_key=True)
+            password = StringField()
+
+        User.drop_collection()
+
+        User.objects.create(name='huangz', password='secret')
+        def duplicate_primary_key():
+            User.objects.create(name='huangz', password='secret2')
+        self.assertRaises(NotUniqueError, duplicate_primary_key)
+
+        self.assertEqual(User.objects.count(), 1)
+        self.assertEqual(User.objects.get().password, 'secret')
+
+        User.drop_collection()
+
     def test_index_with_pk(self):
         """Ensure you can use `pk` as part of a query"""
 

--- a/tests/document/indexes.py
+++ b/tests/document/indexes.py
@@ -412,7 +412,6 @@ class IndexesTest(unittest.TestCase):
         User.ensure_indexes()
         info = User.objects._collection.index_information()
         self.assertEqual(sorted(info.keys()), ['_cls_1_user_guid_1', '_id_'])
-        User.drop_collection()
 
     def test_embedded_document_index(self):
         """Tests settings an index on an embedded document
@@ -434,7 +433,6 @@ class IndexesTest(unittest.TestCase):
 
         info = BlogPost.objects._collection.index_information()
         self.assertEqual(sorted(info.keys()), ['_id_', 'date.yr_-1'])
-        BlogPost.drop_collection()
 
     def test_list_embedded_document_index(self):
         """Ensure list embedded documents can be indexed
@@ -461,7 +459,6 @@ class IndexesTest(unittest.TestCase):
         post1 = BlogPost(title="Embedded Indexes tests in place",
                          tags=[Tag(name="about"), Tag(name="time")])
         post1.save()
-        BlogPost.drop_collection()
 
     def test_recursive_embedded_objects_dont_break_indexes(self):
 
@@ -623,8 +620,6 @@ class IndexesTest(unittest.TestCase):
         post3 = BlogPost(title='test3', date=Date(year=2010), slug='test')
         self.assertRaises(OperationError, post3.save)
 
-        BlogPost.drop_collection()
-
     def test_unique_embedded_document(self):
         """Ensure that uniqueness constraints are applied to fields on embedded documents.
         """
@@ -651,8 +646,6 @@ class IndexesTest(unittest.TestCase):
         post3 = BlogPost(title='test3',
                          sub=SubDocument(year=2010, slug='test'))
         self.assertRaises(NotUniqueError, post3.save)
-
-        BlogPost.drop_collection()
 
     def test_unique_embedded_document_in_list(self):
         """
@@ -683,8 +676,6 @@ class IndexesTest(unittest.TestCase):
         )
 
         self.assertRaises(NotUniqueError, post2.save)
-
-        BlogPost.drop_collection()
 
     def test_unique_with_embedded_document_and_embedded_unique(self):
         """Ensure that uniqueness constraints are applied to fields on
@@ -718,8 +709,6 @@ class IndexesTest(unittest.TestCase):
         post3 = BlogPost(title='test1',
                          sub=SubDocument(year=2009, slug='test-1'))
         self.assertRaises(NotUniqueError, post3.save)
-
-        BlogPost.drop_collection()
 
     def test_ttl_indexes(self):
 
@@ -768,13 +757,11 @@ class IndexesTest(unittest.TestCase):
             raise AssertionError("We saved a dupe!")
         except NotUniqueError:
             pass
-        Customer.drop_collection()
 
     def test_unique_and_primary(self):
         """If you set a field as primary, then unexpected behaviour can occur.
         You won't create a duplicate but you will update an existing document.
         """
-
         class User(Document):
             name = StringField(primary_key=True, unique=True)
             password = StringField()
@@ -790,13 +777,10 @@ class IndexesTest(unittest.TestCase):
         self.assertEqual(User.objects.count(), 1)
         self.assertEqual(User.objects.get().password, 'secret2')
 
-        User.drop_collection()
-
     def test_unique_and_primary_create(self):
         """Create a new record with a duplicate primary key
         throws an exception
         """
-
         class User(Document):
             name = StringField(primary_key=True)
             password = StringField()
@@ -804,14 +788,11 @@ class IndexesTest(unittest.TestCase):
         User.drop_collection()
 
         User.objects.create(name='huangz', password='secret')
-        def duplicate_primary_key():
+        with self.assertRaises(NotUniqueError):
             User.objects.create(name='huangz', password='secret2')
-        self.assertRaises(NotUniqueError, duplicate_primary_key)
 
         self.assertEqual(User.objects.count(), 1)
         self.assertEqual(User.objects.get().password, 'secret')
-
-        User.drop_collection()
 
     def test_index_with_pk(self):
         """Ensure you can use `pk` as part of a query"""


### PR DESCRIPTION
The SAVE function of pymongo has been deprecated.
It does not raise an exception in case of duplication in value of _id, because in this case it treats the operation as UPDATE and not INSERT, and practically, does not do anything - not really duplicates the document, but also does not raise an exception
I stopped using SAVE and started using INSERT_ONCE instead, as recommended by pymongo