### PR TITLE
Fixes query operations on BinaryFields

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -1393,6 +1393,12 @@ class BinaryField(BaseField):
         if self.max_bytes is not None and len(value) > self.max_bytes:
             self.error('Binary value is too long')
 
+    def prepare_query_value(self, op, value):
+        if value is None:
+            return value
+        return super(BinaryField, self).prepare_query_value(
+            op, self.to_mongo(value))
+
 
 class GridFSError(Exception):
     pass


### PR DESCRIPTION
Overrides `prepare_query_value` in `BinaryField` to wrap the query value in
`bson.binary.Binary`. This was already done in the `to_mongo` call when
saving a document, but query operations required the user to convert the
value manually.

Fixes https://github.com/MongoEngine/mongoengine/issues/1127