### PR TITLE
minor rework in test

### DIFF
--- a/.install_mongodb_on_travis.sh
+++ b/.install_mongodb_on_travis.sh
@@ -3,12 +3,7 @@
 sudo apt-get remove mongodb-org-server
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
 
-if [ "$MONGODB" = "2.4" ]; then
-    echo "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen" | sudo tee /etc/apt/sources.list.d/mongodb.list
-    sudo apt-get update
-    sudo apt-get install mongodb-10gen=2.4.14
-    sudo service mongodb start
-elif [ "$MONGODB" = "2.6" ]; then
+if [ "$MONGODB" = "2.6" ]; then
     echo "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen" | sudo tee /etc/apt/sources.list.d/mongodb.list
     sudo apt-get update
     sudo apt-get install mongodb-org-server=2.6.12
@@ -25,7 +20,7 @@ elif [ "$MONGODB" = "3.2" ]; then
     sudo apt-get install mongodb-org-server=3.2.20
     # service should be started automatically
 else
-    echo "Invalid MongoDB version, expected 2.4, 2.6, or 3.0."
+    echo "Invalid MongoDB version, expected 2.6, 3.0, or 3.2"
     exit 1
 fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,10 @@
 # PyMongo combinations. However, that would result in an overly long build
 # with a very large number of jobs, hence we only test a subset of all the
 # combinations:
-# * MongoDB v2.4 & v3.0 are only tested against Python v2.7 & v3.5.
-# * MongoDB v2.4 is tested against PyMongo v2.7 & v3.x.
-# * MongoDB v3.0 is tested against PyMongo v3.x.
 # * MongoDB v2.6 is currently the "main" version tested against Python v2.7,
-#   v3.5, PyPy & PyPy3, and PyMongo v2.7, v2.8 & v3.x.
-#
+#   v3.5, v3.6, PyPy, and PyMongo v3.x.
+# * MongoDB v3.0 & v3.2 are tested against Python v2.7, v3.5 & v3.6
+#   and Pymongo v3.5 & v3.x
 # Reminder: Update README.rst if you change MongoDB versions we test.
 
 language: python

--- a/mongoengine/queryset/visitor.py
+++ b/mongoengine/queryset/visitor.py
@@ -3,7 +3,7 @@ import copy
 from mongoengine.errors import InvalidQueryError
 from mongoengine.queryset import transform
 
-__all__ = ('Q',)
+__all__ = ('Q', 'QNode')
 
 
 class QNodeVisitor(object):

--- a/tests/document/class_methods.py
+++ b/tests/document/class_methods.py
@@ -5,7 +5,7 @@ from mongoengine import *
 
 from mongoengine.queryset import NULLIFY, PULL
 from mongoengine.connection import get_db
-from tests.utils import needs_mongodb_v26
+from tests.utils import requires_mongodb_gte_26
 
 __all__ = ("ClassMethodsTest", )
 
@@ -188,7 +188,7 @@ class ClassMethodsTest(unittest.TestCase):
         self.assertEqual(BlogPostWithTags.compare_indexes(), { 'missing': [], 'extra': [] })
         self.assertEqual(BlogPostWithCustomField.compare_indexes(), { 'missing': [], 'extra': [] })
 
-    @needs_mongodb_v26
+    @requires_mongodb_gte_26
     def test_compare_indexes_for_text_indexes(self):
         """ Ensure that compare_indexes behaves correctly for text indexes """
 

--- a/tests/document/indexes.py
+++ b/tests/document/indexes.py
@@ -8,7 +8,7 @@ import pymongo
 
 from mongoengine import *
 from mongoengine.connection import get_db
-from tests.utils import get_mongodb_version, needs_mongodb_v26, MONGODB_32, MONGODB_3
+from tests.utils import get_mongodb_version, requires_mongodb_gte_26, MONGODB_32, MONGODB_3
 
 __all__ = ("IndexesTest", )
 
@@ -754,7 +754,7 @@ class IndexesTest(unittest.TestCase):
         except NotUniqueError:
             pass
 
-    def test_unique_and_primary(self):
+    def test_primary_save_duplicate_update_existing_object(self):
         """If you set a field as primary, then unexpected behaviour can occur.
         You won't create a duplicate but you will update an existing document.
         """
