### PR TITLE
removed deprecated warning for 'update' method

### DIFF
--- a/mongoengine/context_managers.py
+++ b/mongoengine/context_managers.py
@@ -221,6 +221,6 @@ class query_counter(object):
 
 @contextmanager
 def set_write_concern(collection, write_concerns):
-    yield collection.with_options(write_concern=WriteConcern(
-        **dict(collection.write_concern.document.items()),
-        **write_concerns))
+    old_concerns = dict(collection.write_concern.document.items())
+    combined_concerns = old_concerns.update(write_concerns)
+    yield collection.with_options(write_concern=WriteConcern(**combined_concerns))

--- a/mongoengine/context_managers.py
+++ b/mongoengine/context_managers.py
@@ -221,6 +221,6 @@ class query_counter(object):
 
 @contextmanager
 def set_write_concern(collection, write_concerns):
-    old_concerns = dict(collection.write_concern.document.items())
-    combined_concerns = old_concerns.update(write_concerns)
+    combined_concerns = dict(collection.write_concern.document.items())
+    combined_concerns.update(write_concerns)
     yield collection.with_options(write_concern=WriteConcern(**combined_concerns))

--- a/mongoengine/context_managers.py
+++ b/mongoengine/context_managers.py
@@ -1,9 +1,11 @@
 from mongoengine.common import _import_class
 from mongoengine.connection import DEFAULT_CONNECTION_NAME, get_db
+from pymongo.write_concern import WriteConcern
+from contextlib import contextmanager
 
 
 __all__ = ('switch_db', 'switch_collection', 'no_dereference',
-           'no_sub_classes', 'query_counter')
+           'no_sub_classes', 'query_counter', 'set_write_concern')
 
 
 class switch_db(object):
@@ -215,3 +217,10 @@ class query_counter(object):
         count = self.db.system.profile.find(ignore_query).count() - self.counter
         self.counter += 1
         return count
+
+
+@contextmanager
+def set_write_concern(collection, write_concerns):
+    yield collection.with_options(write_concern=WriteConcern(
+        **dict(collection.write_concern.document.items()),
+        **write_concerns))

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -9,6 +9,7 @@ from nose.plugins.skip import SkipTest
 import pymongo
 from pymongo.errors import ConfigurationError
 from pymongo.read_preferences import ReadPreference
+from pymongo.results import UpdateResult
 import six
 
 from mongoengine import *
@@ -656,14 +657,14 @@ class QuerySetTest(unittest.TestCase):
 
         result = self.Person(name="Bob", age=25).update(
             upsert=True, full_result=True)
-        self.assertTrue(isinstance(result, dict))
-        self.assertTrue("upserted" in result)
-        self.assertFalse(result["updatedExisting"])
+        self.assertTrue(isinstance(result, UpdateResult))
+        self.assertTrue("upserted" in result.raw_result)
+        self.assertFalse(result.raw_result["updatedExisting"])
 
         bob = self.Person.objects.first()
         result = bob.update(set__age=30, full_result=True)
-        self.assertTrue(isinstance(result, dict))
-        self.assertTrue(result["updatedExisting"])
+        self.assertTrue(isinstance(result, UpdateResult))
+        self.assertTrue(result.raw_result["updatedExisting"])
 
         self.Person(name="Bob", age=20).save()
         result = self.Person.objects(name="Bob").update(


### PR DESCRIPTION
Related Issue: #1491 

I have replaced our usage of PyMongo's `update` method with `update_one` and `update_many`. These new methods return an `UpdateResult` object -- the tests and code have been updated accordingly to handle this new object.

In order to accomplish this, I had to develop a new way of setting the write concern on the collection. This logic has been moved into `context_manager.set_write_concern`. This method will return a clone of the collection that is passed in and combine the previous write concerns with the new ones passed in.