### PR TITLE
Fix bug #1965 of $position and $push operators do not work with nested list

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -247,3 +247,4 @@ that much better:
  * Erdenezul Batmunkh (https://github.com/erdenezul)
  * Andy Yankovsky (https://github.com/werat)
  * Bastien Gérard (https://github.com/bagerard)
+ * Trevor Hall (https://github.com/tjhall13)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,11 @@ Development
 - (Fill this out as you fix issues and develop your features).
 
 =================
+Changes in 0.16.3
+=================
+- Fix $push with $position operator not working with lists in embedded document #1965
+
+=================
 Changes in 0.16.2
 =================
 - Fix .save() that fails when called with write_concern=None (regression of 0.16.1) #1958

--- a/mongoengine/queryset/transform.py
+++ b/mongoengine/queryset/transform.py
@@ -345,7 +345,7 @@ def update(_doc_cls=None, **update):
             value = {key: {'$each': value}}
         elif op in ('push', 'pushAll'):
             if parts[-1].isdigit():
-                key = parts[0]
+                key = '.'.join(parts[0:-1])
                 position = int(parts[-1])
                 # $position expects an iterable. If pushing a single value,
                 # wrap it in a list.


### PR DESCRIPTION
$position and $push operators do not work with list in an EmbeddedDocument. Set key value to joined parts excluding the index at the end. Added test case