### PR TITLE
fixed TypeError on translated choices

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -1091,6 +1091,6 @@ class BaseDocument(object):
             sep = getattr(field, 'display_sep', ' ')
             values = value if field.__class__.__name__ in ('ListField', 'SortedListField') else [value]
             return sep.join([
-                dict(field.choices).get(val, val)
+                six.text_type(dict(field.choices).get(val, val))
                 for val in values or []])
         return value


### PR DESCRIPTION
join expect strings, but if we use django ugettext_lazy like this:
```
    choices=[(1, _("One")), (2, _("Two"))]
```
there will be `TypeError: sequence item 0: expected string, __proxy__ found`

this commif fixes error by converting label to string