### PR TITLE
fix handling of lazy translation objects as choice values

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -1085,6 +1085,6 @@ class BaseDocument(object):
             sep = getattr(field, 'display_sep', ' ')
             values = value if field.__class__.__name__ in ('ListField', 'SortedListField') else [value]
             return sep.join([
-                dict(field.choices).get(val, val)
+                str(dict(field.choices).get(val, val))
                 for val in values or []])
         return value


### PR DESCRIPTION
Choices may be lazy django translation objects and need to be converted into strings

See: https://docs.djangoproject.com/en/2.0/topics/i18n/translation/#working-with-lazy-translation-objects