### PR TITLE
Avoid creating a regex for startswith/endswith/contains/exact.

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -97,9 +97,9 @@ class StringField(BaseField):
             return value
 
         if op.lstrip('i') in ('startswith', 'endswith', 'contains', 'exact'):
-            flags = 0
+            options = ''
             if op.startswith('i'):
-                flags = re.IGNORECASE
+                options = 'i'
                 op = op.lstrip('i')
 
             regex = r'%s'
@@ -112,7 +112,11 @@ class StringField(BaseField):
 
             # escape unsafe characters which could lead to a re.error
             value = re.escape(value)
-            value = re.compile(regex % value, flags)
+            value = {
+                '$regex': regex % value
+            }
+            if options:
+                value['$options'] = options
         return super(StringField, self).prepare_query_value(op, value)
 
 


### PR DESCRIPTION
Python 3 regexs will _always_ have the `unicode` flag set, regardless
of what flags are sent in:

```python
Python 3.6.0 (default, Mar  2 2017, 15:58:29)
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import re
>>> re.compile('^hi$', 0).flags
32
>>> re.UNICODE
<RegexFlag.UNICODE: 32>
```

MongoDB doesn't support the unicode flag:
https://docs.mongodb.com/manual/reference/operator/query/regex/#op._S_options

This results in Mongo failing to use any indicies and to fall back to a
full-table scan.

@behackett from MongoDB suggested avoiding regexs all together - https://jira.mongodb.org/browse/SERVER-26991?focusedCommentId=1719722&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1719722

This should partially fix https://github.com/MongoEngine/mongoengine/issues/965