### PR TITLE
Add LazyReferenceField & GenericLazyReferencField

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 
 Changes in 0.15.0
 =================
-- Add LazyReferenceField to address #1230
+- Add LazyReferenceField and GenericLazyReferenceField to address #1230
 
 Changes in 0.14.1
 =================

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,9 +2,9 @@
 Changelog
 =========
 
-Development
-===========
-- (Fill this out as you fix issues and develop your features).
+Changes in 0.15.0
+=================
+- Add LazyReferenceField to address #1230
 
 Changes in 0.14.1
 =================

--- a/mongoengine/base/__init__.py
+++ b/mongoengine/base/__init__.py
@@ -15,7 +15,7 @@ __all__ = (
     'UPDATE_OPERATORS', '_document_registry', 'get_document',
 
     # datastructures
-    'BaseDict', 'BaseList', 'EmbeddedDocumentList',
+    'BaseDict', 'BaseList', 'EmbeddedDocumentList', 'LazyReference',
 
     # document
     'BaseDocument',

--- a/mongoengine/base/datastructures.py
+++ b/mongoengine/base/datastructures.py
@@ -1,8 +1,8 @@
 import itertools
 import weakref
 
-import six
 from bson import DBRef
+import six
 
 from mongoengine.common import _import_class
 from mongoengine.errors import DoesNotExist, MultipleObjectsReturned

--- a/mongoengine/base/datastructures.py
+++ b/mongoengine/base/datastructures.py
@@ -2,11 +2,12 @@ import itertools
 import weakref
 
 import six
+from bson import DBRef
 
 from mongoengine.common import _import_class
 from mongoengine.errors import DoesNotExist, MultipleObjectsReturned
 
-__all__ = ('BaseDict', 'BaseList', 'EmbeddedDocumentList')
+__all__ = ('BaseDict', 'BaseList', 'EmbeddedDocumentList', 'LazyReference')
 
 
 class BaseDict(dict):
@@ -445,3 +446,42 @@ class StrictDict(object):
 
             cls._classes[allowed_keys] = SpecificStrictDict
         return cls._classes[allowed_keys]
+
+
+class LazyReference(DBRef):
+    __slots__ = ('_cached_doc', 'passthrough', 'document_type')
+
+    def fetch(self, force=False):
+        if not self._cached_doc or force:
+            self._cached_doc = self.document_type.objects.get(pk=self.pk)
+            if not self._cached_doc:
+                raise DoesNotExist('Trying to dereference unknown document %s' % (self))
+        return self._cached_doc
+
+    @property
+    def pk(self):
+        return self.id
+
+    def __init__(self, document_type, pk, cached_doc=None, passthrough=False):
+        self.document_type = document_type
+        self._cached_doc = cached_doc
+        self.passthrough = passthrough
+        super(LazyReference, self).__init__(self.document_type._get_collection_name(), pk)
+
+    def __getitem__(self, name):
+        if not self.passthrough:
+            raise KeyError()
+        document = self.fetch()
+        return document[name]
+
+    def __getattr__(self, name):
+        if not object.__getattribute__(self, 'passthrough'):
+            raise AttributeError()
+        document = self.fetch()
+        try:
+            return document[name]
+        except KeyError:
+            raise AttributeError()
+
+    def __repr__(self):
+        return "<LazyReference(%s, %r)>" % (self.document_type, self.pk)

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -26,8 +26,8 @@ except ImportError:
     Int64 = long
 
 from mongoengine.base import (BaseDocument, BaseField, ComplexBaseField,
-                              GeoJsonBaseField, ObjectIdField, get_document,
-                              LazyReference)
+                              GeoJsonBaseField, LazyReference, ObjectIdField,
+                              get_document)
 from mongoengine.connection import DEFAULT_CONNECTION_NAME, get_db
 from mongoengine.document import Document, EmbeddedDocument
 from mongoengine.errors import DoesNotExist, InvalidQueryError, ValidationError
