### PR TITLE
Improve the error message that mentions that Document cant be subclassed

### DIFF
--- a/mongoengine/base/metaclasses.py
+++ b/mongoengine/base/metaclasses.py
@@ -121,7 +121,8 @@ class DocumentMetaclass(type):
                 # inheritance of classes where inheritance is set to False
                 allow_inheritance = base._meta.get('allow_inheritance')
                 if not allow_inheritance and not base._meta.get('abstract'):
-                    raise ValueError('Document %s may not be subclassed' %
+                    raise ValueError('Document %s may not be subclassed. '
+                                     'To enable inheritance, use the "allow_inheritance" meta attribute.' %
                                      base.__name__)
 
         # Get superclasses from last base superclass

--- a/tests/document/inheritance.py
+++ b/tests/document/inheritance.py
@@ -258,9 +258,10 @@ class InheritanceTest(unittest.TestCase):
             name = StringField()
 
         # can't inherit because Animal didn't explicitly allow inheritance
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as cm:
             class Dog(Animal):
                 pass
+        self.assertIn("Document Animal may not be subclassed", str(cm.exception))
 
         # Check that _cls etc aren't present on simple documents
         dog = Animal(name='dog').save()
@@ -277,9 +278,10 @@ class InheritanceTest(unittest.TestCase):
             name = StringField()
             meta = {'allow_inheritance': True}
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as cm:
             class Mammal(Animal):
                 meta = {'allow_inheritance': False}
+        self.assertEqual(str(cm.exception), 'Only direct subclasses of Document may set "allow_inheritance" to False')
 
     def test_allow_inheritance_abstract_document(self):
         """Ensure that abstract documents can set inheritance rules and that
@@ -292,7 +294,7 @@ class InheritanceTest(unittest.TestCase):
         class Animal(FinalDocument):
             name = StringField()
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as cm:
             class Mammal(Animal):
                 pass
 


### PR DESCRIPTION
As suggested by wojcikstefan in https://github.com/MongoEngine/mongoengine/issues/1563#issuecomment-309483935, I've udpated the error message that gets thrown when you subclass a Document without setting allow_inheritance: True