### PR TITLE
Fix the exception message when validating unicode URLs

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -139,12 +139,12 @@ class URLField(StringField):
         # Check first if the scheme is valid
         scheme = value.split('://')[0].lower()
         if scheme not in self.schemes:
-            self.error('Invalid scheme {} in URL: {}'.format(scheme, value))
+            self.error(u'Invalid scheme {} in URL: {}'.format(scheme, value))
             return
 
         # Then check full URL
         if not self.url_regex.match(value):
-            self.error('Invalid URL: {}'.format(value))
+            self.error(u'Invalid URL: {}'.format(value))
             return
 
 

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -341,15 +341,30 @@ class FieldTest(MongoDBTestCase):
         person.validate()
 
     def test_url_validation(self):
-        """Ensure that URLFields validate urls properly.
-        """
+        """Ensure that URLFields validate urls properly."""
         class Link(Document):
             url = URLField()
+
+        Link.drop_collection()
+
+        link = Link()
+        link.url = 'google'
+        self.assertRaises(ValidationError, link.validate)
+
+        link.url = 'http://www.google.com:8080'
+        link.validate()
+
+    def test_unicode_url_validation(self):
+        """Ensure unicode URLs are validated properly."""
+        class Link(Document):
+            url = URLField()
+
+        Link.drop_collection()
 
         link = Link()
         link.url = u'http://привет.com'
 
-        # TODO fix URL validation - this IS a valid URL
+        # TODO fix URL validation - this *IS* a valid URL
         # For now we just want to make sure that the error message is correct
         try:
             link.validate()
@@ -359,18 +374,6 @@ class FieldTest(MongoDBTestCase):
                 unicode(e),
                 u"ValidationError (Link:None) (Invalid URL: http://\u043f\u0440\u0438\u0432\u0435\u0442.com: ['url'])"
             )
-
-    def test_unicode_url_validation(self):
-        """Ensure unicode URLs are validated properly."""
-        class Link(Document):
-            url = URLField()
-
-        link = Link()
-        link.url = 'google'
-        self.assertRaises(ValidationError, link.validate)
-
-        link.url = 'http://www.google.com:8080'
-        link.validate()
 
     def test_url_scheme_validation(self):
         """Ensure that URLFields validate urls with specific schemes properly.

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -347,6 +347,25 @@ class FieldTest(MongoDBTestCase):
             url = URLField()
 
         link = Link()
+        link.url = u'http://привет.com'
+
+        # TODO fix URL validation - this IS a valid URL
+        # For now we just want to make sure that the error message is correct
+        try:
+            link.validate()
+            self.assertTrue(False)
+        except ValidationError as e:
+            self.assertEqual(
+                unicode(e),
+                u"ValidationError (Link:None) (Invalid URL: http://\u043f\u0440\u0438\u0432\u0435\u0442.com: ['url'])"
+            )
+
+    def test_unicode_url_validation(self):
+        """Ensure unicode URLs are validated properly."""
+        class Link(Document):
+            url = URLField()
+
+        link = Link()
         link.url = 'google'
         self.assertRaises(ValidationError, link.validate)
 


### PR DESCRIPTION
Prior to this PR, formatting the exception message would fail:
```
In [1]: from mongoengine.fields import URLField

In [2]: URLField().validate(u'http://привет.com')
---------------------------------------------------------------------------
UnicodeEncodeError                        Traceback (most recent call last)
<ipython-input-2-023c2c193da6> in <module>()
----> 1 URLField().validate(u'http://привет.com')

/Users/wojcikstefan/Repos/temp/mongoengine/mongoengine/fields.py in validate(self, value)
    145         # Then check full URL
    146         if not self.url_regex.match(value):
--> 147             self.error('Invalid URL: {}'.format(value))
    148             return
    149

UnicodeEncodeError: 'ascii' codec can't encode characters in position 7-12: ordinal not in range(128)
```