### PR TITLE
Fix but with save(write_concern=None) - introduced in 0.16.1

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,11 @@ Development
 - (Fill this out as you fix issues and develop your features).
 
 =================
+Changes in 0.16.2
+=================
+- Fix .save() that fails when called with write_concern=None (regression of 0.16.1) #1958
+
+=================
 Changes in 0.16.1
 =================
 - Fix `_cls` that is not set properly in Document constructor (regression) #1950

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -299,7 +299,7 @@ class Document(six.with_metaclass(TopLevelDocumentMetaclass, BaseDocument)):
         return True
 
     def save(self, force_insert=False, validate=True, clean=True,
-             write_concern={'w': 1}, cascade=None, cascade_kwargs=None,
+             write_concern=None, cascade=None, cascade_kwargs=None,
              _refs=None, save_condition=None, signal_kwargs=None, **kwargs):
         """Save the :class:`~mongoengine.Document` to the database. If the
         document already exists, it will be updated, otherwise it will be
@@ -360,6 +360,9 @@ class Document(six.with_metaclass(TopLevelDocumentMetaclass, BaseDocument)):
 
         if validate:
             self.validate(clean=clean)
+
+        if write_concern is None:
+            write_concern = {'w': 1}
 
         doc = self.to_mongo()
 

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -400,13 +400,17 @@ class QuerySetTest(unittest.TestCase):
         self.Person.drop_collection()
 
         write_concern = {"fsync": True}
-
         author = self.Person.objects.create(name='Test User')
         author.save(write_concern=write_concern)
 
+        # Ensure no regression of #1958
+        author = self.Person(name='Test User2')
+        author.save(write_concern=None)  # will default to {w: 1}
+
         result = self.Person.objects.update(
             set__name='Ross', write_concern={"w": 1})
-        self.assertEqual(result, 1)
+
+        self.assertEqual(result, 2)
         result = self.Person.objects.update(
             set__name='Ross', write_concern={"w": 0})
         self.assertEqual(result, None)


### PR DESCRIPTION
Fixes #1958 
@erdenezul Please have a look when you have a chance as I think we need to move quickly on this before other people hit the bug. I guess we'll trigger a 0.16.2 when it get merged

Please also note that using mutable value for function param should be avoided ([see this post](https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments)) as it can lead to strange behavior. This is not the root cause of this bug though but better to fix this