### PR TITLE
defensive programming for v as an instance of DBRef in dereference.

### DIFF
--- a/mongoengine/dereference.py
+++ b/mongoengine/dereference.py
@@ -237,7 +237,7 @@ class DeReference(object):
             elif isinstance(v, (dict, list, tuple)) and depth <= self.max_depth:
                 item_name = '%s.%s' % (name, k) if name else name
                 data[k] = self._attach_objects(v, depth - 1, instance=instance, name=item_name)
-            elif hasattr(v, 'id'):
+            elif isinstance(v, DBRef) and hasattr(v, 'id'):
                 data[k] = self.object_map.get((v.collection, v.id), v)
 
         if instance and name:


### PR DESCRIPTION
Found that DeReference._attach_objects does not restrict the type of the v in the items,
but assumes that v.collection exists when v.id exists.

The results in some issue when I intended to use python-social-auth + social-app-flask-mongoengine.
(some weird thing happened in /disconnection)

I would like to add defensive programming for v as DBRef as illustrated in the pr.