### PR TITLE
Fixes #1641

### DIFF
--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -1964,6 +1964,18 @@ class QuerySetTest(unittest.TestCase):
         post.reload()
         self.assertEqual(post.tags, ["code", "mongodb"])
 
+    def test_push_dict(self):
+
+        class Model(Document):
+            events = ListField(DictField())
+
+        doc = Model().save()
+
+        Model.objects(id=doc.id).update(events__push={})
+        doc.reload()
+        self.assertEqual(len(doc.events), 1)
+        self.assertEqual(doc.events[0], {})
+
     def test_add_to_set_each(self):
         class Item(Document):
             name = StringField(required=True)


### PR DESCRIPTION
There's no need to explicitly raise StopIteration as that's what a bare return statement does for a generator function - so yes they're the same.
As of late 2014 return is correct and raise StopIteration for ending a generator is on a depreciation schedule. See PEP 479 for full details.
https://stackoverflow.com/q/14183803/248296
https://www.python.org/dev/peps/pep-0479/