### PR TITLE
Bump the required version of pymongo to >=3.5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Dependencies
 All of the dependencies can easily be installed via `pip <https://pip.pypa.io/>`_.
 At the very least, you'll need these two packages to use MongoEngine:
 
-- pymongo>=2.7.1
+- pymongo>=3.5
 - six>=1.10.0
 
 If you utilize a ``DateTimeField``, you might also use a more flexible date parser:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 
 Development
 ===========
+- mongoengine now requires pymongo>=3.5 #2017
 - (Fill this out as you fix issues and develop your features).
 
 Changes in 0.17.0

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -451,16 +451,6 @@ class Document(six.with_metaclass(TopLevelDocumentMetaclass, BaseDocument)):
 
             object_id = wc_collection.insert_one(doc).inserted_id
 
-        # In PyMongo 3.0, the save() call calls internally the _update() call
-        # but they forget to return the _id value passed back, therefore getting it back here
-        # Correct behaviour in 2.X and in 3.0.1+ versions
-        if not object_id and pymongo.version_tuple == (3, 0):
-            pk_as_mongo_obj = self._fields.get(self._meta['id_field']).to_mongo(self.pk)
-            object_id = (
-                self._qs.filter(pk=pk_as_mongo_obj).first() and
-                self._qs.filter(pk=pk_as_mongo_obj).first().pk
-            )  # TODO doesn't this make 2 queries?
-
         return object_id
 
     def _get_update_doc(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 nose
-pymongo>=2.7.1
+pymongo>=3.5
 six==1.10.0
 flake8
 flake8-import-order

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
     long_description=LONG_DESCRIPTION,
     platforms=['any'],
     classifiers=CLASSIFIERS,
-    install_requires=['pymongo>=2.7.1', 'six'],
+    install_requires=['pymongo>=3.5', 'six'],
     test_suite='nose.collector',
     **extra_opts
 )

--- a/tests/document/indexes.py
+++ b/tests/document/indexes.py
@@ -565,10 +565,6 @@ class IndexesTest(unittest.TestCase):
         self.assertEqual(BlogPost.objects.count(), 10)
         self.assertEqual(BlogPost.objects.hint().count(), 10)
 
-        # PyMongo 3.0 bug only, works correctly with 2.X and 3.0.1+ versions
-        if pymongo.version != '3.0':
-            self.assertEqual(BlogPost.objects.hint([('tags', 1)]).count(), 10)
-
         if MONGO_VER >= MONGODB_32:
             # Mongo32 throws an error if an index exists (i.e `tags` in our case)
             # and you use hint on an index name that does not exist

--- a/tests/document/json_serialisation.py
+++ b/tests/document/json_serialisation.py
@@ -61,10 +61,6 @@ class TestJson(unittest.TestCase):
         self.assertEqual(doc, Doc.from_json(doc.to_json()))
 
     def test_json_complex(self):
-
-        if pymongo.version_tuple[0] <= 2 and pymongo.version_tuple[1] <= 3:
-            raise SkipTest("Need pymongo 2.4 as has a fix for DBRefs")
-
         class EmbeddedDoc(EmbeddedDocument):
             pass
 

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -4602,9 +4602,6 @@ class QuerySetTest(unittest.TestCase):
         self.assertEqual(doc_objects, Doc.objects.from_json(json_data))
 
     def test_json_complex(self):
-        if pymongo.version_tuple[0] <= 2 and pymongo.version_tuple[1] <= 3:
-            raise SkipTest("Need pymongo 2.4 as has a fix for DBRefs")
-
         class EmbeddedDoc(EmbeddedDocument):
             pass
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -285,14 +285,7 @@ class ConnectionTest(unittest.TestCase):
         """Ensure we can specify a max connection pool size using
         a connection kwarg.
         """
-        # Use "max_pool_size" or "maxpoolsize" depending on PyMongo version
-        # (former was changed to the latter as described in
-        # https://jira.mongodb.org/browse/PYTHON-854).
-        # TODO remove once PyMongo < 3.0 support is dropped
-        if pymongo.version_tuple[0] >= 3:
-            pool_size_kwargs = {'maxpoolsize': 100}
-        else:
-            pool_size_kwargs = {'max_pool_size': 100}
+        pool_size_kwargs = {'maxpoolsize': 100}
 
         conn = connect('mongoenginetest', alias='max_pool_size_via_kwarg', **pool_size_kwargs)
         self.assertEqual(conn.max_pool_size, 100)
@@ -301,9 +294,6 @@ class ConnectionTest(unittest.TestCase):
         """Ensure we can specify a max connection pool size using
         an option in a connection URI.
         """
-        if pymongo.version_tuple[0] == 2 and pymongo.version_tuple[1] < 9:
-            raise SkipTest('maxpoolsize as a URI option is only supported in PyMongo v2.9+')
-
         conn = connect(host='mongodb://localhost/test?maxpoolsize=100', alias='max_pool_size_via_uri')
         self.assertEqual(conn.max_pool_size, 100)
 


### PR DESCRIPTION
Closes #2017

As spotted in the linked issue, we aren't pymongo < 3 compatible since some time. We could simply bump the required pymongo version to >=3.0 but I thought that we could push it further and require pymongo>=3.5 as:
- its the oldest version against which we run the test suite in travis
- recent version of pymongo are fully backward compatible

Let me know what you think @erdenezul, if you prefer that I get back to >=3.0, I'll revert some changes