@@ -2265,9 +2265,10 @@ class LazyReferenceField(BaseField):
             try:
                 id_field.validate(pk)
             except ValidationError:
-                self.error("value should be `{0}` document, LazyReference or DBRef on `{0}` "
-                           "or `{0}`'s primary key (i.e. `{1}`)".format(
-                            self.document_type.__name__, type(id_field).__name__))
+                self.error(
+                    "value should be `{0}` document, LazyReference or DBRef on `{0}` "
+                    "or `{0}`'s primary key (i.e. `{1}`)".format(
+                        self.document_type.__name__, type(id_field).__name__))
 
         if pk is None:
             self.error('You can only reference documents once they have been '

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -26,7 +26,7 @@ except ImportError:
 from mongoengine import *
 from mongoengine.connection import get_db
 from mongoengine.base import (BaseDict, BaseField, EmbeddedDocumentList,
-                              _document_registry)
+                              _document_registry, LazyReference)
 
 from tests.utils import MongoDBTestCase
 
@@ -931,7 +931,9 @@ class FieldTest(MongoDBTestCase):
             comments = ListField(EmbeddedDocumentField(Comment))
             tags = ListField(StringField())
             authors = ListField(ReferenceField(User))
+            authors_as_lazy = ListField(LazyReferenceField(User))
             generic = ListField(GenericReferenceField())
+            # generic_as_lazy = ListField(LazyGenericReferenceField())
 
         User.drop_collection()
         BlogPost.drop_collection()
@@ -969,6 +971,15 @@ class FieldTest(MongoDBTestCase):
         post.authors = [user]
         post.validate()
 
+        post.authors_as_lazy = [Comment()]
+        self.assertRaises(ValidationError, post.validate)
+
+        post.authors_as_lazy = [User()]
+        self.assertRaises(ValidationError, post.validate)
+
+        post.authors_as_lazy = [user]
+        post.validate()
+
         post.generic = [1, 2]
         self.assertRaises(ValidationError, post.validate)
 
@@ -980,6 +991,18 @@ class FieldTest(MongoDBTestCase):
 
         post.generic = [user]
         post.validate()
