### PR TITLE
Add DeprecationWarning for EmbeddedDocument.save & .reload

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Development
 - Fix .only() working improperly after using .count() of the same instance of QuerySet
 - POTENTIAL BREAKING CHANGE: All result fields are now passed, including internal fields (_cls, _id) when using `QuerySet.as_pymongo` #1976
 - Fix InvalidStringData error when using modify on a BinaryField #1127
+- DEPRECATION: `EmbeddedDocument.save` & `.reload` are marked as deprecated and will be removed in a next version of mongoengine #1552
 
 =================
 Changes in 0.16.3

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -90,9 +90,15 @@ class EmbeddedDocument(six.with_metaclass(DocumentMetaclass, BaseDocument)):
         return data
 
     def save(self, *args, **kwargs):
+        warnings.warn("EmbeddedDocument.save is deprecated and will be removed in a next version of mongoengine."
+                      "Use the parent document's .save() or ._instance.save()",
+                      DeprecationWarning, stacklevel=2)
         self._instance.save(*args, **kwargs)
 
     def reload(self, *args, **kwargs):
+        warnings.warn("EmbeddedDocument.reload is deprecated and will be removed in a next version of mongoengine."
+                      "Use the parent document's .reload() or ._instance.reload()",
+                      DeprecationWarning, stacklevel=2)
         self._instance.reload(*args, **kwargs)
 
 


### PR DESCRIPTION
Relates to  #1570 

I also deprecate .reload because just like .save, I believe it confuses users to see that on the EmbeddedDocument