### PR TITLE
Better db_field validation

### DIFF
--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -81,7 +81,14 @@ class BaseField(object):
         self.sparse = sparse
         self._owner_document = None
 
-        # Validate the db_field
+        # Make sure db_field is a string (if it's explicitly defined).
+        if (
+            self.db_field is not None and
+            not isinstance(self.db_field, six.string_types)
+        ):
+            raise TypeError('db_field should be a string.')
+
+        # Make sure db_field doesn't contain any forbidden characters.
         if isinstance(self.db_field, six.string_types) and (
             '.' in self.db_field or
             '\0' in self.db_field or

--- a/tests/document/instance.py
+++ b/tests/document/instance.py
@@ -242,7 +242,7 @@ class InstanceTest(unittest.TestCase):
         Zoo.drop_collection()
 
         class Zoo(Document):
-            animals = ListField(GenericReferenceField(Animal))
+            animals = ListField(GenericReferenceField())
 
         # Save a reference to each animal
         zoo = Zoo(animals=Animal.objects)


### PR DESCRIPTION
Building on top of #1448, we should also disallow explicit `db_field` values that aren't strings.