### PR TITLE
Bump version number and update changelog for 0.18.1

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,8 +5,13 @@ Changelog
 
 Development
 ===========
-- Add Python 3.7 in travis #2058
 - (Fill this out as you fix issues and develop your features).
+
+Changes in 0.18.1
+=================
+- Fix a bug introduced in 0.18.0 which was causing `.save()` to update all the fields
+    instead of updating only the modified fields. This gug only occurs when using custom pk #2082
+- Add Python 3.7 in travis #2058
 
 Changes in 0.18.0
 =================

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,7 @@ Development
 Changes in 0.18.1
 =================
 - Fix a bug introduced in 0.18.0 which was causing `.save()` to update all the fields
-    instead of updating only the modified fields. This gug only occurs when using custom pk #2082
+    instead of updating only the modified fields. This bug only occurs when using custom pk #2082
 - Add Python 3.7 in travis #2058
 
 Changes in 0.18.0

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -23,7 +23,7 @@ __all__ = (list(document.__all__) + list(fields.__all__) +
            list(signals.__all__) + list(errors.__all__))
 
 
-VERSION = (0, 18, 0)
+VERSION = (0, 18, 1)
 
 
 def get_version():


### PR DESCRIPTION
Hi @wojcikstefan @erdenezul , 0.18.0 suffered from a bug (#2082) and we need to release a 0.18.1 asap.

The bug only affects models with custom primary keys, let me know if you have suggestion to this.
I checked the other commits that were merged since 0.18.0 and it mainly update to docs or tests so it should be safe to include them in 0.18.1