### PR TITLE
Py2py3 fix compat

### DIFF
--- a/.landscape.yml
+++ b/.landscape.yml
@@ -5,17 +5,12 @@ pylint:
 
     options:
         additional-builtins:
-            # add xrange and long as valid built-ins. In Python 3, xrange is
-            # translated into range and long is translated into int via 2to3 (see
-            # "use_2to3" in setup.py). This should be removed when we drop Python
-            # 2 support (which probably won't happen any time soon).
-            - xrange
+            # add long as valid built-ins.
             - long
 
 pyflakes:
     disable:
-        # undefined variables are already covered by pylint (and exclude
-        # xrange & long)
+        # undefined variables are already covered by pylint (and exclude long)
         - F821
 
 ignore-paths:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ python:
 
 dist: xenial
 
+dist: xenial
+
 env:
   global:
     - MONGODB_3_4=3.4.17

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,9 +80,6 @@ before_script:
 script:
   - tox -e $(echo py$TRAVIS_PYTHON_VERSION-mg$PYMONGO | tr -d . | sed -e 's/pypypy/pypy/') -- -a "--cov=mongoengine"
 
-# For now only submit coveralls for Python v2.7. Python v3.x currently shows
-# 0% coverage. That's caused by 'use_2to3', which builds the py3-compatible
-# code in a separate dir and runs tests on that.
 after_success:
 - coveralls --verbose
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ install:
 before_script:
   - mkdir ${PWD}/mongodb-linux-x86_64-${MONGODB}/data
   - ${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --dbpath ${PWD}/mongodb-linux-x86_64-${MONGODB}/data --logpath ${PWD}/mongodb-linux-x86_64-${MONGODB}/mongodb.log --fork
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then flake8 .; else echo "flake8 only runs on py27"; fi   # Run flake8 for Python 2.7 only
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then flake8 .; else echo "flake8 only runs on py37"; fi         # Run flake8 for Python 3.7 only
   - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then black --check .; else echo "black only runs on py37"; fi   # Run black for Python 3.7 only
   - mongo --eval 'db.version();'    # Make sure mongo is awake
 
@@ -84,7 +84,7 @@ script:
 # 0% coverage. That's caused by 'use_2to3', which builds the py3-compatible
 # code in a separate dir and runs tests on that.
 after_success:
-- if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then coveralls --verbose; else echo "coveralls only sent for py27"; fi
+- coveralls --verbose
 
 notifications:
   irc: irc.freenode.org#mongoengine

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -22,11 +22,19 @@ Supported Interpreters
 
 MongoEngine supports CPython 2.7 and newer. Language
 features not supported by all interpreters can not be used.
-The codebase is written in python 2 so you must be using python 2
-when developing new features. Compatibility of the library with Python 3
-relies on the 2to3 package that gets executed as part of the installation
-build. You should ensure that your code is properly converted by
-`2to3 <http://docs.python.org/library/2to3.html>`_.
+The codebase is written in a compatible manner for python 2 & 3 so it
+is important that this is taken into account when it comes to discrepencies
+between the 2 versions (check this https://python-future.org/compatible_idioms.html).
+Travis runs run the tests against the different versions as a safety net.
+
+Python 2/3 compatibility
+----------------------
+
+The codebase is written in a compatible manner for python 2 & 3 so it
+is important that this is taken into account when it comes to discrepencies
+between the 2 versions (check this https://python-future.org/compatible_idioms.html).
+Travis runs run the tests against the different versions as a safety net.
+
 
 Style Guide
 -----------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -28,8 +28,8 @@ Python 2/3 compatibility
 
 The codebase is written in a compatible manner for python 2 & 3 so it
 is important that this is taken into account when it comes to discrepencies
-between the 2 versions (check this https://python-future.org/compatible_idioms.html).
-Travis runs run the tests against the different versions as a safety net.
+between the two versions (see https://python-future.org/compatible_idioms.html).
+Travis runs the tests against different Python versions as a safety net.
 
 
 Style Guide

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -22,10 +22,6 @@ Supported Interpreters
 
 MongoEngine supports CPython 2.7 and newer. Language
 features not supported by all interpreters can not be used.
-The codebase is written in a compatible manner for python 2 & 3 so it
-is important that this is taken into account when it comes to discrepencies
-between the 2 versions (check this https://python-future.org/compatible_idioms.html).
-Travis runs run the tests against the different versions as a safety net.
 
 Python 2/3 compatibility
 ----------------------

--- a/benchmarks/test_basic_doc_ops.py
+++ b/benchmarks/test_basic_doc_ops.py
@@ -135,7 +135,6 @@ def test_big_doc():
         % (timeit(create_and_delete_company, 10) * 10 ** 3)
     )
 
-
 if __name__ == "__main__":
     test_basic()
     print("-" * 100)

--- a/benchmarks/test_basic_doc_ops.py
+++ b/benchmarks/test_basic_doc_ops.py
@@ -135,6 +135,7 @@ def test_big_doc():
         % (timeit(create_and_delete_company, 10) * 10 ** 3)
     )
 
+
 if __name__ == "__main__":
     test_basic()
     print("-" * 100)

--- a/benchmarks/test_inserts.py
+++ b/benchmarks/test_inserts.py
@@ -3,13 +3,17 @@ import timeit
 
 def main():
     setup = """
+from builtins import range
+
 from pymongo import MongoClient
+
 connection = MongoClient()
 connection.drop_database('mongoengine_benchmark_test')
 """
 
     stmt = """
 from pymongo import MongoClient
+
 connection = MongoClient()
 
 db = connection.mongoengine_benchmark_test
@@ -55,7 +59,10 @@ myNoddys = noddy.find()
     print("{}s".format(t.timeit(1)))
 
     setup = """
+from builtins import range
+
 from pymongo import MongoClient
+
 connection = MongoClient()
 connection.drop_database('mongoengine_benchmark_test')
 connection.close()

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 Development
 ===========
 - (Fill this out as you fix issues and develop your features).
+- Codebase is now compatible with both Python2 and Python3 (no more relying on 2to3 during installation) #2087
 - Documentation improvements:
     - Documented how `pymongo.monitoring` can be used to log all queries issued by MongoEngine to the driver.
 - BREAKING CHANGE: ``class_check`` and ``read_preference`` keyword arguments are no longer available when filtering a ``QuerySet``. #2112

--- a/mongoengine/base/datastructures.py
+++ b/mongoengine/base/datastructures.py
@@ -422,10 +422,10 @@ class StrictDict(object):
         return len(list(iteritems(self)))
 
     def __eq__(self, other):
-        return self.items() == other.items()
+        return list(self.items()) == list(other.items())
 
     def __ne__(self, other):
-        return self.items() != other.items()
+        return list(self.items()) != list(other.items())
 
     @classmethod
     def create(cls, allowed_keys):

--- a/mongoengine/base/datastructures.py
+++ b/mongoengine/base/datastructures.py
@@ -426,7 +426,7 @@ class StrictDict(object):
         return listitems(self) == listitems(other)
 
     def __ne__(self, other):
-        return not(self == other)
+        return not (self == other)
 
     @classmethod
     def create(cls, allowed_keys):

--- a/mongoengine/base/datastructures.py
+++ b/mongoengine/base/datastructures.py
@@ -1,6 +1,7 @@
 import weakref
 
 from bson import DBRef
+from future.utils import listitems
 import six
 from six import iteritems
 
@@ -422,10 +423,10 @@ class StrictDict(object):
         return len(list(iteritems(self)))
 
     def __eq__(self, other):
-        return list(self.items()) == list(other.items())
+        return listitems(self) == listitems(other)
 
     def __ne__(self, other):
-        return list(self.items()) != list(other.items())
+        return not(self == other)
 
     @classmethod
     def create(cls, allowed_keys):

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -3,6 +3,7 @@ import numbers
 from functools import partial
 
 from bson import DBRef, ObjectId, SON, json_util
+from future.utils import listitems
 import pymongo
 import six
 from six import iteritems
@@ -670,7 +671,7 @@ class BaseDocument(object):
                 del set_data["_id"]
 
         # Determine if any changed items were actually unset.
-        for path, value in list(set_data.items()):
+        for path, value in listitems(set_data):
             if value or isinstance(
                 value, (numbers.Number, bool)
             ):  # Account for 0 and True that are truthy

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -92,7 +92,7 @@ class BaseDocument(object):
         # if so raise an Exception.
         if not self._dynamic and (self._meta.get("strict", True) or _created):
             _undefined_fields = set(values.keys()) - set(
-                self._fields.keys() + ["id", "pk", "_cls", "_text_score"]
+                list(self._fields.keys()) + ["id", "pk", "_cls", "_text_score"]
             )
             if _undefined_fields:
                 msg = ('The fields "{0}" do not exist on the document "{1}"').format(
@@ -670,7 +670,7 @@ class BaseDocument(object):
                 del set_data["_id"]
 
         # Determine if any changed items were actually unset.
-        for path, value in set_data.items():
+        for path, value in list(set_data.items()):
             if value or isinstance(
                 value, (numbers.Number, bool)
             ):  # Account for 0 and True that are truthy

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -71,7 +71,6 @@ class EmbeddedDocument(six.with_metaclass(DocumentMetaclass, BaseDocument)):
 
     __slots__ = ("_instance",)
 
-    # The __metaclass__ attribute is removed by 2to3 when running with Python3
     # my_metaclass is defined so that metaclass can be queried in Python 2 & 3
     my_metaclass = DocumentMetaclass
 
@@ -156,7 +155,6 @@ class Document(six.with_metaclass(TopLevelDocumentMetaclass, BaseDocument)):
     in the :attr:`meta` dictionary.
     """
 
-    # The __metaclass__ attribute is removed by 2to3 when running with Python3
     # my_metaclass is defined so that metaclass can be queried in Python 2 & 3
     my_metaclass = TopLevelDocumentMetaclass
 
@@ -1045,7 +1043,6 @@ class DynamicDocument(six.with_metaclass(TopLevelDocumentMetaclass, Document)):
         There is one caveat on Dynamic Documents: undeclared fields cannot start with `_`
     """
 
-    # The __metaclass__ attribute is removed by 2to3 when running with Python3
     # my_metaclass is defined so that metaclass can be queried in Python 2 & 3
     my_metaclass = TopLevelDocumentMetaclass
 
@@ -1069,7 +1066,6 @@ class DynamicEmbeddedDocument(six.with_metaclass(DocumentMetaclass, EmbeddedDocu
     information about dynamic documents.
     """
 
-    # The __metaclass__ attribute is removed by 2to3 when running with Python3
     # my_metaclass is defined so that metaclass can be queried in Python 2 & 3
     my_metaclass = DocumentMetaclass
 

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -8,6 +8,7 @@ import uuid
 from operator import itemgetter
 
 from bson import Binary, DBRef, ObjectId, SON
+from bson.int64 import Int64
 import gridfs
 import pymongo
 from pymongo import ReturnDocument
@@ -20,11 +21,6 @@ except ImportError:
     dateutil = None
 else:
     import dateutil.parser
-
-try:
-    from bson.int64 import Int64
-except ImportError:
-    Int64 = long
 
 
 from mongoengine.base import (
@@ -53,8 +49,6 @@ except ImportError:
     ImageOps = None
 
 if six.PY3:
-    # Useless as long as 2to3 gets executed
-    # as it turns `long` into `int` blindly
     long = int
 
 

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -10,6 +10,7 @@ from operator import itemgetter
 from bson import Binary, DBRef, ObjectId, SON
 from bson.int64 import Int64
 import gridfs
+from past.builtins import long
 import pymongo
 from pymongo import ReturnDocument
 import six
@@ -47,9 +48,6 @@ try:
 except ImportError:
     Image = None
     ImageOps = None
-
-if six.PY3:
-    long = int
 
 
 __all__ = (

--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -989,7 +989,7 @@ class BaseQuerySet(object):
         .. versionchanged:: 0.5 - Added subfield support
         """
         fields = {f: QueryFieldList.ONLY for f in fields}
-        self.only_fields = fields.keys()
+        self.only_fields = list(fields.keys())
         return self.fields(True, **fields)
 
     def exclude(self, *fields):

--- a/setup.py
+++ b/setup.py
@@ -118,8 +118,8 @@ extra_opts = {
         "Pillow>=2.0.0",
     ],
 }
+
 if sys.version_info[0] == 3:
-    extra_opts["use_2to3"] = True
     if "test" in sys.argv:
         extra_opts["packages"] = find_packages()
         extra_opts["package_data"] = {
@@ -143,7 +143,7 @@ setup(
     long_description=LONG_DESCRIPTION,
     platforms=["any"],
     classifiers=CLASSIFIERS,
-    install_requires=["pymongo>=3.4", "six>=1.10.0"],
+    install_requires=['pymongo>=3.4', 'six', 'future'],
     cmdclass={"test": PyTest},
     **extra_opts
 )

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ setup(
     long_description=LONG_DESCRIPTION,
     platforms=["any"],
     classifiers=CLASSIFIERS,
-    install_requires=['pymongo>=3.4', 'six', 'future'],
+    install_requires=["pymongo>=3.4", "six", "future"],
     cmdclass={"test": PyTest},
     **extra_opts
 )

--- a/tests/fields/test_embedded_document_field.py
+++ b/tests/fields/test_embedded_document_field.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from builtins import str
+
 import pytest
 
 from mongoengine import (
@@ -75,7 +77,7 @@ class TestEmbeddedDocumentField(MongoDBTestCase):
         # Test non exiting attribute
         with pytest.raises(InvalidQueryError) as exc_info:
             Person.objects(settings__notexist="bar").first()
-        assert unicode(exc_info.value) == u'Cannot resolve field "notexist"'
+        assert str(exc_info.value) == u'Cannot resolve field "notexist"'
 
         with pytest.raises(LookUpError):
             Person.objects.only("settings.notexist")
@@ -111,7 +113,7 @@ class TestEmbeddedDocumentField(MongoDBTestCase):
         # Test non exiting attribute
         with pytest.raises(InvalidQueryError) as exc_info:
             assert Person.objects(settings__notexist="bar").first().id == p.id
-        assert unicode(exc_info.value) == u'Cannot resolve field "notexist"'
+        assert str(exc_info.value) == u'Cannot resolve field "notexist"'
 
         # Test existing attribute
         assert Person.objects(settings__base_foo="basefoo").first().id == p.id
@@ -319,7 +321,7 @@ class TestGenericEmbeddedDocumentField(MongoDBTestCase):
         # Test non exiting attribute
         with pytest.raises(InvalidQueryError) as exc_info:
             Person.objects(settings__notexist="bar").first()
-        assert unicode(exc_info.value) == u'Cannot resolve field "notexist"'
+        assert str(exc_info.value) == u'Cannot resolve field "notexist"'
 
         with pytest.raises(LookUpError):
             Person.objects.only("settings.notexist")
@@ -347,7 +349,7 @@ class TestGenericEmbeddedDocumentField(MongoDBTestCase):
         # Test non exiting attribute
         with pytest.raises(InvalidQueryError) as exc_info:
             assert Person.objects(settings__notexist="bar").first().id == p.id
-        assert unicode(exc_info.value) == u'Cannot resolve field "notexist"'
+        assert str(exc_info.value) == u'Cannot resolve field "notexist"'
 
         # Test existing attribute
         assert Person.objects(settings__base_foo="basefoo").first().id == p.id

--- a/tests/fields/test_long_field.py
+++ b/tests/fields/test_long_field.py
@@ -1,11 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
+from bson.int64 import Int64
 import six
-
-try:
-    from bson.int64 import Int64
-except ImportError:
-    Int64 = long
 
 from mongoengine import *
 from mongoengine.connection import get_db

--- a/tests/fields/test_sequence_field.py
+++ b/tests/fields/test_sequence_field.py
@@ -21,7 +21,7 @@ class TestSequenceField(MongoDBTestCase):
         assert c["next"] == 10
 
         ids = [i.id for i in Person.objects]
-        assert ids == range(1, 11)
+        assert ids == list(range(1, 11))
 
         c = self.db["mongoengine.counters"].find_one({"_id": "person.id"})
         assert c["next"] == 10
@@ -76,7 +76,7 @@ class TestSequenceField(MongoDBTestCase):
         assert c["next"] == 10
 
         ids = [i.id for i in Person.objects]
-        assert ids == range(1, 11)
+        assert ids == list(range(1, 11))
 
         c = self.db["mongoengine.counters"].find_one({"_id": "jelly.id"})
         assert c["next"] == 10
@@ -101,10 +101,10 @@ class TestSequenceField(MongoDBTestCase):
         assert c["next"] == 10
 
         ids = [i.id for i in Person.objects]
-        assert ids == range(1, 11)
+        assert ids == list(range(1, 11))
 
         counters = [i.counter for i in Person.objects]
-        assert counters == range(1, 11)
+        assert counters == list(range(1, 11))
 
         c = self.db["mongoengine.counters"].find_one({"_id": "person.id"})
         assert c["next"] == 10
@@ -166,10 +166,10 @@ class TestSequenceField(MongoDBTestCase):
         assert c["next"] == 10
 
         ids = [i.id for i in Person.objects]
-        assert ids == range(1, 11)
+        assert ids == list(range(1, 11))
 
         id = [i.id for i in Animal.objects]
-        assert id == range(1, 11)
+        assert id == list(range(1, 11))
 
         c = self.db["mongoengine.counters"].find_one({"_id": "person.id"})
         assert c["next"] == 10
@@ -193,7 +193,7 @@ class TestSequenceField(MongoDBTestCase):
         assert c["next"] == 10
 
         ids = [i.id for i in Person.objects]
-        assert ids == map(str, range(1, 11))
+        assert ids == [str(i) for i in range(1, 11)]
 
         c = self.db["mongoengine.counters"].find_one({"_id": "person.id"})
         assert c["next"] == 10

--- a/tests/fields/test_sequence_field.py
+++ b/tests/fields/test_sequence_field.py
@@ -267,12 +267,12 @@ class TestSequenceField(MongoDBTestCase):
         foo = Foo(name="Foo")
         foo.save()
 
-        assert not (
-            "base.counter" in self.db["mongoengine.counters"].find().distinct("_id")
+        assert (
+            "base.counter" not in self.db["mongoengine.counters"].find().distinct("_id")
         )
-        assert ("foo.counter" and "bar.counter") in self.db[
-            "mongoengine.counters"
-        ].find().distinct("_id")
+        existing_counters = self.db["mongoengine.counters"].find().distinct("_id")
+        assert "foo.counter" in existing_counters
+        assert "bar.counter" in existing_counters
         assert foo.counter == bar.counter
         assert foo._fields["counter"].owner_document == Foo
         assert bar._fields["counter"].owner_document == Bar

--- a/tests/fields/test_sequence_field.py
+++ b/tests/fields/test_sequence_field.py
@@ -267,8 +267,8 @@ class TestSequenceField(MongoDBTestCase):
         foo = Foo(name="Foo")
         foo.save()
 
-        assert (
-            "base.counter" not in self.db["mongoengine.counters"].find().distinct("_id")
+        assert "base.counter" not in self.db["mongoengine.counters"].find().distinct(
+            "_id"
         )
         existing_counters = self.db["mongoengine.counters"].find().distinct("_id")
         assert "foo.counter" in existing_counters

--- a/tests/fields/test_url_field.py
+++ b/tests/fields/test_url_field.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+from builtins import str
+
 from mongoengine import *
 
 from tests.utils import MongoDBTestCase
@@ -35,9 +37,8 @@ class TestURLField(MongoDBTestCase):
         with pytest.raises(ValidationError) as exc_info:
             link.validate()
         assert (
-            unicode(exc_info.value)
-            == u"ValidationError (Link:None) (Invalid URL: http://\u043f\u0440\u0438\u0432\u0435\u0442.com: ['url'])"
-        )
+            str(exc_info.exception)
+            == u"ValidationError (Link:None) (Invalid URL: http://\u043f\u0440\u0438\u0432\u0435\u0442.com: ['url'])")
 
     def test_url_scheme_validation(self):
         """Ensure that URLFields validate urls with specific schemes properly.

--- a/tests/fields/test_url_field.py
+++ b/tests/fields/test_url_field.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
-import pytest
-
 from builtins import str
 
-from mongoengine import *
+import pytest
 
+from mongoengine import *
 from tests.utils import MongoDBTestCase
 
 
@@ -37,8 +36,9 @@ class TestURLField(MongoDBTestCase):
         with pytest.raises(ValidationError) as exc_info:
             link.validate()
         assert (
-            str(exc_info.exception)
-            == u"ValidationError (Link:None) (Invalid URL: http://\u043f\u0440\u0438\u0432\u0435\u0442.com: ['url'])")
+            str(exc_info.value)
+            == u"ValidationError (Link:None) (Invalid URL: http://\u043f\u0440\u0438\u0432\u0435\u0442.com: ['url'])"
+        )
 
     def test_url_scheme_validation(self):
         """Ensure that URLFields validate urls with specific schemes properly.

--- a/tests/queryset/test_queryset.py
+++ b/tests/queryset/test_queryset.py
@@ -110,7 +110,7 @@ class TestQueryset(unittest.TestCase):
         # Filter people by age
         people = self.Person.objects(age=20)
         assert people.count() == 1
-        person = people.next()
+        person = next(people)
         assert person == user_a
         assert person.name == "User A"
         assert person.age == 20
@@ -2768,7 +2768,7 @@ class TestQueryset(unittest.TestCase):
         )
 
         # start a map/reduce
-        cursor.next()
+        next(cursor)
 
         results = Person.objects.map_reduce(
             map_f=map_person,
@@ -4395,7 +4395,7 @@ class TestQueryset(unittest.TestCase):
         # Use a query to filter the people found to just person1
         people = self.Person.objects(age=20).scalar("name")
         assert people.count() == 1
-        person = people.next()
+        person = next(people)
         assert person == "User A"
 
         # Test limit
@@ -5309,7 +5309,7 @@ class TestQueryset(unittest.TestCase):
         if not test:
             raise AssertionError("Cursor has data and returned False")
 
-        queryset.next()
+        next(queryset)
         if not queryset:
             raise AssertionError(
                 "Cursor has data and it must returns True, even in the last item."

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -58,7 +58,9 @@ class TestSignal(unittest.TestCase):
 
             @classmethod
             def post_save(cls, sender, document, **kwargs):
-                dirty_keys = list(document._delta()[0].keys()) + list(document._delta()[1].keys())
+                dirty_keys = list(document._delta()[0].keys()) + list(
+                    document._delta()[1].keys()
+                )
                 signal_output.append("post_save signal, %s" % document)
                 signal_output.append("post_save dirty keys, %s" % dirty_keys)
                 if kwargs.pop("created", False):

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -58,7 +58,7 @@ class TestSignal(unittest.TestCase):
 
             @classmethod
             def post_save(cls, sender, document, **kwargs):
-                dirty_keys = document._delta()[0].keys() + document._delta()[1].keys()
+                dirty_keys = list(document._delta()[0].keys()) + list(document._delta()[1].keys())
                 signal_output.append("post_save signal, %s" % document)
                 signal_output.append("post_save dirty keys, %s" % dirty_keys)
                 if kwargs.pop("created", False):


### PR DESCRIPTION
This PR should fix the legacy `python2-only` codebase and the fact that we had to run 2to3 as part of the installation of mongoengine on python3 env.
Note that update was listed on that page: https://github.com/MongoEngine/mongoengine/wiki/Towards-1.0

I'll comment my own PR in order to point out some part of the codebase that I'd like you to validate