### PR TITLE
Fix empty string casted to datetime today in DateTimeField

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -484,6 +484,9 @@ class DateTimeField(BaseField):
         if not isinstance(value, six.string_types):
             return None
 
+        if value == '':
+            return None
+
         # Attempt to parse a datetime:
         if dateutil:
             try:

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -484,7 +484,8 @@ class DateTimeField(BaseField):
         if not isinstance(value, six.string_types):
             return None
 
-        if value == '':
+        value = value.strip()
+        if not value:
             return None
 
         # Attempt to parse a datetime:

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -40,6 +40,16 @@ __all__ = ("FieldTest", "EmbeddedDocumentListFieldTestCase")
 
 class FieldTest(MongoDBTestCase):
 
+    def test_datetime_from_empty_string(self):
+        """
+        Ensure an exception is raised when trying to
+        cast an empty string to datetime.
+        """
+        class MyDoc(Document):
+            dt = DateTimeField()
+        md = MyDoc(dt='')
+        self.assertRaises(ValidationError, md.save)
+
     def test_default_values_nothing_set(self):
         """Ensure that default field values are used when creating
         a document.

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -47,7 +47,19 @@ class FieldTest(MongoDBTestCase):
         """
         class MyDoc(Document):
             dt = DateTimeField()
+
         md = MyDoc(dt='')
+        self.assertRaises(ValidationError, md.save)
+
+    def test_datetime_from_whitespace_string(self):
+        """
+        Ensure an exception is raised when trying to
+        cast a whitespace-only string to datetime.
+        """
+        class MyDoc(Document):
+            dt = DateTimeField()
+
+        md = MyDoc(dt='   ')
         self.assertRaises(ValidationError, md.save)
 
     def test_default_values_nothing_set(self):


### PR DESCRIPTION
This happens in python 2.7 because `dateutil.parser.parse('')`
return `datetime.date.today()`