### PR TITLE
Fixes 2 bugs in no_subclasses context mgr

### DIFF
--- a/mongoengine/context_managers.py
+++ b/mongoengine/context_managers.py
@@ -145,18 +145,17 @@ class no_sub_classes(object):
         :param cls: the class to turn querying sub classes on
         """
         self.cls = cls
+        self.cls_initial_subclasses = None
 
     def __enter__(self):
         """Change the objects default and _auto_dereference values."""
-        self.cls._all_subclasses = self.cls._subclasses
-        self.cls._subclasses = (self.cls,)
+        self.cls_initial_subclasses = self.cls._subclasses
+        self.cls._subclasses = (self.cls._class_name,)
         return self.cls
 
     def __exit__(self, t, value, traceback):
         """Reset the default and _auto_dereference values."""
-        self.cls._subclasses = self.cls._all_subclasses
-        delattr(self.cls, '_all_subclasses')
-        return self.cls
+        self.cls._subclasses = self.cls_initial_subclasses
 
 
 class query_counter(object):


### PR DESCRIPTION
Fixes #1865
- Fixed __exit__ of no_subclasses context manager so that it won't swallow errors
- repair the feature because it was completely broken since at least 0.10.0...