### PR TITLE
Add support for '$nin' when transforming a 'pull' update query.

### DIFF
--- a/mongoengine/queryset/transform.py
+++ b/mongoengine/queryset/transform.py
@@ -281,7 +281,7 @@ def update(_doc_cls=None, **update):
 
             if op == 'pull':
                 if field.required or value is not None:
-                    if match == 'in' and not isinstance(value, dict):
+                    if match in ('in', 'nin') and not isinstance(value, dict):
                         value = _prepare_query_for_iterable(field, op, value)
                     else:
                         value = field.prepare_query_value(op, value)

--- a/tests/queryset/transform.py
+++ b/tests/queryset/transform.py
@@ -276,13 +276,18 @@ class TransformTest(unittest.TestCase):
             title = StringField()
             content = EmbeddedDocumentField(SubDoc)
 
-        word = Word(word='abc', index=1)
-        update = transform.update(MainDoc, pull__content__text=word)
-        self.assertEqual(update, {'$pull': {'content.text': SON([('word', u'abc'), ('index', 1)])}})
+        # word = Word(word='abc', index=1)
+        # update = transform.update(MainDoc, pull__content__text=word)
+        # self.assertEqual(update, {'$pull': {'content.text': SON([('word', u'abc'), ('index', 1)])}})
 
-        update = transform.update(MainDoc, pull__content__heading='xyz')
-        self.assertEqual(update, {'$pull': {'content.heading': 'xyz'}})
+        # update = transform.update(MainDoc, pull__content__heading='xyz')
+        # self.assertEqual(update, {'$pull': {'content.heading': 'xyz'}})
 
+        # update = transform.update(MainDoc, pull__content__text__word__in=['foo', 'bar'])
+        # self.assertEqual(update, {'$pull': {'content.text': {'word': {'$in': ['foo', 'bar']}}}})
+
+        update = transform.update(MainDoc, pull__content__text__word__nin=['foo', 'bar'])
+        self.assertEqual(update, {'$pull': {'content.text': {'word': {'$nin': ['foo', 'bar']}}}})
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/queryset/transform.py
+++ b/tests/queryset/transform.py
@@ -276,15 +276,15 @@ class TransformTest(unittest.TestCase):
             title = StringField()
             content = EmbeddedDocumentField(SubDoc)
 
-        # word = Word(word='abc', index=1)
-        # update = transform.update(MainDoc, pull__content__text=word)
-        # self.assertEqual(update, {'$pull': {'content.text': SON([('word', u'abc'), ('index', 1)])}})
+        word = Word(word='abc', index=1)
+        update = transform.update(MainDoc, pull__content__text=word)
+        self.assertEqual(update, {'$pull': {'content.text': SON([('word', u'abc'), ('index', 1)])}})
 
-        # update = transform.update(MainDoc, pull__content__heading='xyz')
-        # self.assertEqual(update, {'$pull': {'content.heading': 'xyz'}})
+        update = transform.update(MainDoc, pull__content__heading='xyz')
+        self.assertEqual(update, {'$pull': {'content.heading': 'xyz'}})
 
-        # update = transform.update(MainDoc, pull__content__text__word__in=['foo', 'bar'])
-        # self.assertEqual(update, {'$pull': {'content.text': {'word': {'$in': ['foo', 'bar']}}}})
+        update = transform.update(MainDoc, pull__content__text__word__in=['foo', 'bar'])
+        self.assertEqual(update, {'$pull': {'content.text': {'word': {'$in': ['foo', 'bar']}}}})
 
         update = transform.update(MainDoc, pull__content__text__word__nin=['foo', 'bar'])
         self.assertEqual(update, {'$pull': {'content.text': {'word': {'$nin': ['foo', 'bar']}}}})


### PR DESCRIPTION
Consider the following model:

```python
class Word(EmbeddedDocument):
    word = StringField()
    index = IntField()

class SubDoc(EmbeddedDocument):
    heading = ListField(StringField())
    text = EmbeddedDocumentListField(Word)

class MainDoc(Document):
    title = StringField()
    content = EmbeddedDocumentField(SubDoc)
```

If we want to remove all the `Word` list entries in all `MainDoc` records which contain a list of words, you can use:

```
MainDoc.objects().update(pull__content__text__word__in=['foo','bar'])
```

However, right now it is not possible to use the `nin` operator in this context, to remove the entries that do not contain certain words as in:

```
MainDoc.objects().update(pull__content__text__word__nin=['foo','bar'])
```

This PR add support for `nin` operator with a `pull` update.