### PR TITLE
Fix default write concern on save call that was overwriting connection WC

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ Development
     - disconnect now clears `mongoengine.connection._connection_settings`
     - disconnect now clears the cached attribute `Document._collection`
 - POTENTIAL BREAKING CHANGE: Aggregate gives wrong results when used with a queryset having limit and skip #2029
+- Fix the default write concern of .save that was overwriting the connection write concern #568
 - mongoengine now requires pymongo>=3.5 #2017
 - Generate Unique Indices for SortedListField and EmbeddedDocumentListFields #2020
 - connect() fails immediately when db name contains invalid characters #2031 #1718

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -375,7 +375,7 @@ class Document(six.with_metaclass(TopLevelDocumentMetaclass, BaseDocument)):
             self.validate(clean=clean)
 
         if write_concern is None:
-            write_concern = {'w': 1}
+            write_concern = {}
 
         doc = self.to_mongo()
 


### PR DESCRIPTION
Fixes #568 
Unfortunately I didn't find a great way to test this, I could do something with `mock` though, let me know if you want me to go that way