### PR TITLE
Improve perf of Document.save

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Development
 - Add support for MongoDB 3.6 and Python3.7 in travis
 - BREAKING CHANGE: Changed the custom field validator (i.e `validation` parameter of Field) so that it now requires:
     the callable to raise a ValidationError (i.o return True/False).
+- Prevent an expensive call to to_mongo in Document.save() to improve performance #?
 - Fix querying on List(EmbeddedDocument) subclasses fields #1961 #1492
 - Fix querying on (Generic)EmbeddedDocument subclasses fields #475
 - expose `mongoengine.connection.disconnect` and `mongoengine.connection.disconnect_all`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,10 +4,9 @@ Changelog
 
 Development
 ===========
-- Add support for MongoDB 3.6 and Python3.7 in travis
+- Add support for MongoDB 3.6 in travis
 - BREAKING CHANGE: Changed the custom field validator (i.e `validation` parameter of Field) so that it now requires:
     the callable to raise a ValidationError (i.o return True/False).
-- Prevent an expensive call to to_mongo in Document.save() to improve performance #?
 - Improve perf of .save by avoiding a call to to_mongo in Document.save() #2049
 - Fix querying on List(EmbeddedDocument) subclasses fields #1961 #1492
 - Fix querying on (Generic)EmbeddedDocument subclasses fields #475

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Development
 - BREAKING CHANGE: Changed the custom field validator (i.e `validation` parameter of Field) so that it now requires:
     the callable to raise a ValidationError (i.o return True/False).
 - Prevent an expensive call to to_mongo in Document.save() to improve performance #?
+- Improve perf of .save by avoiding a call to to_mongo in Document.save() #2049
 - Fix querying on List(EmbeddedDocument) subclasses fields #1961 #1492
 - Fix querying on (Generic)EmbeddedDocument subclasses fields #475
 - expose `mongoengine.connection.disconnect` and `mongoengine.connection.disconnect_all`

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -293,8 +293,7 @@ class BaseDocument(object):
         """
         Return as SON data ready for use with MongoDB.
         """
-        if not fields:
-            fields = []
+        fields = fields or []
 
         data = SON()
         data['_id'] = None

--- a/tests/document/instance.py
+++ b/tests/document/instance.py
@@ -751,6 +751,10 @@ class InstanceTest(MongoDBTestCase):
                 '_id': post.id
             })
 
+        # Important to disconnect as it could cause some assertions in test_signals
+        # to fail (due to the garbage collection timing of this signal)
+        signals.pre_save_post_validation.disconnect(BlogPost.pre_save_post_validation)
+
     def test_document_clean(self):
         class TestDocument(Document):
             status = StringField()

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -227,6 +227,9 @@ class SignalTests(unittest.TestCase):
 
         self.ExplicitId.objects.delete()
 
+        # Note that there is a chance that the following assert fails in case
+        # some receivers (eventually created in other tests)
+        # gets garbage collected (https://pythonhosted.org/blinker/#blinker.base.Signal.connect)
         self.assertEqual(self.pre_signals, post_signals)
 
     def test_model_signals(self):


### PR DESCRIPTION
Document.save is currently making 2 calls to to_mongo (before and after validation), this is expensive  when objects are very large. Since the first call was only used to identify if the document is created or updated, we could restrict the call with to_mongo(fields=['id'])