### PR TITLE
not restrict by _cls as query if allow_inheritance is True but index_cls is False

### DIFF
--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -71,7 +71,9 @@ class BaseQuerySet(object):
 
         # If inheritance is allowed, only return instances and instances of
         # subclasses of the class being used
-        if document._meta.get('allow_inheritance') is True:
+        # This is disabled when index_cls is set to False explicitly.
+        if document._meta.get('allow_inheritance') is True and \
+           document._meta.get('index_cls', True) is True:
             if len(self._document._subclasses) == 1:
                 self._initial_query = {'_cls': self._document._subclasses[0]}
             else:


### PR DESCRIPTION
I'm using `mongoengine` in my project to query/set existing data which are added by other applications, hence documents don't have `_cls` attribute.
In this case, if I define subclass of `Document` with `allow_inheritance` is `True` and `index_cls` is `False` (because existing data don't have `_cls` attr), `queryset` returns no object.
This is because if `allow_inheritance` is `True`, restriction on `_cls` is automatically added to all queries to mongodb.
So in this pull request, I updated the condition that adds the restriction to query only when `allow_inheritance` is True **and** `index_cls` is explicitly `False`.