+
+        # post.generic_as_lazy = [1, 2]
+        # self.assertRaises(ValidationError, post.validate)
+
+        # post.generic_as_lazy = [User(), Comment()]
+        # self.assertRaises(ValidationError, post.validate)
+
+        # post.generic_as_lazy = [Comment()]
+        # self.assertRaises(ValidationError, post.validate)
+
+        # post.generic_as_lazy = [user]
+        # post.validate()
 
     def test_sorted_list_sorting(self):
         """Ensure that a sorted list field properly sorts values.
@@ -4596,6 +4619,257 @@ class CachedReferenceFieldTest(MongoDBTestCase):
             animal__owner__tags='cool').first()
         self.assertEqual(ocorrence.person, "teste 2")
         self.assertTrue(isinstance(ocorrence.animal, Animal))
+
+
+class LazyReferenceFieldTest(MongoDBTestCase):
+    def test_lazy_reference_config(self):
+        # Make sure ReferenceField only accepts a document class or a string
+        # with a document class name.
+        self.assertRaises(ValidationError, LazyReferenceField, EmbeddedDocument)
+
+    def test_lazy_reference_simple(self):
+        class Animal(Document):
+            name = StringField()
+            tag = StringField()
+
+        class Ocurrence(Document):
+            person = StringField()
+            animal = LazyReferenceField(Animal)
+
+        Animal.drop_collection()
+        Ocurrence.drop_collection()
+
+        animal = Animal(name="Leopard", tag="heavy").save()
+        Ocurrence(person="test", animal=animal).save()
+        p = Ocurrence.objects.get()
+        self.assertIsInstance(p.animal, LazyReference)
+        fetched_animal = p.animal.fetch()
+        self.assertEqual(fetched_animal, animal)
+        # `fetch` keep cache on referenced document by default...
+        animal.tag = "not so heavy"
+        animal.save()
+        double_fetch = p.animal.fetch()
+        self.assertIs(fetched_animal, double_fetch)
+        self.assertEqual(double_fetch.tag, "heavy")
+        # ...unless specified otherwise
+        fetch_force = p.animal.fetch(force=True)
+        self.assertIsNot(fetch_force, fetched_animal)
+        self.assertEqual(fetch_force.tag, "not so heavy")
+
+    def test_lazy_reference_fetch_invalid_ref(self):
+        class Animal(Document):
+            name = StringField()
+            tag = StringField()
+
+        class Ocurrence(Document):
+            person = StringField()
+            animal = LazyReferenceField(Animal)
+
+        Animal.drop_collection()
+        Ocurrence.drop_collection()
+
+        animal = Animal(name="Leopard", tag="heavy").save()
+        Ocurrence(person="test", animal=animal).save()
+        animal.delete()
+        p = Ocurrence.objects.get()
+        self.assertIsInstance(p.animal, LazyReference)
+        with self.assertRaises(DoesNotExist):
+            p.animal.fetch()
+
+    def test_lazy_reference_set(self):
+        class Animal(Document):
+            meta = {'allow_inheritance': True}
+
+            name = StringField()
+            tag = StringField()
+
+        class Ocurrence(Document):
+            person = StringField()
+            animal = LazyReferenceField(Animal)
+
+        Animal.drop_collection()
+        Ocurrence.drop_collection()
+
+        class SubAnimal(Animal):
+            nick = StringField()
+
+        animal = Animal(name="Leopard", tag="heavy").save()
+        sub_animal = SubAnimal(nick='doggo', name='dog').save()
+        for ref in (
+                animal,
+                animal.pk,
+                DBRef(animal._get_collection_name(), animal.pk),
+                LazyReference(Animal, animal.pk),
+
+                sub_animal,
+                sub_animal.pk,
+                DBRef(sub_animal._get_collection_name(), sub_animal.pk),
+                LazyReference(SubAnimal, sub_animal.pk),
+                ):
+            p = Ocurrence(person="test", animal=ref).save()
+            p.reload()
+            self.assertIsInstance(p.animal, LazyReference)
+            p.animal.fetch()
+
+    def test_lazy_reference_bad_set(self):
+        class Animal(Document):
+            name = StringField()
+            tag = StringField()
+
+        class Ocurrence(Document):
+            person = StringField()
+            animal = LazyReferenceField(Animal)
+
+        Animal.drop_collection()
+        Ocurrence.drop_collection()
+
+        class BadDoc(Document):
+            pass
+
+        animal = Animal(name="Leopard", tag="heavy").save()
+        baddoc = BadDoc().save()
+        for bad in (
+                42,
+                'foo',
+                baddoc,
+                DBRef(baddoc._get_collection_name(), animal.pk),
+                LazyReference(BadDoc, animal.pk)
+                ):
+            with self.assertRaises(ValidationError):
+                p = Ocurrence(person="test", animal=bad).save()
+
+    def test_lazy_reference_query_conversion(self):
+        """Ensure that LazyReferenceFields can be queried using objects and values
+        of the type of the primary key of the referenced object.
+        """
+        class Member(Document):
+            user_num = IntField(primary_key=True)
+
+        class BlogPost(Document):
+            title = StringField()
+            author = LazyReferenceField(Member, dbref=False)
+
+        Member.drop_collection()
+        BlogPost.drop_collection()
+
+        m1 = Member(user_num=1)
+        m1.save()
+        m2 = Member(user_num=2)
+        m2.save()
+
+        post1 = BlogPost(title='post 1', author=m1)
+        post1.save()
+
+        post2 = BlogPost(title='post 2', author=m2)
+        post2.save()
+
+        post = BlogPost.objects(author=m1).first()
+        self.assertEqual(post.id, post1.id)
+
+        post = BlogPost.objects(author=m2).first()
+        self.assertEqual(post.id, post2.id)
+
+        # Same thing by passing a LazyReference instance
+        post = BlogPost.objects(author=LazyReference(Member, m2.pk)).first()
+        self.assertEqual(post.id, post2.id)
+
+    def test_lazy_reference_query_conversion_dbref(self):
+        """Ensure that LazyReferenceFields can be queried using objects and values
+        of the type of the primary key of the referenced object.
+        """
+        class Member(Document):
+            user_num = IntField(primary_key=True)
+
+        class BlogPost(Document):
+            title = StringField()
+            author = LazyReferenceField(Member, dbref=True)
+
+        Member.drop_collection()
+        BlogPost.drop_collection()
+
+        m1 = Member(user_num=1)
+        m1.save()
+        m2 = Member(user_num=2)
+        m2.save()
+
+        post1 = BlogPost(title='post 1', author=m1)
+        post1.save()
+
+        post2 = BlogPost(title='post 2', author=m2)
+        post2.save()
+
+        post = BlogPost.objects(author=m1).first()
+        self.assertEqual(post.id, post1.id)
+
+        post = BlogPost.objects(author=m2).first()
+        self.assertEqual(post.id, post2.id)
+
+        # Same thing by passing a LazyReference instance
+        post = BlogPost.objects(author=LazyReference(Member, m2.pk)).first()
+        self.assertEqual(post.id, post2.id)
+
+    def test_lazy_reference_passthrough(self):
+        class Animal(Document):
+            name = StringField()
+            tag = StringField()
+
+        class Ocurrence(Document):
+            animal = LazyReferenceField(Animal, passthrough=False)
+            animal_passthrough = LazyReferenceField(Animal, passthrough=True)
+
+        Animal.drop_collection()
+        Ocurrence.drop_collection()
+
+        animal = Animal(name="Leopard", tag="heavy").save()
+        Ocurrence(animal=animal, animal_passthrough=animal).save()
+        p = Ocurrence.objects.get()
+        self.assertIsInstance(p.animal, LazyReference)
+        with self.assertRaises(KeyError):
+            p.animal['name']
+        with self.assertRaises(AttributeError):
+            p.animal.name
+        self.assertEqual(p.animal.pk, animal.pk)
+
+        self.assertEqual(p.animal_passthrough.name, "Leopard")
+        self.assertEqual(p.animal_passthrough['name'], "Leopard")
+
+        # Should not be able to access referenced document's methods
+        with self.assertRaises(AttributeError):
+            p.animal.save
+        with self.assertRaises(KeyError):
+            p.animal['save']
+
+    def test_lazy_reference_not_set(self):
+        class Animal(Document):
+            name = StringField()
+            tag = StringField()
+
+        class Ocurrence(Document):
+            person = StringField()
+            animal = LazyReferenceField(Animal)
+
+        Animal.drop_collection()
+        Ocurrence.drop_collection()
+
+        Ocurrence(person='foo').save()
+        p = Ocurrence.objects.get()
+        self.assertIs(p.animal, None)
+
+    def test_lazy_reference_equality(self):
+        class Animal(Document):
+            name = StringField()
+            tag = StringField()
+
+        Animal.drop_collection()
+
+        animal = Animal(name="Leopard", tag="heavy").save()
+        animalref = LazyReference(Animal, animal.pk)
+        self.assertEqual(animal, animalref)
+        self.assertEqual(animalref, animal)
+
+        other_animalref = LazyReference(Animal, ObjectId("54495ad94c934721ede76f90"))
+        self.assertNotEqual(animal, other_animalref)
+        self.assertNotEqual(other_animalref, animal)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Replacement for `ReferencField` and `GenericReferencField` which address issues from #1230 

The `passthrough` argument allows to use them as an *almost)* dropin replacement on existing codebase ;-)