### PR TITLE
When building a query set from filters that reference the same field several times, do not assume each value is a dict

### DIFF
--- a/mongoengine/queryset/transform.py
+++ b/mongoengine/queryset/transform.py
@@ -147,7 +147,7 @@ def query(_doc_cls=None, **kwargs):
         if op is None or key not in mongo_query:
             mongo_query[key] = value
         elif key in mongo_query:
-            if isinstance(mongo_query[key], dict):
+            if isinstance(mongo_query[key], dict) and isinstance(value, dict):
                 mongo_query[key].update(value)
                 # $max/minDistance needs to come last - convert to SON
                 value_dict = mongo_query[key]

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -1202,6 +1202,14 @@ class QuerySetTest(unittest.TestCase):
         BlogPost.drop_collection()
         Blog.drop_collection()
 
+    def test_filter_chaining_with_regex(self):
+        person = self.Person(name='Guido van Rossum')
+        person.save()
+
+        people = self.Person.objects
+        people = people.filter(name__startswith='Gui').filter(name__not__endswith='tum')
+        self.assertEqual(people.count(), 1)
+
     def assertSequence(self, qs, expected):
         qs = list(qs)
         expected = list(expected)


### PR DESCRIPTION
Fix issues #1286 and #844 (basically the same issue).