### PR TITLE
Handles edge case when EmbeddedDocumentListField receives a Document and not a list

### DIFF
--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -313,11 +313,16 @@ class ComplexBaseField(BaseField):
         if hasattr(value, 'to_python'):
             return value.to_python()
 
+        BaseDocument = _import_class('BaseDocument')
+        if isinstance(value, BaseDocument):
+            # Something is wrong, return the value as it is
+            return value
+
         is_list = False
         if not hasattr(value, 'items'):
             try:
                 is_list = True
-                value = {k: v for k, v in enumerate(value)}
+                value = {idx: v for idx, v in enumerate(value)}
             except TypeError:  # Not iterable return the value
                 return value
 

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -3868,7 +3868,7 @@ class FieldTest(MongoDBTestCase):
         assert isinstance(doc.field, ToEmbedChild)
         assert doc.field == to_embed_child
 
-    def test_invalid_dict_value(self):
+    def test_dict_field_invalid_dict_value(self):
         class DictFieldTest(Document):
             dictionary = DictField(required=True)
 
@@ -3881,6 +3881,22 @@ class FieldTest(MongoDBTestCase):
         test = DictFieldTest(dictionary=False)
         test.dictionary  # Just access to test getter
         self.assertRaises(ValidationError, test.validate)
+
+    def test_dict_field_raises_validation_error_if_wrongly_assign_embedded_doc(self):
+        class DictFieldTest(Document):
+            dictionary = DictField(required=True)
+
+        DictFieldTest.drop_collection()
+
+        class Embedded(EmbeddedDocument):
+            name = StringField()
+
+        embed = Embedded(name='garbage')
+        doc = DictFieldTest(dictionary=embed)
+        with self.assertRaises(ValidationError) as ctx_err:
+            doc.validate()
+        self.assertIn("'dictionary'", str(ctx_err.exception))
+        self.assertIn('Only dictionaries may be used in a DictField', str(ctx_err.exception))
 
     def test_cls_field(self):
         class Animal(Document):
@@ -3979,6 +3995,28 @@ class EmbeddedDocumentListFieldTestCase(MongoDBTestCase):
             self.Comments(author='user2', message='message3'),
             self.Comments(author='user3', message='message1')
         ]).save()
+
+    def test_fails_upon_validate_if_provide_a_doc_instead_of_a_list_of_doc(self):
+        # Relates to Issue #1464
+        comment = self.Comments(author='John')
+
+        class Title(Document):
+            content = StringField()
+
+        # Test with an embeddedDocument instead of a list(embeddedDocument)
+        # It's an edge case but it used to fail with a vague error, making it difficult to troubleshoot it
+        post = self.BlogPost(comments=comment)
+        with self.assertRaises(ValidationError) as ctx_err:
+            post.validate()
+        self.assertIn("'comments'", str(ctx_err.exception))
+        self.assertIn('Only lists and tuples may be used in a list field', str(ctx_err.exception))
+
+        # Test with a Document
+        post = self.BlogPost(comments=Title(content='garbage'))
+        with self.assertRaises(ValidationError) as e:
+            post.validate()
+        self.assertIn("'comments'", str(ctx_err.exception))
+        self.assertIn('Only lists and tuples may be used in a list field', str(ctx_err.exception))
 
     def test_no_keyword_filter(self):
         """


### PR DESCRIPTION
Detect when EmbeddedDocumentListField receives an EmbeddedDocument instance instead of a list. It is a common mistake and the previous error wasn't meaningful (was fired from _from_son). The same applies for DictField.
Fixes #1464