### PR TITLE
docs: use explicit example of register_delete_rule

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -971,11 +971,13 @@ class ReferenceField(BaseField):
 
     .. code-block:: python
 
-        class Bar(Document):
-            content = StringField()
-            foo = ReferenceField('Foo')
+        class Org(Document):
+            owner = ReferenceField('User')
 
-        Foo.register_delete_rule(Bar, 'foo', NULLIFY)
+        class User(Document):
+	        org = ReferenceField('Org', reverse_delete_rule=CASCADE)
+
+        User.register_delete_rule(Org, 'owner', DENY)
 
     .. versionchanged:: 0.5 added `reverse_delete_rule`
     """

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -971,13 +971,13 @@ class ReferenceField(BaseField):
 
     .. code-block:: python
 
-        class Org(Document):
-            owner = ReferenceField('User')
+    class Org(Document):
+        owner = ReferenceField('User')
 
-        class User(Document):
-	        org = ReferenceField('Org', reverse_delete_rule=CASCADE)
+    class User(Document):
+        org = ReferenceField('Org', reverse_delete_rule=CASCADE)
 
-        User.register_delete_rule(Org, 'owner', DENY)
+    User.register_delete_rule(Org, 'owner', DENY)
 
     .. versionchanged:: 0.5 added `reverse_delete_rule`
     """


### PR DESCRIPTION
The previous example of creating bi-directional delete rules was vague since the example defined only one class and the relationship between "Foo" and "Bar" wasn't clear. I added a more explicit example where the relationship between the two classes is explicit.