### PR TITLE
queryset.update: `full_result`-argument not clearly described

### DIFF
--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -486,8 +486,9 @@ class BaseQuerySet(object):
             ``save(..., write_concern={w: 2, fsync: True}, ...)`` will
             wait until at least two servers have recorded the write and
             will force an fsync on the primary server.
-        :param full_result: Return the full result rather than just the number
-            updated.
+        :param full_result: Return the full result dictionary rather than just the number
+            updated, e.g. return
+            `{u'n': 2, u'nModified': 2, u'ok': 1.0, 'updatedExisting': True}`.
         :param update: Django-style update keyword arguments
 
         .. versionadded:: 0.2


### PR DESCRIPTION
The documentation for the `full_result`-argument to `queryset.update()` can be read as returning the updated documents/objects, whereas it's really returning just the full "PyMongo result dictionary".

This commit adds some wording and an example dictionary, to make it clear what the behavior is.

Basically the docs for `full_result` can be misread as having the same behavior as the `load_bulk`-argument to `insert()`. 