@@ -872,7 +872,7 @@ class IndexesTest(unittest.TestCase):
                          info['provider_ids.foo_1_provider_ids.bar_1']['key'])
         self.assertTrue(info['provider_ids.foo_1_provider_ids.bar_1']['sparse'])
 
-    @needs_mongodb_v26
+    @requires_mongodb_gte_26
     def test_text_indexes(self):
         class Book(Document):
             title = DictField()

--- a/tests/document/instance.py
+++ b/tests/document/instance.py
@@ -25,7 +25,7 @@ from mongoengine.queryset import NULLIFY, Q
 from mongoengine.context_managers import switch_db, query_counter
 from mongoengine import signals
 
-from tests.utils import needs_mongodb_v26
+from tests.utils import requires_mongodb_gte_26
 
 TEST_IMAGE_PATH = os.path.join(os.path.dirname(__file__),
                                '../fields/mongoengine.png')
@@ -840,7 +840,7 @@ class InstanceTest(MongoDBTestCase):
 
         self.assertDbEqual([dict(other_doc.to_mongo()), dict(doc.to_mongo())])
 
-    @needs_mongodb_v26
+    @requires_mongodb_gte_26
     def test_modify_with_positional_push(self):
         class BlogPost(Document):
             tags = ListField(StringField())
@@ -3272,7 +3272,7 @@ class InstanceTest(MongoDBTestCase):
 
         person.update(set__height=2.0)
 
-    @needs_mongodb_v26
+    @requires_mongodb_gte_26
     def test_push_with_position(self):
         """Ensure that push with position works properly for an instance."""
         class BlogPost(Document):

--- a/tests/queryset/geo.py
+++ b/tests/queryset/geo.py
@@ -3,7 +3,7 @@ import unittest
 
 from mongoengine import *
 
-from tests.utils import MongoDBTestCase, needs_mongodb_v3
+from tests.utils import MongoDBTestCase, requires_mongodb_gte_3
 
 
 __all__ = ("GeoQueriesTest",)
@@ -72,7 +72,7 @@ class GeoQueriesTest(MongoDBTestCase):
 
     # $minDistance was added in MongoDB v2.6, but continued being buggy
     # until v3.0; skip for older versions
-    @needs_mongodb_v3
+    @requires_mongodb_gte_3
     def test_near_and_min_distance(self):
         """Ensure the "min_distance" operator works alongside the "near"
         operator.
@@ -245,7 +245,7 @@ class GeoQueriesTest(MongoDBTestCase):
 
     # $minDistance was added in MongoDB v2.6, but continued being buggy
     # until v3.0; skip for older versions
-    @needs_mongodb_v3
+    @requires_mongodb_gte_3
     def test_2dsphere_near_and_min_max_distance(self):
         """Ensure "min_distace" and "max_distance" operators work well
         together with the "near" operator in a 2dsphere index.
@@ -329,7 +329,7 @@ class GeoQueriesTest(MongoDBTestCase):
         self._test_embedded(point_field_class=PointField)
 
     # Needs MongoDB > 2.6.4 https://jira.mongodb.org/browse/SERVER-14039
-    @needs_mongodb_v3
+    @requires_mongodb_gte_3
     def test_spherical_geospatial_operators(self):
         """Ensure that spherical geospatial queries are working."""
         class Point(Document):

--- a/tests/queryset/modify.py
+++ b/tests/queryset/modify.py
@@ -2,7 +2,7 @@ import unittest
 
 from mongoengine import connect, Document, IntField, StringField, ListField
 
-from tests.utils import needs_mongodb_v26
+from tests.utils import requires_mongodb_gte_26
 
 __all__ = ("FindAndModifyTest",)
 
@@ -96,7 +96,7 @@ class FindAndModifyTest(unittest.TestCase):
         self.assertEqual(old_doc.to_mongo(), {"_id": 1})
         self.assertDbEqual([{"_id": 0, "value": 0}, {"_id": 1, "value": -1}])
 
-    @needs_mongodb_v26
+    @requires_mongodb_gte_26
     def test_modify_with_push(self):
         class BlogPost(Document):
             tags = ListField(StringField())

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -21,7 +21,7 @@ from mongoengine.python_support import IS_PYMONGO_3
 from mongoengine.queryset import (DoesNotExist, MultipleObjectsReturned,
                                   QuerySet, QuerySetManager, queryset_manager)
 
