### PR TITLE
Cleaner as_pymongo

### DIFF
--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -1132,6 +1132,9 @@ class BaseQuerySet(object):
     def as_pymongo(self):
         """Instead of returning Document instances, return raw values from
         pymongo.
+
+        This method is particularly useful if you don't need dereferencing
+        and care primarily about the speed of data retrieval.
         """
         queryset = self.clone()
         queryset._as_pymongo = True

--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -67,7 +67,6 @@ class BaseQuerySet(object):
         self._scalar = []
         self._none = False
         self._as_pymongo = False
-        self._as_pymongo_coerce = False
         self._search_text = None
 
         # If inheritance is allowed, only return instances and instances of
@@ -728,11 +727,12 @@ class BaseQuerySet(object):
                 '%s is not a subclass of BaseQuerySet' % new_qs.__name__)
 
         copy_props = ('_mongo_query', '_initial_query', '_none', '_query_obj',
-                      '_where_clause', '_loaded_fields', '_ordering', '_snapshot',
-                      '_timeout', '_class_check', '_slave_okay', '_read_preference',
-                      '_iter', '_scalar', '_as_pymongo', '_as_pymongo_coerce',
+                      '_where_clause', '_loaded_fields', '_ordering',
+                      '_snapshot', '_timeout', '_class_check', '_slave_okay',
+                      '_read_preference', '_iter', '_scalar', '_as_pymongo',
                       '_limit', '_skip', '_hint', '_auto_dereference',
-                      '_search_text', 'only_fields', '_max_time_ms', '_comment')
+                      '_search_text', 'only_fields', '_max_time_ms',
+                      '_comment')
 
         for prop in copy_props:
             val = getattr(self, prop)
@@ -939,7 +939,8 @@ class BaseQuerySet(object):
 
             posts = BlogPost.objects(...).fields(slice__comments=5)
 
-        :param kwargs: A set keywors arguments identifying what to include.
+        :param kwargs: A set of keyword arguments identifying what to
+            include, exclude, or slice.
 
         .. versionadded:: 0.5
         """
@@ -1128,16 +1129,12 @@ class BaseQuerySet(object):
         """An alias for scalar"""
         return self.scalar(*fields)
 
-    def as_pymongo(self, coerce_types=False):
+    def as_pymongo(self):
         """Instead of returning Document instances, return raw values from
         pymongo.
-
-        :param coerce_types: Field types (if applicable) would be use to
-            coerce types.
         """
         queryset = self.clone()
         queryset._as_pymongo = True
-        queryset._as_pymongo_coerce = coerce_types
         return queryset
 
     def max_time_ms(self, ms):
@@ -1799,59 +1796,25 @@ class BaseQuerySet(object):
 
         return tuple(data)
 
-    def _get_as_pymongo(self, row):
-        # Extract which fields paths we should follow if .fields(...) was
-        # used. If not, handle all fields.
-        if not getattr(self, '__as_pymongo_fields', None):
-            self.__as_pymongo_fields = []
+    def _get_as_pymongo(self, doc):
+        """Clean up a PyMongo doc, removing fields that were only fetched
+        for the sake of MongoEngine's implementation, and return it.
+        """
+        # Always remove _cls as a MongoEngine's implementation detail.
+        if '_cls' in doc:
+            del doc['_cls']
 
-            for field in self._loaded_fields.fields - set(['_cls']):
-                self.__as_pymongo_fields.append(field)
-                while '.' in field:
-                    field, _ = field.rsplit('.', 1)
-                    self.__as_pymongo_fields.append(field)
+        # If the _id was not included in a .only or was excluded in a .exclude,
+        # remove it from the doc (we always fetch it so that we can properly
+        # construct documents).
+        fields = self._loaded_fields
+        if fields and '_id' in doc and (
+            (fields.value == QueryFieldList.ONLY and '_id' not in fields.fields) or
+            (fields.value == QueryFieldList.EXCLUDE and '_id' in fields.fields)
+        ):
+            del doc['_id']
 
-        all_fields = not self.__as_pymongo_fields
-
-        def clean(data, path=None):
-            path = path or ''
-
-            if isinstance(data, dict):
-                new_data = {}
-                for key, value in data.iteritems():
-                    new_path = '%s.%s' % (path, key) if path else key
-
-                    if all_fields:
-                        include_field = True
-                    elif self._loaded_fields.value == QueryFieldList.ONLY:
-                        include_field = new_path in self.__as_pymongo_fields
-                    else:
-                        include_field = new_path not in self.__as_pymongo_fields
-
-                    if include_field:
-                        new_data[key] = clean(value, path=new_path)
-                data = new_data
-            elif isinstance(data, list):
-                data = [clean(d, path=path) for d in data]
-            else:
-                if self._as_pymongo_coerce:
-                    # If we need to coerce types, we need to determine the
-                    # type of this field and use the corresponding
-                    # .to_python(...)
-                    EmbeddedDocumentField = _import_class('EmbeddedDocumentField')
-
-                    obj = self._document
-                    for chunk in path.split('.'):
-                        obj = getattr(obj, chunk, None)
-                        if obj is None:
-                            break
-                        elif isinstance(obj, EmbeddedDocumentField):
-                            obj = obj.document_type
-                    if obj and data is not None:
-                        data = obj.to_python(data)
-            return data
-
-        return clean(row)
+        return doc
 
     def _sub_js_fields(self, code):
         """When fields are specified with [~fieldname] syntax, where

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -4646,7 +4646,6 @@ class QuerySetTest(unittest.TestCase):
 
     def test_no_cache(self):
         """Ensure you can add meta data to file"""
