### PR TITLE
Unicode support in EmailField

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -164,12 +164,13 @@ class EmailField(StringField):
     )
 
     UTF8_USER_REGEX = re.compile(
-        # RFC 6531 Section 3.3 extends `atext` (used by dot-atom) to include
-        # `UTF8-non-ascii`.
-        ur"(^[-!#$%&'*+/=?^_`{}|~0-9A-Z\u0080-\U0010FFFF]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z\u0080-\U0010FFFF]+)*\Z"
-        # `quoted-string`
-        ur'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]|\\[\001-\011\013\014\016-\177])*"\Z)',
-        re.IGNORECASE | re.UNICODE
+        six.u(
+            # RFC 6531 Section 3.3 extends `atext` (used by dot-atom) to
+            # include `UTF8-non-ascii`.
+            r"(^[-!#$%&'*+/=?^_`{}|~0-9A-Z\u0080-\U0010FFFF]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z\u0080-\U0010FFFF]+)*\Z"
+            # `quoted-string`
+            r'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]|\\[\001-\011\013\014\016-\177])*"\Z)'
+        ), re.IGNORECASE | re.UNICODE
     )
 
     DOMAIN_REGEX = re.compile(

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -159,7 +159,7 @@ class EmailField(StringField):
         # `dot-atom` defined in RFC 5322 Section 3.2.3.
         r"(^[-!#$%&'*+/=?^_`{}|~0-9A-Z]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z]+)*\Z"
         # `quoted-string` defined in RFC 5322 Section 3.2.4.
-        r'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]|\\[\001-\011\013\014\016-\177])*"\Z)',
+        r'|^"([\x01-\x08\x0b\x0c\x0e-\x1f!#-\[\]-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*"\Z)',
         re.IGNORECASE
     )
 
@@ -167,9 +167,9 @@ class EmailField(StringField):
         six.u(
             # RFC 6531 Section 3.3 extends `atext` (used by dot-atom) to
             # include `UTF8-non-ascii`.
-            r"(^[-!#$%&'*+/=?^_`{}|~0-9A-Z\u0080-\U0010FFFF]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z\u0080-\U0010FFFF]+)*\Z"
+            r"(^[-!#$%&'*+/=?^_`{}|~0-9A-Z\x80-\U0010FFFF]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z\x80-\U0010FFFF]+)*\Z"
             # `quoted-string`
-            r'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]|\\[\001-\011\013\014\016-\177])*"\Z)'
+            r'|^"([\x01-\x08\x0b\x0c\x0e-\x1f!#-\[\]-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*"\Z)',
         ), re.IGNORECASE | re.UNICODE
     )
 

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -159,7 +159,7 @@ class EmailField(StringField):
         # `dot-atom` defined in RFC 5322 Section 3.2.3.
         r"(^[-!#$%&'*+/=?^_`{}|~0-9A-Z]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z]+)*\Z"
         # `quoted-string` defined in RFC 5322 Section 3.2.4.
-        r'|^"([\x01-\x08\x0b\x0c\x0e-\x1f!#-\[\]-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*"\Z)',
+        r'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]|\\[\001-\011\013\014\016-\177])*"\Z)',
         re.IGNORECASE
     )
 
@@ -167,9 +167,9 @@ class EmailField(StringField):
         six.u(
             # RFC 6531 Section 3.3 extends `atext` (used by dot-atom) to
             # include `UTF8-non-ascii`.
-            r"(^[-!#$%&'*+/=?^_`{}|~0-9A-Z\x80-\U0010FFFF]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z\x80-\U0010FFFF]+)*\Z"
+            r"(^[-!#$%&'*+/=?^_`{}|~0-9A-Z\u0080-\U0010FFFF]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z\u0080-\U0010FFFF]+)*\Z"
             # `quoted-string`
-            r'|^"([\x01-\x08\x0b\x0c\x0e-\x1f!#-\[\]-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*"\Z)',
+            r'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]|\\[\001-\011\013\014\016-\177])*"\Z)'
         ), re.IGNORECASE | re.UNICODE
     )
 

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -2,9 +2,9 @@ import datetime
 import decimal
 import itertools
 import re
+import socket
 import time
 import uuid
-import socket
 import warnings
 from collections import Mapping
 from operator import itemgetter
@@ -223,7 +223,7 @@ class EmailField(StringField):
         if domain_part[0] == '[' and domain_part[-1] == ']':
             for addr_family in socket.AF_INET, socket.AF_INET6:
                 try:
