### PR TITLE
Improve doc of EmbeddedDocumentList.filter, 

### DIFF
--- a/mongoengine/base/datastructures.py
+++ b/mongoengine/base/datastructures.py
@@ -234,6 +234,9 @@ class EmbeddedDocumentList(BaseList):
         Filters the list by only including embedded documents with the
         given keyword arguments.
 
+        This method only supports simple comparison (e.g: .filter(name='John Doe'))
+        and does not support operators like __gte, __lte, __icontains like queryset.filter does
+
         :param kwargs: The keyword arguments corresponding to the fields to
          filter on. *Multiple arguments are treated as if they are ANDed
          together.*


### PR DESCRIPTION
Fixes #1664
Improve doc of EmbeddedDocumentList.filter and clarify that that it does not supports fancy operators like queryset.filter