-
         class Noddy(Document):
             fields = DictField()
 
@@ -4664,15 +4663,19 @@ class QuerySetTest(unittest.TestCase):
 
         self.assertEqual(len(list(docs)), 100)
 
+        # Can't directly get a length of a no-cache queryset.
         with self.assertRaises(TypeError):
             len(docs)
 
+        # Another iteration over the queryset should result in another db op.
         with query_counter() as q:
-            self.assertEqual(q, 0)
             list(docs)
             self.assertEqual(q, 1)
+
+        # ... and another one to double-check.
+        with query_counter() as q:
             list(docs)
-            self.assertEqual(q, 2)
+            self.assertEqual(q, 1)
 
     def test_nested_queryset_iterator(self):
         # Try iterating the same queryset twice, nested.

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -4073,7 +4073,6 @@ class QuerySetTest(unittest.TestCase):
         self.assertEqual(activity.owner, person)
 
         activity = TestActivity.objects(owner=person).only('id', 'owner').as_pymongo().first()
-        print activity
         self.assertEqual(activity['_id'], a1.pk)
         self.assertTrue(activity['owner']['_ref'], DBRef('test_person', person.pk))
 


### PR DESCRIPTION
Fixes #563 and closes #1002.

This PR introduces tweaks to `QuerySet.as_pymongo` - a method that hasn't been touched in at least a couple years. Part of me wants to get rid of it entirely and suggest that people use `Doc._get_collection().find(...)` if they need raw PyMongo documents, but perhaps that's too drastic of a change (and can be revisited when we make `_get_collection` public, see #1182).

This PR significantly simplifies the code and gets rid of an arguably useless `coerce_types` kwarg (the idea of converting values to MongoEngine-specific types in a method that's supposed to return raw PyMongo documents confuses me greatly). For now I also followed the previous logic of excluding `_cls` as an implementation detail and also excluding `_id` if it was only fetched for internal MongoEngine purposes.

Even though I suspect this to be barely used, it introduces a breaking change and should hence be released along with a major version bump.

---

This is off-topic, but I was curious and performed a test of how much faster `as_pymongo` is compared to the regular queryset iteration:

```
In [12]: class User(Document):
    ...:     name = StringField()
    ...:     email = EmailField()
    ...:

In [13]: for i in range(100000):
    ...:     User.objects.create(name='Steve ' + str(i), email='steve%d@gmail.com' % i)
    ...:

In [14]: def test():
    ...:     for doc in User.objects:
    ...:         pass
    ...:

In [15]: def test2():
    ...:     for doc in User.objects.as_pymongo():
    ...:         pass
    ...:

In [16]: %time test()
CPU times: user 8.75 s, sys: 179 ms, total: 8.93 s
Wall time: 8.89 s

In [17]: %time test2()
CPU times: user 463 ms, sys: 37.8 ms, total: 500 ms
Wall time: 517 ms
```

Quite a difference...