### PR TITLE
fix side effect from queryset.no_dereference

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -700,7 +700,7 @@ class BaseDocument(object):
 
         fields = cls._fields
         if not _auto_dereference:
-            fields = copy.copy(fields)
+            fields = copy.deepcopy(fields)
 
         for field_name, field in fields.iteritems():
             field._auto_dereference = _auto_dereference

--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -266,13 +266,15 @@ class ComplexBaseField(BaseField):
         ReferenceField = _import_class('ReferenceField')
         GenericReferenceField = _import_class('GenericReferenceField')
         EmbeddedDocumentListField = _import_class('EmbeddedDocumentListField')
-        dereference = (self._auto_dereference and
+
+        auto_dereference = instance._fields[self.name]._auto_dereference
+
+        dereference = (auto_dereference and
                        (self.field is None or isinstance(self.field,
                                                          (GenericReferenceField, ReferenceField))))
 
         _dereference = _import_class('DeReference')()
 
-        self._auto_dereference = instance._fields[self.name]._auto_dereference
         if instance._initialised and dereference and instance._data.get(self.name):
             instance._data[self.name] = _dereference(
                 instance._data.get(self.name), max_depth=1, instance=instance,
@@ -293,7 +295,7 @@ class ComplexBaseField(BaseField):
             value = BaseDict(value, instance, self.name)
             instance._data[self.name] = value
 
-        if (self._auto_dereference and instance._initialised and
+        if (auto_dereference and instance._initialised and
                 isinstance(value, (BaseList, BaseDict)) and
                 not value._dereferenced):
             value = _dereference(

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -1104,9 +1104,9 @@ class ReferenceField(BaseField):
 
         # Get value from document instance if available
         value = instance._data.get(self.name)
-        self._auto_dereference = instance._fields[self.name]._auto_dereference
+        auto_dereference = instance._fields[self.name]._auto_dereference
         # Dereference DBRefs
-        if self._auto_dereference and isinstance(value, DBRef):
+        if auto_dereference and isinstance(value, DBRef):
             if hasattr(value, 'cls'):
                 # Dereference using the class type specified in the reference
                 cls = get_document(value.cls)
@@ -1267,6 +1267,7 @@ class CachedReferenceField(BaseField):
         # Get value from document instance if available
         value = instance._data.get(self.name)
         self._auto_dereference = instance._fields[self.name]._auto_dereference
+
         # Dereference DBRefs
         if self._auto_dereference and isinstance(value, DBRef):
             dereferenced = self.document_type._get_db().dereference(value)


### PR DESCRIPTION
The queryset.no_dereference() method was having side effect on the class Field (descriptor) _auto_dereference attribute. Meaning that existing instances could be impacted by a call to no_dereference and suddenly stop dereferencing. See below:
```
class User(me.Document):
    name = me.StringField()
    
class Organization(me.Document):
    name = me.StringField()
    user = me.ReferenceField(User)

user = User(name='John').save()
Organization(name='GitHub', user=user).save()

org = Organization.objects.first()   # fetch an instance before the no_dereference call
_ = Organization.objects.no_dereference().first() # alters the _auto_dereference of the class field (i.e the ReferenceField descriptor) 
print org.user    # DBRef('user', ObjectId('5b9ec11d4ec5dc58df8290ba')) <-- SHould have been dereferenced
```
Fixes  #1677 (more info in the issue)

Note that:
- this does not fix the no_dereference context manager
- CachedReferenceField & GenericReferenceField suffers from the same bug. I'll fix those in a separate PR