### PR TITLE
Updated text-indexes.rst

### DIFF
--- a/docs/guide/text-indexes.rst
+++ b/docs/guide/text-indexes.rst
@@ -48,4 +48,4 @@ Ordering by text score
 
 ::
 
-  objects = News.objects.search('mongo').order_by('$text_score')
+  objects = News.objects.search_text('mongo').order_by('$text_score')


### PR DESCRIPTION
The search statement under the `Ordering by text score` section uses `search` on the QuerySet object instead of `search_text` and thus raised an `AttributeError`

AttributeError: 'QuerySet' object has no attribute 'search'