### PR TITLE
Update link to index options

### DIFF
--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -538,7 +538,7 @@ There are a few top level defaults for all indexes that can be set::
 
 
 :attr:`index_options` (Optional)
-    Set any default index options - see the `full options list <http://docs.mongodb.org/manual/reference/method/db.collection.ensureIndex/#db.collection.ensureIndex>`_
+    Set any default index options - see the `full options list <https://docs.mongodb.com/manual/reference/method/db.collection.createIndex/#ensureindex-options>`_
 
 :attr:`index_background` (Optional)
     Set the default value for if an index should be indexed in the background


### PR DESCRIPTION
The previous link goes to a page without the options mentioned.