### PR TITLE
Removing the usage of the '$pushAll' operator

### DIFF
--- a/mongoengine/queryset/transform.py
+++ b/mongoengine/queryset/transform.py
@@ -335,7 +335,7 @@ def update(_doc_cls=None, **update):
                 value = {key: value}
         elif op == 'addToSet' and isinstance(value, list):
             value = {key: {'$each': value}}
-        elif op == 'push':
+        elif op in ('push', 'pushAll'):
             if parts[-1].isdigit():
                 key = parts[0]
                 position = int(parts[-1])
@@ -345,7 +345,13 @@ def update(_doc_cls=None, **update):
                     value = [value]
                 value = {key: {'$each': value, '$position': position}}
             else:
-                value = {key: value}
+                if op == 'pushAll':
+                    op = 'push'  # convert to non-deprecated keyword
+                    if not isinstance(value, (set, tuple, list)):
+                        value = [value]
+                    value = {key: {'$each': value}}
+                else:
+                    value = {key: value}
         else:
             value = {key: value}
         key = '$' + op

--- a/tests/queryset/transform.py
+++ b/tests/queryset/transform.py
@@ -51,6 +51,17 @@ class TransformTest(unittest.TestCase):
         update = transform.update(DicDoc, pull__dictField__test=doc)
         self.assertTrue(isinstance(update["$pull"]["dictField"]["test"], dict))
 
+    def test_transform_update_push(self):
+        """Ensure the differences in behvaior between 'push' and 'push_all'"""
+        class BlogPost(Document):
+            tags = ListField(StringField())
+
+        update = transform.update(BlogPost, push__tags=['mongo', 'db'])
+        self.assertEqual(update, {'$push': {'tags': ['mongo', 'db']}})
+
+        update = transform.update(BlogPost, push_all__tags=['mongo', 'db'])
+        self.assertEqual(update, {'$push': {'tags': {'$each': ['mongo', 'db']}}})
+
     def test_query_field_name(self):
         """Ensure that the correct field name is used when querying.
         """


### PR DESCRIPTION
Related Issue: #1729 

I have removed the usage of '$pushAll' from the `transform.update` function. This method has been deprecated since MongoDB v2.4. In its favor, I have implemented the preferred method of pushing multiples: [$each](https://docs.mongodb.com/v3.2/reference/operator/update/each/#up._S_each).

This will not make any change to mongoengine's api. Users will still be able to call `push_all` as an atomic update modifier. That being said, we should consider removing this verbiage in favor of `push_each`; this would be more consistent/clear with the operation that is being performed.