### PR TITLE
Fix Document.modify fail on sharded collection #1569

### DIFF
--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -280,6 +280,9 @@ class Document(BaseDocument):
         elif query[id_field] != self.pk:
             raise InvalidQueryError('Invalid document modify query: it must modify only this document.')
 
+        # Need to add shard key to query, or you get an error
+        query.update(self._object_key)
+
         updated = self._qs(**query).modify(new=True, **update)
         if updated is None:
             return False


### PR DESCRIPTION
I submitted PR for Document.modify fails on sharded collection. However, I don't know how to write unit test for it. Gladly, I checked it with manual
Created sharded cluster with 
<pre>
mlaunch --single --sharded 3
</pre>
<pre>
use test-db
db.doc.createIndex({name:1})
use admin
sh.enableSharding('test-db')
db.runCommand({shardCollection: "test-db.doc", key: {name:1}}
</pre>
and tried code snippet from #1569 .