### PR TITLE
Improve DynamicDocument documentation regarding fields with underscore

### DIFF
--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -1016,7 +1016,7 @@ class DynamicDocument(six.with_metaclass(TopLevelDocumentMetaclass, Document)):
 
     .. note::
 
-        There is one caveat on Dynamic Documents: fields cannot start with `_`
+        There is one caveat on Dynamic Documents: undeclared fields cannot start with `_`
     """
 
     # The __metaclass__ attribute is removed by 2to3 when running with Python3


### PR DESCRIPTION
The restriction on fields that can't start with underscore only seem to apply to undeclared fields.
Fixes #1994