### PR TITLE
Adds no conflict doc, not quite done. Still has issues.

### DIFF
--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -1,6 +1,7 @@
 # Import submodules so that we can expose their __all__
 from mongoengine import connection
 from mongoengine import document
+from mongoengine import no_conflict_doc
 from mongoengine import errors
 from mongoengine import fields
 from mongoengine import queryset
@@ -12,6 +13,7 @@ from mongoengine import signals
 # `from mongoengine import *` and then `connect('testdb')`.
 from mongoengine.connection import *
 from mongoengine.document import *
+from mongoengine.no_conflict_doc import *
 from mongoengine.errors import *
 from mongoengine.fields import *
 from mongoengine.queryset import *
@@ -20,7 +22,7 @@ from mongoengine.signals import *
 
 __all__ = (list(document.__all__) + list(fields.__all__) +
            list(connection.__all__) + list(queryset.__all__) +
-           list(signals.__all__) + list(errors.__all__))
+           list(signals.__all__) + list(errors.__all__) + list(no_conflict_doc.__all__), )
 
 
 VERSION = (0, 14, 0)

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -53,7 +53,7 @@ class EmbeddedDocument(BaseDocument):
     :attr:`meta` dictionary.
     """
 
-    __slots__ = ('_instance', )
+    __slots__ = ('_instance',)
 
     # The __metaclass__ attribute is removed by 2to3 when running with Python3
     # my_metaclass is defined so that metaclass can be queried in Python 2 & 3
@@ -222,8 +222,8 @@ class Document(BaseDocument):
             collection = db[collection_name]
             options = collection.options()
             if (
-                options.get('max') != max_documents or
-                options.get('size') != max_size
+                            options.get('max') != max_documents or
+                            options.get('size') != max_size
             ):
                 raise InvalidCollectionError(
                     'Cannot create collection "{}" as a capped '
@@ -916,16 +916,16 @@ class Document(BaseDocument):
 
             for base_cls in cls.__bases__:
                 if (isinstance(base_cls, TopLevelDocumentMetaclass) and
-                        base_cls != Document and
+                            base_cls != Document and
                         not base_cls._meta.get('abstract') and
-                        base_cls._get_collection().full_name == cls._get_collection().full_name and
-                        base_cls not in classes):
+                            base_cls._get_collection().full_name == cls._get_collection().full_name and
+                            base_cls not in classes):
                     classes.append(base_cls)
                     get_classes(base_cls)
             for subclass in cls.__subclasses__():
                 if (isinstance(base_cls, TopLevelDocumentMetaclass) and
-                        subclass._get_collection().full_name == cls._get_collection().full_name and
-                        subclass not in classes):
+                            subclass._get_collection().full_name == cls._get_collection().full_name and
+                            subclass not in classes):
                     classes.append(subclass)
                     get_classes(subclass)
 

--- a/mongoengine/no_conflict_doc.py
+++ b/mongoengine/no_conflict_doc.py
@@ -1,0 +1,43 @@
+from .document import Document
+from .fields import ObjectIdField
+import bson
+
+__all__ = 'NoConflictDocument',
+
+
+class NoConflictDocument(Document):
+    doc_ver = ObjectIdField(default=bson.ObjectId)
+    meta = {
+        'indexes': ['doc_ver'],
+        'allow_inheritance': True,
+    }
+
+    def save(self, force_insert=False, validate=True, clean=True,
+             write_concern=None, cascade=None, cascade_kwargs=None,
+             _refs=None, save_condition=None, signal_kwargs=None, **kwargs):
+
+        # If there are no changes, don't increment the version and force an actual save.
+        if not hasattr(self, '_changed_fields') or not self._changed_fields:
+            return super(NoConflictDocument, self).save(force_insert, validate, clean,
+                                                        write_concern, cascade, cascade_kwargs,
+                                                        _refs, save_condition, signal_kwargs, **kwargs)
+
+        # Grab the doc_ver and use it in the save statement.
+        # Ensure that we have not seen a change by using the save condition.
+        op_save_condition = {'doc_ver': self.doc_ver}
+
+        # Refresh doc_ver for this document's state, to be saved with changes.
+        self.doc_ver = bson.ObjectId()
+
+        if save_condition:
+            if not isinstance(save_condition, dict):
+                raise ValueError("save_condition must be empty or a dictionary")
+
+            # If there is a passed save condition, merge the two dictionaries
+            # giving precedence to our doc_ver statement.
+            save_condition.update(op_save_condition)
+            op_save_condition = save_condition
+
+        return super(NoConflictDocument, self).save(force_insert, validate, clean,
+                                                    write_concern, cascade, cascade_kwargs,
+                                                    _refs, op_save_condition, signal_kwargs, **kwargs)


### PR DESCRIPTION
Here's the PR for issue #1563 

@wojcikstefan It's not quite right but I wanted to have you look at it.

There are two problems. When running your example with this class we get this warning:

```
class Record(mongoengine.NoConflictDocument):
    name = mongoengine.StringField()
    meta = {
        'db_alias': 'core',
        'collection': 'records'
    }
```

```SyntaxWarning: Trying to set a collection on a subclass (Record)
  warnings.warn(msg, SyntaxWarning)```

And the specified collection `records` was not use, but `no_conflict_document` was used instead. Moreover, the document contains multiple inheritance features which shouldn't appear:

```
{
    "_id" : ObjectId("59483dd83ae7400f83dc5ac4"),
    "_cls" : "NoConflictDocument.Record",
    "doc_ver" : ObjectId("59483de43ae7400f88f48877"),
    "name" : "Test name 2"
}
```

Note the `_cls` field.

There has to be a better why to add this right?