### PR TITLE
set default for list field [] without lambda

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -687,7 +687,7 @@ class ListField(ComplexBaseField):
 
     def __init__(self, field=None, **kwargs):
         self.field = field
-        kwargs.setdefault('default', lambda: [])
+        kwargs.setdefault('default', [])
         super(ListField, self).__init__(**kwargs)
 
     def validate(self, value):


### PR DESCRIPTION
I'm not sure why this one using `lambda`, but I got an issue with this
```python
class Installment(DynamicDocument):
    pass

class Invoice(DynamicDocument):
    installments = ListField(ReferenceField(Installment))

```
When I set
```python
installment = Installment()
installment.save()

invoice = Invoice()
invoice.installments = [installment]
```
I got issue
```
TypeError: 'function' object is not iterable
```

It turn out that in dereference.py line 49 
```python
                if is_list and all([i.__class__ == doc_type for i in items]):
```
 Where items is `lambda: []`

I manually fix by
```python
class Invoice(DynamicDocument):
    installments = ListField(ReferenceField(Installment), default=[])
```

Hope this help