### PR TITLE
Add RegexField

### DIFF
--- a/tests/fields/test_regex_field.py
+++ b/tests/fields/test_regex_field.py
@@ -6,19 +6,20 @@ from mongoengine import Document, RegexField, ValidationError
 from tests.utils import MongoDBTestCase
 
 
-class Rule(Document):
-    """Fake Document using a RegexField"""
-    regex = RegexField()
-
-
 class TestValidate(MongoDBTestCase):
     def test_raises_exception_if_invalid_type(self):
         """RegexField should raise an error if value is not a regex"""
+        class Rule(Document):
+            """Fake Document using a RegexField"""
+            regex = RegexField()
         doc = Rule(regex=1)
         self.assertRaises(ValidationError, doc.save)
 
     def test_do_not_raise_exception_if_regex(self):
         """RegexField should not raise error if value is a regex"""
+        class Rule(Document):
+            """Fake Document using a RegexField"""
+            regex = RegexField()
         regex = re.compile('mongo', re.U)
         doc = Rule(regex=regex)
         doc.save()
@@ -27,6 +28,9 @@ class TestValidate(MongoDBTestCase):
 class TestToPython(MongoDBTestCase):
     def test_convert_to_python_regex_if_bson_regex(self):
         """RegexField should convert bson regex to python regex"""
+        class Rule(Document):
+            """Fake Document using a RegexField"""
+            regex = RegexField()
         regex = re.compile('mongo', re.U)
         doc = Rule._from_son(SON([
             ('regex', Regex('mongo', 32))
@@ -36,6 +40,9 @@ class TestToPython(MongoDBTestCase):
 
     def test_keep_original_value_if_invalid_type(self):
         """RegexField should keep the original value if not a regex object"""
+        class Rule(Document):
+            """Fake Document using a RegexField"""
+            regex = RegexField()
         doc = Rule._from_son(SON([
             ('regex', 'str')
         ]))
@@ -46,6 +53,9 @@ class TestToPython(MongoDBTestCase):
 class TestToMongo(MongoDBTestCase):
     def test_convert_to_bson_regex_if_valid_regex(self):
         """RegexField should convert python regex to bson regex"""
+        class Rule(Document):
+            """Fake Document using a RegexField"""
+            regex = RegexField()
         regex = re.compile('mongo', re.U)
         doc = Rule(regex=regex)
         mongo_representation = SON([
@@ -55,6 +65,9 @@ class TestToMongo(MongoDBTestCase):
 
     def test_keep_value_if_invalid_regex(self):
         """RegexField should keep original value if invalid regex"""
+        class Rule(Document):
+            """Fake Document using a RegexField"""
+            regex = RegexField()
         doc = Rule(regex='mongo')
         mongo_representation = SON([
             ('regex', 'mongo')

--- a/tests/fields/test_regex_field.py
+++ b/tests/fields/test_regex_field.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+import re
+
+from bson import Regex, SON
+from mongoengine import Document, RegexField, ValidationError
+from tests.utils import MongoDBTestCase
+
+
+class Rule(Document):
+    """Fake Document using a RegexField"""
+    regex = RegexField()
+
+
+class TestValidate(MongoDBTestCase):
+    def test_raises_exception_if_invalid_type(self):
+        """RegexField should raise an error if value is not a regex"""
+        doc = Rule(regex=1)
+        self.assertRaises(ValidationError, doc.save)
+
+    def test_do_not_raise_exception_if_regex(self):
+        """RegexField should not raise error if value is a regex"""
+        regex = re.compile('mongo', re.U)
+        doc = Rule(regex=regex)
+        doc.save()
+
+
+class TestToPython(MongoDBTestCase):
+    def test_convert_to_python_regex_if_bson_regex(self):
+        """RegexField should convert bson regex to python regex"""
+        regex = re.compile('mongo', re.U)
+        doc = Rule._from_son(SON([
+            ('regex', Regex('mongo', 32))
+        ]))
+
+        self.assertEqual(doc.regex, regex)
+
+    def test_keep_original_value_if_invalid_type(self):
+        """RegexField should keep the original value if not a regex object"""
+        doc = Rule._from_son(SON([
+            ('regex', 'str')
+        ]))
+
+        self.assertEqual(doc.regex, 'str')
+
+
+class TestToMongo(MongoDBTestCase):
+    def test_convert_to_bson_regex_if_valid_regex(self):
+        """RegexField should convert python regex to bson regex"""
+        regex = re.compile('mongo', re.U)
+        doc = Rule(regex=regex)
+        mongo_representation = SON([
+            ('regex', Regex('mongo', 32))
+        ])
+        self.assertEqual(doc.to_mongo(), mongo_representation)
+
+    def test_keep_value_if_invalid_regex(self):
+        """RegexField should keep original value if invalid regex"""
+        doc = Rule(regex='mongo')
+        mongo_representation = SON([
+            ('regex', 'mongo')
+        ])
+        self.assertEqual(doc.to_mongo(), mongo_representation)


### PR DESCRIPTION
Hi,

This pull request brings a new field handling regular expressions.

Example :
```python
class Rule(Document):
    regex = RegexField()

Rule(regex=re.compile("mongo")).save()
doc = Rule.objects.first()

assert doc.regex.match("mongo")
assert not doc.regex.match("hello")
```