### PR TITLE
Regression bug fix - _cls not set in constructor

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 Development
 ===========
 - (Fill this out as you fix issues and develop your features).
+- Fix `_cls` that is not set properly in Document constructor (regression) #1950
 - Remove deprecated `save()` method and used `insert_one()` #1899
 
 =================

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -91,6 +91,9 @@ class BaseDocument(object):
             value = getattr(self, key, None)
             setattr(self, key, value)
 
+        if '_cls' not in values:
+            self._cls = self._class_name
+
         # Set passed values after initialisation
         if self._dynamic:
             dynamic_data = {}


### PR DESCRIPTION
Fixes #1950 
I actually introduced this in https://github.com/MongoEngine/mongoengine/commit/adfb039ba636202ce034e6104dc27f5bf74601c3#diff-e3e316e6686a3db66d2e679634f57f7f. I guess that was a mistake, my bad...

@erdenezul I think we should release a 0.16.1 with this, what do you think?