-                    return socket.inet_pton(addr_family , domain_part[1:-1])
+                    socket.inet_pton(addr_family, domain_part[1:-1])
                     return True
                 except (socket.error, UnicodeEncodeError):
                     pass

--- a/tests/document/instance.py
+++ b/tests/document/instance.py
@@ -844,7 +844,7 @@ class InstanceTest(unittest.TestCase):
         class Recipient(Document):
             email = EmailField(required=True)
 
-        recipient = Recipient(email='root@localhost')
+        recipient = Recipient(email='not-an-email')
         self.assertRaises(ValidationError, recipient.save)
         recipient.save(validate=False)
 

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -3477,6 +3477,10 @@ class FieldTest(MongoDBTestCase):
         user = User(email=u'user@пример')
         self.assertRaises(ValidationError, user.validate)
 
+        # invalid data type
+        user = User(email=123)
+        self.assertRaises(ValidationError, user.validate)
+
     def test_email_field_unicode_user(self):
         # Don't run this test on pypy3, which doesn't support unicode regex:
         # https://bitbucket.org/pypy/pypy/issues/1821/regular-expression-doesnt-find-unicode

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -6,6 +6,7 @@ import math
 import itertools
 import re
 import pymongo
+import sys
 
 from nose.plugins.skip import SkipTest
 from collections import OrderedDict
@@ -3477,6 +3478,11 @@ class FieldTest(MongoDBTestCase):
         self.assertRaises(ValidationError, user.validate)
 
     def test_email_field_unicode_user(self):
+        # Don't run this test on pypy3, which doesn't support unicode regex:
+        # https://bitbucket.org/pypy/pypy/issues/1821/regular-expression-doesnt-find-unicode
+        if sys.version_info[:2] == (3, 2):
+            raise SkipTest('unicode email addresses are not supported on PyPy 3')
+
         class User(Document):
             email = EmailField()
 


### PR DESCRIPTION
Fixes #1228

Previously, email addresses containing unicode characters didn't work at all. Now, unicode domains are supported out of the box and utf8 validation on the user parts can be explicitly enabled. This PR also adds validation of IP-based domain parts (e.g. "user@[127.0.0.1]") and introduces support for whitelisting otherwise invalid domains (e.g. "root@localhost").

Support for unicode usernames is still somewhat limited in many packages, so that option should be enabled only after a thorough inspection of the other parts of the system. The domain whitelist is empty and the IP validation is disabled by default primarily to be consistent with the past behavior, and because many applications may choose to reject such addresses.

### Performance

TL;DR validation of regular ascii-only email addresses is slightly slower than previously, but still fast enough for vast majority of use cases (< 5us). Validation of unicode email addresses is slower by an order of magnitude (~75-85us), but works as expected and is only slow for these less-common addresses.

On master:
```
In [2]: ef = EmailField()

In [3]: %timeit ef.validate('wojcikstefan@gmail.com')
The slowest run took 7.05 times longer than the fastest. This could mean that an intermediate result is being cached.
100000 loops, best of 3: 2.13 µs per loop
```

On this branch:
```
In [14]: %timeit ef.validate('wojcikstefan@gmail.com')
The slowest run took 7.29 times longer than the fastest. This could mean that an intermediate result is being cached.
100000 loops, best of 3: 3.57 µs per loop

In [15]: %timeit ef.validate(u'wojcikstefan@gmail.com')
The slowest run took 5.52 times longer than the fastest. This could mean that an intermediate result is being cached.
100000 loops, best of 3: 3.41 µs per loop

In [16]: %timeit unicode_ef.validate('wojcikstefan@gmail.com')
The slowest run took 5.69 times longer than the fastest. This could mean that an intermediate result is being cached.
100000 loops, best of 3: 3.69 µs per loop

In [17]: %timeit ip_ef.validate('wojcikstefan@gmail.com')
The slowest run took 6.07 times longer than the fastest. This could mean that an intermediate result is being cached.
100000 loops, best of 3: 3.3 µs per loop

In [18]: %timeit ip_ef.validate(u'user@[192.168.0.1]')
The slowest run took 10.05 times longer than the fastest. This could mean that an intermediate result is being cached.
100000 loops, best of 3: 3.68 µs per loop

In [19]: %timeit unicode_ef.validate(u'Dörte@Sörensen.example.com')
The slowest run took 51.38 times longer than the fastest. This could mean that an intermediate result is being cached.
10000 loops, best of 3: 77.4 µs per loop

In [20]: %timeit ef.validate(u'ascii@Sörensen.example.com')
10000 loops, best of 3: 82.3 µs per loop
```