### PR TITLE
minor improvement to DateTimeField doc

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -462,6 +462,8 @@ class DateTimeField(BaseField):
     installed you can utilise it to convert varying types of date formats into valid
     python datetime objects.
 
+    Note: To default the field to the current datetime, use: DateTimeField(default=datetime.utcnow)
+
     Note: Microseconds are rounded to the nearest millisecond.
       Pre UTC microsecond support is effectively broken.
       Use :class:`~mongoengine.fields.ComplexDateTimeField` if you


### PR DESCRIPTION
I've seen so many people doing mistakes (including myself) when defaulting a DateTimeField to utcnow (using datetime.utcnow() instead of datetime.utcnow) that I believe its worth mentioning it explicitly in the doc.
Fixes #1583