### PR TITLE
Add documentation for auto_create_index to the Indexing section of the Docs

### DIFF
--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -526,8 +526,9 @@ There are a few top level defaults for all indexes that can be set::
         meta = {
             'index_options': {},
             'index_background': True,
+            'index_cls': False,
+            'auto_create_index': True,
             'index_drop_dups': True,
-            'index_cls': False
         }
 
 
@@ -539,6 +540,12 @@ There are a few top level defaults for all indexes that can be set::
 
 :attr:`index_cls` (Optional)
     A way to turn off a specific index for _cls.
+
+:attr:`auto_create_index` (Optional)
+    When this is True (default), MongoEngine will ensure that the correct
+    indexes exist in MongoDB each time a command is run. This can be disabled
+    in systems where indexes are managed separately. Disabling this will improve
+    performance.
 
 :attr:`index_drop_dups` (Optional)
     Set the default value for if an index should drop duplicates


### PR DESCRIPTION
This adds a snippet to describe the `auto_create_index` attribute in the Indexing section of the User Guide. It was confusing to me that this was only mentioned in the docstring of the `Document` object (http://docs.mongoengine.org/apireference.html#documents) so it's visible in the API section of the docs but not mentioned at all in the User Guide.

I also change the ordering of the attributes in the dictionary to match the ordering of their descriptions.