### PR TITLE
Remove DictField.basecls related code, it is useless

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -945,14 +945,9 @@ class DictField(ComplexBaseField):
     .. versionchanged:: 0.5 - Can now handle complex / varying types of data
     """
 
-    def __init__(self, basecls=None, field=None, *args, **kwargs):
+    def __init__(self, field=None, *args, **kwargs):
         self.field = field
         self._auto_dereference = False
-        self.basecls = basecls or BaseField
-
-        # XXX ValidationError raised outside of the "validate" method.
-        if not issubclass(self.basecls, BaseField):
-            self.error('DictField only accepts dict values')
 
         kwargs.setdefault('default', lambda: {})
         super(DictField, self).__init__(*args, **kwargs)
@@ -972,7 +967,7 @@ class DictField(ComplexBaseField):
         super(DictField, self).validate(value)
 
     def lookup_member(self, member_name):
-        return DictField(basecls=self.basecls, db_field=member_name)
+        return DictField(db_field=member_name)
 
     def prepare_query_value(self, op, value):
         match_operators = ['contains', 'icontains', 'startswith',

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -3618,33 +3618,6 @@ class QuerySetTest(unittest.TestCase):
 
         Group.drop_collection()
 
-    def test_dict_with_custom_baseclass(self):
-        """Ensure DictField working with custom base clases.
-        """
-        class Test(Document):
-            testdict = DictField()
-
-        Test.drop_collection()
-
-        t = Test(testdict={'f': 'Value'})
-        t.save()
-
-        self.assertEqual(
-            Test.objects(testdict__f__startswith='Val').count(), 1)
-        self.assertEqual(Test.objects(testdict__f='Value').count(), 1)
-        Test.drop_collection()
-
-        class Test(Document):
-            testdict = DictField(basecls=StringField)
-
-        t = Test(testdict={'f': 'Value'})
-        t.save()
-
-        self.assertEqual(Test.objects(testdict__f='Value').count(), 1)
-        self.assertEqual(
-            Test.objects(testdict__f__startswith='Val').count(), 1)
-        Test.drop_collection()
-
     def test_bulk(self):
         """Ensure bulk querying by object id returns a proper dict.
         """


### PR DESCRIPTION
The `basecls` attribute that can be given to the DictField constructor isn't doing anything, additionally it is also not documented and confusing with the `field` attribute