### PR TITLE
Update gridfs.rst - make it clear that user must call Document.save()

### DIFF
--- a/docs/guide/gridfs.rst
+++ b/docs/guide/gridfs.rst
@@ -53,7 +53,8 @@ Deletion
 
 Deleting stored files is achieved with the :func:`delete` method::
 
-    marmot.photo.delete()
+    marmot.photo.delete()    # Deletes the GridFS document
+    marmot.save()            # Saves the GridFS reference (being None) contained in the marmot instance
 
 .. warning::
 
@@ -71,4 +72,5 @@ Files can be replaced with the :func:`replace` method. This works just like
 the :func:`put` method so even metadata can (and should) be replaced::
 
     another_marmot = open('another_marmot.png', 'rb')
-    marmot.photo.replace(another_marmot, content_type='image/png')
+    marmot.photo.replace(another_marmot, content_type='image/png')  # Replaces the GridFS document
+    marmot.save()                                                   # Replaces the GridFS reference contained in marmot instance

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -1528,9 +1528,9 @@ class GridFSProxy(object):
         return '<%s: %s>' % (self.__class__.__name__, self.grid_id)
 
     def __str__(self):
-        name = getattr(
-            self.get(), 'filename', self.grid_id) if self.get() else '(no file)'
-        return '<%s: %s>' % (self.__class__.__name__, name)
+        gridout = self.get()
+        filename = getattr(gridout, 'filename') if gridout else '<no file>'
+        return '<%s: %s (%s)>' % (self.__class__.__name__, filename, self.grid_id)
 
     def __eq__(self, other):
         if isinstance(other, GridFSProxy):

--- a/tests/fields/file_tests.py
+++ b/tests/fields/file_tests.py
@@ -54,7 +54,7 @@ class FileTest(MongoDBTestCase):
 
         result = PutFile.objects.first()
         self.assertTrue(putfile == result)
-        self.assertEqual("%s" % result.the_file, "<GridFSProxy: hello>")
+        self.assertEqual("%s" % result.the_file, "<GridFSProxy: hello (%s)>" % result.the_file.grid_id)
         self.assertEqual(result.the_file.read(), text)
         self.assertEqual(result.the_file.content_type, content_type)
         result.the_file.delete()  # Remove file from GridFS


### PR DESCRIPTION
I believe the implementation is consistent but as mentioned in #710, it is unclear that you should save the Document hosting the GridFSProxy after calling .delete() or .replace() on the GridFSProxy.