-from tests.utils import needs_mongodb_v26, skip_pymongo3, get_mongodb_version, MONGODB_32
+from tests.utils import requires_mongodb_gte_26, skip_pymongo3, get_mongodb_version, MONGODB_32
 
 __all__ = ("QuerySetTest",)
 
@@ -576,7 +576,7 @@ class QuerySetTest(unittest.TestCase):
         self.assertEqual(post.comments[0].by, 'joe')
         self.assertEqual(post.comments[0].votes.score, 4)
 
-    @needs_mongodb_v26
+    @requires_mongodb_gte_26
     def test_update_min_max(self):
         class Scores(Document):
             high_score = IntField()
@@ -594,7 +594,7 @@ class QuerySetTest(unittest.TestCase):
         Scores.objects(id=scores.id).update(max__high_score=500)
         self.assertEqual(Scores.objects.get(id=scores.id).high_score, 1000)
 
-    @needs_mongodb_v26
+    @requires_mongodb_gte_26
     def test_update_multiple(self):
         class Product(Document):
             item = StringField()
@@ -1007,7 +1007,7 @@ class QuerySetTest(unittest.TestCase):
         self.assertEqual(person.name, "User A")
         self.assertEqual(person.age, 20)
 
-    @needs_mongodb_v26
+    @requires_mongodb_gte_26
     @skip_pymongo3
     def test_cursor_args(self):
         """Ensures the cursor args can be set as expected
@@ -1986,7 +1986,7 @@ class QuerySetTest(unittest.TestCase):
         pymongo_doc = BlogPost.objects.as_pymongo().first()
         self.assertNotIn('title', pymongo_doc)
 
-    @needs_mongodb_v26
+    @requires_mongodb_gte_26
     def test_update_push_with_position(self):
         """Ensure that the 'push' update with position works properly.
         """
@@ -3278,7 +3278,7 @@ class QuerySetTest(unittest.TestCase):
 
         self.assertEqual(Foo.objects.distinct("bar"), [bar])
 
-    @needs_mongodb_v26
+    @requires_mongodb_gte_26
     def test_text_indexes(self):
         class News(Document):
             title = StringField()
@@ -3365,7 +3365,7 @@ class QuerySetTest(unittest.TestCase):
             'brasil').order_by('$text_score').first()
         self.assertEqual(item.get_text_score(), max_text_score)
 
-    @needs_mongodb_v26
+    @requires_mongodb_gte_26
     def test_distinct_handles_references_to_alias(self):
         register_connection('testdb', 'mongoenginetest2')
 
@@ -4494,7 +4494,7 @@ class QuerySetTest(unittest.TestCase):
         self.assertEqual(bars._cursor._Cursor__read_preference,
                          ReadPreference.SECONDARY_PREFERRED)
 
-    @needs_mongodb_v26
+    @requires_mongodb_gte_26
     def test_read_preference_aggregation_framework(self):
         class Bar(Document):
             txt = StringField()
@@ -5188,7 +5188,7 @@ class QuerySetTest(unittest.TestCase):
             self.assertTrue(Person.objects._has_data(),
                             'Cursor has data and returned False')
 
-    @needs_mongodb_v26
+    @requires_mongodb_gte_26
     def test_queryset_aggregation_framework(self):
         class Person(Document):
             name = StringField()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -61,14 +61,14 @@ def _decorated_with_ver_requirement(func, version):
     return _inner
 
 
-def needs_mongodb_v26(func):
+def requires_mongodb_gte_26(func):
     """Raise a SkipTest exception if we're working with MongoDB version
     lower than v2.6.
     """
     return _decorated_with_ver_requirement(func, MONGODB_26)
 
 
-def needs_mongodb_v3(func):
+def requires_mongodb_gte_3(func):
     """Raise a SkipTest exception if we're working with MongoDB version
     lower than v3.0.
     """


### PR DESCRIPTION
- renamed decorator "needs_mongodb_26" from test suite to "requires_mongodb_gte_26", so that it is clear that the test applies to >= 2.6

- removed reference to mongodb 2.4 in travis since it was removed recently