### PR TITLE
added a feature to save and load object data in order

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -6,6 +6,7 @@ import time
 import uuid
 import warnings
 from operator import itemgetter
+from collections import OrderedDict
 
 from bson import Binary, DBRef, ObjectId, SON
 import gridfs
@@ -49,7 +50,7 @@ __all__ = (
     'FileField', 'ImageGridFsProxy', 'ImproperlyConfigured', 'ImageField',
     'GeoPointField', 'PointField', 'LineStringField', 'PolygonField',
     'SequenceField', 'UUIDField', 'MultiPointField', 'MultiLineStringField',
-    'MultiPolygonField', 'GeoJsonBaseField'
+    'MultiPolygonField', 'GeoJsonBaseField', 'OrderedDynamicField'
 )
 
 RECURSIVE_REFERENCE_CONSTANT = 'self'
@@ -644,7 +645,7 @@ class DynamicField(BaseField):
             is_list = True
             value = {k: v for k, v in enumerate(value)}
 
-        data = {}
+        data = self._container_type() if hasattr(self, '_container_type') else {}
         for k, v in value.iteritems():
             data[k] = self.to_mongo(v, use_db_field, fields)
 
@@ -673,6 +674,16 @@ class DynamicField(BaseField):
     def validate(self, value, clean=True):
         if hasattr(value, 'validate'):
             value.validate(clean=clean)
+
+
+class OrderedDynamicField(DynamicField):
+    """A field that wraps DynamicField. This uses OrderedDict class
+    to guarantee to store data in the defined order instead of dict.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(OrderedDynamicField, self).__init__(*args, **kwargs)
+        self._container_type = OrderedDict
 
 
 class ListField(ComplexBaseField):

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -7,6 +7,7 @@ import itertools
 import re
 
 from nose.plugins.skip import SkipTest
+from collections import OrderedDict
 import six
 
 try:
@@ -4498,6 +4499,40 @@ class EmbeddedDocumentListFieldTestCase(MongoDBTestCase):
         self.assertFalse(hasattr(a1.c_field, 'custom_data'))
         self.assertTrue(hasattr(CustomData.c_field, 'custom_data'))
         self.assertEqual(custom_data['a'], CustomData.c_field.custom_data['a'])
+
+    def test_ordered_dynamic_fields_class(self):
+        """
+        Tests that OrderedDynamicFields interits features of the DynamicFields
+        and saves/retrieves data in order.
+        """
+        class Member(Document):
+            name = StringField()
+            age = IntField()
+
+        class Team(OrderedDocument):
+            members = OrderedDynamicField()
+
+        Member.drop_collection()
+        Team.drop_collection()
+
+        member_info = [
+            ('Martin McFly', 17),
+            ('Emmett Brown', 65),
+            ('George McFly', 47)
+        ]
+        members = OrderedDict()
+        for name, age in member_info:
+            members[name] = Member(name=name, age=age)
+            members[name].save()
+
+        Team(members=members).save()
+
+        index = 0
+        team = Team.objects.get()
+        for member in team.members:
+            print("%s == %s" % (member, member_info[index][0]))
+            self.assertEqual(member, member_info[index][0])
+            index += 1
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I added a feature to save and load object data in order for #203.

Previously, the saved object data is handled by the Dictionary type implicitly. This causes unordered data store.
And data load processing also decodes BSON object to the Dictionary type.

This patch guarantees data to be saved and loaded in the order.

Thank you.