### PR TITLE
Fix Multiple Redundant Dereference Calls

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -250,3 +250,4 @@ that much better:
  * Trevor Hall (https://github.com/tjhall13)
  * Gleb Voropaev (https://github.com/buggyspace)
  * Paulo Amaral (https://github.com/pauloAmaral)
+ * Gaurav Dadhania (https://github.com/GVRV)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,7 @@ Changes in 0.17.0
 - Fix InvalidStringData error when using modify on a BinaryField #1127
 - DEPRECATION: `EmbeddedDocument.save` & `.reload` are marked as deprecated and will be removed in a next version of mongoengine #1552
 - Fix test suite and CI to support MongoDB 3.4 #1445
+- Fix reference fields querying the database on each access if value contains orphan DBRefs
 
 =================
 Changes in 0.16.3

--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -276,11 +276,16 @@ class ComplexBaseField(BaseField):
 
         _dereference = _import_class('DeReference')()
 
-        if instance._initialised and dereference and instance._data.get(self.name):
+        if (instance._initialised and
+                dereference and
+                instance._data.get(self.name) and
+                not getattr(instance._data[self.name], '_dereferenced', False)):
             instance._data[self.name] = _dereference(
                 instance._data.get(self.name), max_depth=1, instance=instance,
                 name=self.name
             )
+            if hasattr(instance._data[self.name], '_dereferenced'):
+                instance._data[self.name]._dereferenced = True
 
         value = super(ComplexBaseField, self).__get__(instance, owner)
 


### PR DESCRIPTION
G'day! 

Thank you for this amazing library! I came across a peculiar behaviour when working with a particular edge case which I'm unsure is a bug or the intended behaviour. 

I have a document with a `ListField` of `GenericLazyReferenceField` instances. Something like: 

```python
class Entity(mongoengine.Document):
    related_to = fields.ListField(fields.GenericLazyReferenceField())
```

If there are references to documents within `Entity.related_to` which have been deleted or cannot be found in the database, each call to `Entity.related_to` will continue to query the database to try and dereference the values. 

For example, if I have an Entity `name="my-entity"` with the following data: 

```
[{'_cls': 'Entity',
  '_ref': DBRef('entities', ObjectId('5c402bb418a6893bd36f5e30'))}]
```

and this `ObjectId('5c402bb418a6893bd36f5e30')` does not exist in the `entities` collection, when I do something like: 

```
my_entity = Entity.objects.get(name="my-entity")
my_entity.related_to  # makes a query to the database to dereference data 
my_entity.related_to  # makes the same query again to try and dereference the data again 
my_entity.related_to  # ... and another query and so forth
```

As per my understanding, we should only be making the query once to dereference the data for a given object. Is this correct?

Please let me know if this is an improvement. If so, I'll clean up this pull request as per the contribution guidelines and look into adding a unit test for this case. If this is in the intended behaviour, feel free to close this pull request. 

Thank you for your time! 🙏 