### PR TITLE
docs: use explicit example of reverse_delete_rule

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -971,11 +971,13 @@ class ReferenceField(BaseField):
 
     .. code-block:: python
 
-        class Bar(Document):
-            content = StringField()
-            foo = ReferenceField('Foo')
+    class Org(Document):
+        owner = ReferenceField('User')
 
-        Foo.register_delete_rule(Bar, 'foo', NULLIFY)
+    class User(Document):
+        org = ReferenceField('Org', reverse_delete_rule=CASCADE)
+
+    User.register_delete_rule(Org, 'owner', DENY)
 
     .. versionchanged:: 0.5 added `reverse_delete_rule`
     """


### PR DESCRIPTION
The prior example using "Foo" and "Bar was vague; only one was actually defined and the relationship between the two were unclear. The new example has a more concrete relationship.