### PR TITLE
Docs, queryset.update(): Fix backtick mistake

### DIFF
--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -488,7 +488,7 @@ class BaseQuerySet(object):
             will force an fsync on the primary server.
         :param full_result: Return the full result dictionary rather than just the number
             updated, e.g. return
-            `{u'n': 2, u'nModified': 2, u'ok': 1.0, 'updatedExisting': True}`.
+            ``{'n': 2, 'nModified': 2, 'ok': 1.0, 'updatedExisting': True}``.
         :param update: Django-style update keyword arguments
 
         .. versionadded:: 0.2


### PR DESCRIPTION
I made a mistake in the merged PR #1762. As it just docs, it's not the worst, the formatting is just off because my brain was in Markdown-mode not RestructuredText-mode.

Single backticks should be double backticks.

I also removed the superfluous `u`-markers for unicode strings. They're in the output from Python, but they really just add noise (they're not important in terms of getting the point across).