### PR TITLE
Fix side effect of no_dereference on GenericReferenceField

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -1266,10 +1266,10 @@ class CachedReferenceField(BaseField):
 
         # Get value from document instance if available
         value = instance._data.get(self.name)
-        self._auto_dereference = instance._fields[self.name]._auto_dereference
+        auto_dereference = instance._fields[self.name]._auto_dereference
 
         # Dereference DBRefs
-        if self._auto_dereference and isinstance(value, DBRef):
+        if auto_dereference and isinstance(value, DBRef):
             dereferenced = self.document_type._get_db().dereference(value)
             if dereferenced is None:
                 raise DoesNotExist('Trying to dereference unknown document %s' % value)
@@ -1402,8 +1402,8 @@ class GenericReferenceField(BaseField):
 
         value = instance._data.get(self.name)
 
-        self._auto_dereference = instance._fields[self.name]._auto_dereference
-        if self._auto_dereference and isinstance(value, (dict, SON)):
+        auto_dereference = instance._fields[self.name]._auto_dereference
+        if auto_dereference and isinstance(value, (dict, SON)):
             dereferenced = self.dereference(value)
             if dereferenced is None:
                 raise DoesNotExist('Trying to dereference unknown document %s' % value)

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -4720,12 +4720,14 @@ class QuerySetTest(unittest.TestCase):
 
         class User(Document):
             organization = ReferenceField(Organization)
+            organization_gen = GenericReferenceField()
 
         User.drop_collection()
         Organization.drop_collection()
 
         org = Organization(name="whatever").save()
-        User(organization=org).save()
+        User(organization=org,
+             organization_gen=org).save()
 
         qs = User.objects()
         user = qs.first()
@@ -4733,9 +4735,15 @@ class QuerySetTest(unittest.TestCase):
         qs_no_deref = User.objects().no_dereference()
         user_no_deref = qs_no_deref.first()
 
+        # ReferenceField
         no_derf_org = user_no_deref.organization    # was triggering the bug
         self.assertIsInstance(no_derf_org, DBRef)
         self.assertIsInstance(user.organization, Organization)
+
+        # GenericReferenceField
+        no_derf_org_gen = user_no_deref.organization_gen
+        self.assertIsInstance(no_derf_org_gen, dict)
+        self.assertIsInstance(user.organization_gen, Organization)
 
     def test_no_dereference_embedded_doc(self):
 


### PR DESCRIPTION
Similarly to how #1892 fixed the issue for ReferenceField, this PR fixes the issue for GenericReferenceField that is suffering from the exact same issue. See below:
```
class Organization(me.Document):
    name = me.StringField()
    
class User(me.Document):
    name = me.StringField()
    organization = me.GenericReferenceField()

organization = Organization(name='Github').save()
User(name='John', organization=organization).save()

user = User.objects.first()   # fetch an instance before the no_dereference call
user_no_derf = User.objects.no_dereference().first() # alters the _auto_dereference of the class field (i.e the ReferenceField descriptor) 

print(user_no_derf.organization)    # {'_cls': 'Organization', '_ref': DBRef('organization', ObjectId('5baaa27e4ec5dc49f0ffc86a'))} (This is fine)
print(user.organization)    # Should be an Organization instance but is 
                            # {'_cls': 'Organization', '_ref': DBRef('organization', ObjectId('5baaa27e4ec5dc49f0ffc86a'))}


```