### PR TITLE
added a feature to save and load object data in order

### DIFF
--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -1,6 +1,7 @@
 import re
 import warnings
 
+from collections import OrderedDict
 from bson.dbref import DBRef
 import pymongo
 from pymongo.read_preferences import ReadPreference
@@ -21,7 +22,8 @@ from mongoengine.queryset import (NotUniqueError, OperationError,
 
 __all__ = ('Document', 'EmbeddedDocument', 'DynamicDocument',
            'DynamicEmbeddedDocument', 'OperationError',
-           'InvalidCollectionError', 'NotUniqueError', 'MapReduceDocument')
+           'InvalidCollectionError', 'NotUniqueError', 'MapReduceDocument',
+           'OrderedDocument')
 
 
 def includes_cls(fields):
@@ -1036,3 +1038,27 @@ class MapReduceDocument(object):
             self._key_object = self._document.objects.with_id(self.key)
             return self._key_object
         return self._key_object
+
+
+class OrderedDocument(Document):
+    """A document that is almost same with Document except for returning
+    results in OrderedDict instead of dict.
+    """
+
+    # The __metaclass__ attribute is removed by 2to3 when running with Python3
+    # my_metaclass is defined so that metaclass can be queried in Python 2 & 3
+    my_metaclass = TopLevelDocumentMetaclass
+    __metaclass__ = TopLevelDocumentMetaclass
+
+    @classmethod
+    def _get_collection(cls):
+        collection = super(OrderedDocument, cls)._get_collection()
+
+        if IS_PYMONGO_3:
+            # returns collection object which is set OrderedDict class to be decoded from BSON document
+            from bson import CodecOptions
+            return collection.with_options(codec_options=CodecOptions(document_class=OrderedDict))
+        else:
+            # set attribute to specify the class to be decoeded
+            cls.decoded_class = OrderedDict
+            return collection

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -22,8 +22,7 @@ from mongoengine.queryset import (NotUniqueError, OperationError,
 
 __all__ = ('Document', 'EmbeddedDocument', 'DynamicDocument',
            'DynamicEmbeddedDocument', 'OperationError',
-           'InvalidCollectionError', 'NotUniqueError', 'MapReduceDocument',
-           'OrderedDocument')
+           'InvalidCollectionError', 'NotUniqueError', 'MapReduceDocument')
 
 
 def includes_cls(fields):
@@ -1038,27 +1037,3 @@ class MapReduceDocument(object):
             self._key_object = self._document.objects.with_id(self.key)
             return self._key_object
         return self._key_object
-
-
-class OrderedDocument(Document):
-    """A document that is almost same with Document except for returning
-    results in OrderedDict instead of dict.
-    """
-
-    # The __metaclass__ attribute is removed by 2to3 when running with Python3
-    # my_metaclass is defined so that metaclass can be queried in Python 2 & 3
-    my_metaclass = TopLevelDocumentMetaclass
-    __metaclass__ = TopLevelDocumentMetaclass
-
-    @classmethod
-    def _get_collection(cls):
-        collection = super(OrderedDocument, cls)._get_collection()
-
-        if IS_PYMONGO_3:
-            # returns collection object which is set OrderedDict class to be decoded from BSON document
-            from bson import CodecOptions
-            return collection.with_options(codec_options=CodecOptions(document_class=OrderedDict))
-        else:
-            # set attribute to specify the class to be decoeded
-            cls.decoded_class = OrderedDict
-            return collection

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -50,7 +50,7 @@ __all__ = (
     'FileField', 'ImageGridFsProxy', 'ImproperlyConfigured', 'ImageField',
     'GeoPointField', 'PointField', 'LineStringField', 'PolygonField',
     'SequenceField', 'UUIDField', 'MultiPointField', 'MultiLineStringField',
-    'MultiPolygonField', 'GeoJsonBaseField', 'OrderedDynamicField'
+    'MultiPolygonField', 'GeoJsonBaseField'
 )
 
 RECURSIVE_REFERENCE_CONSTANT = 'self'
