### PR TITLE
fix incompatible apistar.typesystem.Array

### DIFF
--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -312,7 +312,7 @@ class ComplexBaseField(BaseField):
             return value.to_python()
 
         is_list = False
-        if not hasattr(value, 'items'):
+        if not callable(getattr(value, 'items', None)):
             try:
                 is_list = True
                 value = {k: v for k, v in enumerate(value)}
@@ -364,7 +364,7 @@ class ComplexBaseField(BaseField):
             return val
 
         is_list = False
-        if not hasattr(value, 'items'):
+        if not callable(getattr(value, 'items', None)):
             try:
                 is_list = True
                 value = {k: v for k, v in enumerate(value)}


### PR DESCRIPTION
```python
pdb> type(value)
<class 'apistar.typesystem.Array'>
ipdb> value
['eaea']
ipdb> hasattr(value, 'items')
True
ipdb> hasattr([], 'items')
False
ipdb> callable(getattr(value, 'items', None))
False
ipdb> callable(getattr([], 'items', None))
False
```
is not possible "isinstance(value, dict)" ??