### PR TITLE
Add optional session parameter to Document.save #1839

### DIFF
--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -313,7 +313,8 @@ class Document(six.with_metaclass(TopLevelDocumentMetaclass, BaseDocument)):
 
     def save(self, force_insert=False, validate=True, clean=True,
              write_concern=None, cascade=None, cascade_kwargs=None,
-             _refs=None, save_condition=None, signal_kwargs=None, **kwargs):
+             _refs=None, save_condition=None, signal_kwargs=None,
+             session=None, **kwargs):
         """Save the :class:`~mongoengine.Document` to the database. If the
         document already exists, it will be updated, otherwise it will be
         created.
@@ -341,6 +342,8 @@ class Document(six.with_metaclass(TopLevelDocumentMetaclass, BaseDocument)):
             Raises :class:`OperationError` if the conditions are not satisfied
         :param signal_kwargs: (optional) kwargs dictionary to be passed to
             the signal calls.
+        :param session: (optional) a
+            :class:`~pymongo.client_session.ClientSession`.
 
         .. versionchanged:: 0.5
             In existing documents it only saves changed fields using
@@ -392,10 +395,10 @@ class Document(six.with_metaclass(TopLevelDocumentMetaclass, BaseDocument)):
         try:
             # Save a new document or update an existing one
             if created:
-                object_id = self._save_create(doc, force_insert, write_concern)
+                object_id = self._save_create(doc, force_insert, write_concern, session)
             else:
                 object_id, created = self._save_update(doc, save_condition,
-                                                       write_concern)
+                                                       write_concern, session)
 
             if cascade is None:
                 cascade = (self._meta.get('cascade', False) or
@@ -438,7 +441,7 @@ class Document(six.with_metaclass(TopLevelDocumentMetaclass, BaseDocument)):
 
         return self
 
-    def _save_create(self, doc, force_insert, write_concern):
+    def _save_create(self, doc, force_insert, write_concern, session=None):
         """Save a new document.
 
         Helper method, should only be used inside save().
@@ -446,16 +449,16 @@ class Document(six.with_metaclass(TopLevelDocumentMetaclass, BaseDocument)):
         collection = self._get_collection()
         with set_write_concern(collection, write_concern) as wc_collection:
             if force_insert:
-                return wc_collection.insert_one(doc).inserted_id
+                return wc_collection.insert_one(doc, session=session).inserted_id
             # insert_one will provoke UniqueError alongside save does not
             # therefore, it need to catch and call replace_one.
             if '_id' in doc:
                 raw_object = wc_collection.find_one_and_replace(
-                    {'_id': doc['_id']}, doc)
+                    {'_id': doc['_id']}, doc, session=session)
                 if raw_object:
                     return doc['_id']
 
-            object_id = wc_collection.insert_one(doc).inserted_id
+            object_id = wc_collection.insert_one(doc, session=session).inserted_id
 
         return object_id
 
@@ -474,7 +477,7 @@ class Document(six.with_metaclass(TopLevelDocumentMetaclass, BaseDocument)):
 
         return update_doc
 
-    def _save_update(self, doc, save_condition, write_concern):
+    def _save_update(self, doc, save_condition, write_concern, session=None):
         """Update an existing document.
 
         Helper method, should only be used inside save().
@@ -504,7 +507,7 @@ class Document(six.with_metaclass(TopLevelDocumentMetaclass, BaseDocument)):
             upsert = save_condition is None
             with set_write_concern(collection, write_concern) as wc_collection:
                 last_error = wc_collection.update_one(select_dict, update_doc,
-                                           upsert=upsert).raw_result
+                                           upsert=upsert, session=session).raw_result
             if not upsert and last_error['n'] == 0:
                 raise SaveConditionError('Race condition preventing'
                                          ' document update detected')

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -502,8 +502,9 @@ class Document(six.with_metaclass(TopLevelDocumentMetaclass, BaseDocument)):
         update_doc = self._get_update_doc()
         if update_doc:
             upsert = save_condition is None
-            last_error = collection.update(select_dict, update_doc,
-                                           upsert=upsert, **write_concern)
+            with set_write_concern(collection, write_concern) as wc_collection:
+                last_error = wc_collection.update_one(select_dict, update_doc,
+                                           upsert=upsert).raw_result
             if not upsert and last_error['n'] == 0:
                 raise SaveConditionError('Race condition preventing'
                                          ' document update detected')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,7 @@ from nose.plugins.skip import SkipTest
 
 from mongoengine import connect
 from mongoengine.connection import get_db, disconnect_all
-from mongoengine.mongodb_support import get_mongodb_version, MONGODB_26, MONGODB_3, MONGODB_32, MONGODB_34
+from mongoengine.mongodb_support import get_mongodb_version, MONGODB_26, MONGODB_3, MONGODB_32, MONGODB_34, MONGODB_36
 from mongoengine.pymongo_support import IS_PYMONGO_3
 
 
@@ -53,6 +53,11 @@ def _decorated_with_ver_requirement(func, mongo_version_req, oper):
     _inner.__doc__ = func.__doc__
     return _inner
 
+def requires_mongodb_gte_36(func):
+    """Raise a SkipTest exception if we're working with MongoDB version
+    lower than v36
+    """
+    return _decorated_with_ver_requirement(func, MONGODB_36, oper=operator.ge)
 
 def requires_mongodb_gte_34(func):
     """Raise a SkipTest exception if we're working with MongoDB version


### PR DESCRIPTION
* Added an optional session parameter to Document.save method.
* Added a test to ensure the session parameter allows documents to be saved.

 [Session](https://docs.mongodb.com/manual/reference/method/Session/) was added in MongoDB v3.6.0.

This pull request goes some of the way towards supporting MongoDB 4.0 transactions, issue [#1839](https://github.com/MongoEngine/mongoengine/issues/1839).