@@ -620,6 +620,14 @@ class DynamicField(BaseField):
 
     Used by :class:`~mongoengine.DynamicDocument` to handle dynamic data"""
 
+    def __init__(self, container_class=dict, *args, **kwargs):
+        self._container_cls = container_class
+        if not issubclass(self._container_cls, dict):
+            self.error('The class that is specified in `container_class` parameter '
+                       'must be a subclass of `dict`.')
+
+        super(DynamicField, self).__init__(*args, **kwargs)
+
     def to_mongo(self, value, use_db_field=True, fields=None):
         """Convert a Python type to a MongoDB compatible type.
         """
@@ -645,7 +653,7 @@ class DynamicField(BaseField):
             is_list = True
             value = {k: v for k, v in enumerate(value)}
 
-        data = self._container_type() if hasattr(self, '_container_type') else {}
+        data = self._container_cls()
         for k, v in value.iteritems():
             data[k] = self.to_mongo(v, use_db_field, fields)
 
@@ -674,16 +682,6 @@ class DynamicField(BaseField):
     def validate(self, value, clean=True):
         if hasattr(value, 'validate'):
             value.validate(clean=clean)
-
-
-class OrderedDynamicField(DynamicField):
-    """A field that wraps DynamicField. This uses OrderedDict class
-    to guarantee to store data in the defined order instead of dict.
-    """
-
-    def __init__(self, *args, **kwargs):
-        super(OrderedDynamicField, self).__init__(*args, **kwargs)
-        self._container_type = OrderedDict
 
 
 class ListField(ComplexBaseField):

--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -1501,6 +1501,10 @@ class BaseQuerySet(object):
                 cursor_args['read_preference'] = self._read_preference
             else:
                 cursor_args['slave_okay'] = self._slave_okay
+
+            # set decode format if needed
+            if hasattr(self._document, 'decoded_class'):
+                cursor_args['as_class'] = self._document.decoded_class
         else:
             fields_name = 'projection'
             # snapshot is not handled at all by PyMongo 3+

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -7,6 +7,7 @@ import itertools
 import re
 
 from nose.plugins.skip import SkipTest
+from collections import OrderedDict
 import six
 
 try:
@@ -4498,6 +4499,40 @@ class EmbeddedDocumentListFieldTestCase(MongoDBTestCase):
         self.assertFalse(hasattr(a1.c_field, 'custom_data'))
         self.assertTrue(hasattr(CustomData.c_field, 'custom_data'))
         self.assertEqual(custom_data['a'], CustomData.c_field.custom_data['a'])
+
+    def test_ordered_dynamic_fields_class(self):
+        """
+        Tests that OrderedDynamicFields interits features of the DynamicFields
+        and saves/retrieves data in order.
+        """
+        class Member(Document):
+            name = StringField()
+            age = IntField()
+
+        class Team(OrderedDocument):
+            members = OrderedDynamicField()
+
+        Member.drop_collection()
+        Team.drop_collection()
+
+        member_info = [
+            ('Martin McFly', 17),
+            ('Emmett Brown', 65),
+            ('George McFly', 47)
+        ]
+        members = OrderedDict()
+        for name, age in member_info:
+            members[name] = Member(name=name, age=age)
+            members[name].save()
+
+        Team(members=members).save()
+
+        index = 0
+        team = Team.objects.get()
+        for member in team.members:
+            print("%s == %s" % (member, member_info[index][0]))
+            self.assertEqual(member, member_info[index][0])
+            index += 1
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I added a feature to save and load object data in order for #203.

Previously, the saved object data is handled by the Dictionary type implicitly. This causes unordered data store.
And data load processing also decodes BSON object to the Dictionary type.

This patch guarantees data to be saved and loaded in the order.

Thank you.
