### PR TITLE
custom field validator is now expected to raise a ValidationError

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,8 @@ Changelog
 Development
 ===========
 - Add support for MongoDB 3.6 and Python3.7 in travis
+- BREAKING CHANGE: Changed the custom field validator (i.e `validation` parameter of Field) so that it now requires:
+    the callable to raise a ValidationError (i.o return True/False).
 - Fix querying on List(EmbeddedDocument) subclasses fields #1961 #1492
 - Fix querying on (Generic)EmbeddedDocument subclasses fields #475
 - expose `mongoengine.connection.disconnect` and `mongoengine.connection.disconnect_all`

--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -11,7 +11,7 @@ from mongoengine.base.common import UPDATE_OPERATORS
 from mongoengine.base.datastructures import (BaseDict, BaseList,
                                              EmbeddedDocumentList)
 from mongoengine.common import _import_class
-from mongoengine.errors import ValidationError, DeprecatedError
+from mongoengine.errors import DeprecatedError, ValidationError
 
 __all__ = ('BaseField', 'ComplexBaseField', 'ObjectIdField',
            'GeoJsonBaseField')

--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -11,8 +11,7 @@ from mongoengine.base.common import UPDATE_OPERATORS
 from mongoengine.base.datastructures import (BaseDict, BaseList,
                                              EmbeddedDocumentList)
 from mongoengine.common import _import_class
-from mongoengine.errors import ValidationError
-
+from mongoengine.errors import ValidationError, DeprecatedError
 
 __all__ = ('BaseField', 'ComplexBaseField', 'ObjectIdField',
            'GeoJsonBaseField')
@@ -53,8 +52,8 @@ class BaseField(object):
             unique with.
         :param primary_key: Mark this field as the primary key. Defaults to False.
         :param validation: (optional) A callable to validate the value of the
-            field.  Generally this is deprecated in favour of the
-            `FIELD.validate` method
+            field.  The callable takes the value as parameter and should raise
+            a ValidationError if validation fails
         :param choices: (optional) The valid choices
         :param null: (optional) If the field value can be null. If no and there is a default value
             then the default value is set
@@ -226,10 +225,18 @@ class BaseField(object):
         # check validation argument
         if self.validation is not None:
             if callable(self.validation):
-                if not self.validation(value):
-                    self.error('Value does not match custom validation method')
+                try:
+                    # breaking change of 0.18
+                    # Get rid of True/False-type return for the validation method
+                    # in favor of having validation raising a ValidationError
+                    ret = self.validation(value)
+                    if ret is not None:
+                        raise DeprecatedError('validation argument for `%s` must not return anything, '
+                                              'it should raise a ValidationError if validation fails' % self.name)
+                except ValidationError as ex:
+                    self.error(str(ex))
             else:
-                raise ValueError('validation argument for "%s" must be a '
+                raise ValueError('validation argument for `"%s"` must be a '
                                  'callable.' % self.name)
 
         self.validate(value, **kwargs)

--- a/mongoengine/errors.py
+++ b/mongoengine/errors.py
@@ -142,3 +142,8 @@ class ValidationError(AssertionError):
         for k, v in iteritems(self.to_dict()):
             error_dict[generate_key(v)].append(k)
         return ' '.join(['%s: %s' % (k, v) for k, v in iteritems(error_dict)])
+
+
+class DeprecatedError(Exception):
+    """Raise when a user uses a feature that has been Deprecated"""
+    pass

--- a/mongoengine/errors.py
+++ b/mongoengine/errors.py
@@ -6,7 +6,7 @@ from six import iteritems
 __all__ = ('NotRegistered', 'InvalidDocumentError', 'LookUpError',
            'DoesNotExist', 'MultipleObjectsReturned', 'InvalidQueryError',
            'OperationError', 'NotUniqueError', 'FieldDoesNotExist',
-           'ValidationError', 'SaveConditionError')
+           'ValidationError', 'SaveConditionError', 'DeprecatedError')
 
 
 class NotRegistered(Exception):


### PR DESCRIPTION
While checking the coverage, I noticed that the custom `validation` callable that we can give to the field constructor had no test coverage.

I took the opportunity to change the way the callable is expected to work, the callable is now expected to raise a ValidationError (and no onger expect a `False` return) when validation fails. This is a BREAKING CHANGE but IMO it is better as:
- more intuitive and closer to django's implementation
- it allows the user to customize the error message

User that miss the breaking change should notice it very quickly due to the DeprecatedError that is being raised in case they didnt update their `validation` method (cfr diff)