### PR TITLE
remove pymongo deprecated methods: find_and_modify & remove

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -10,6 +10,7 @@ from operator import itemgetter
 from bson import Binary, DBRef, ObjectId, SON
 import gridfs
 import pymongo
+from pymongo import ReturnDocument
 import six
 from six import iteritems
 
@@ -1964,10 +1965,12 @@ class SequenceField(BaseField):
         sequence_name = self.get_sequence_name()
         sequence_id = '%s.%s' % (sequence_name, self.name)
         collection = get_db(alias=self.db_alias)[self.collection_name]
-        counter = collection.find_and_modify(query={'_id': sequence_id},
-                                             update={'$inc': {'next': 1}},
-                                             new=True,
-                                             upsert=True)
+
+        counter = collection.find_one_and_update(
+            filter={'_id': sequence_id},
+            update={'$inc': {'next': 1}},
+            return_document=ReturnDocument.AFTER,
+            upsert=True)
         return self.value_decorator(counter['next'])
 
     def set_next_value(self, value):
@@ -1975,10 +1978,11 @@ class SequenceField(BaseField):
         sequence_name = self.get_sequence_name()
         sequence_id = "%s.%s" % (sequence_name, self.name)
         collection = get_db(alias=self.db_alias)[self.collection_name]
-        counter = collection.find_and_modify(query={"_id": sequence_id},
-                                             update={"$set": {"next": value}},
-                                             new=True,
-                                             upsert=True)
+        counter = collection.find_one_and_update(
+            filter={"_id": sequence_id},
+            update={"$set": {"next": value}},
+            return_document=ReturnDocument.AFTER,
+            upsert=True)
         return self.value_decorator(counter['next'])
 
     def get_next_value(self):

--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -480,9 +480,10 @@ class BaseQuerySet(object):
                     write_concern=write_concern,
                     **{'pull_all__%s' % field_name: self})
 
-        result = queryset._collection.remove(queryset._query, **write_concern)
-        if result:
-            return result.get('n')
+        with set_write_concern(queryset._collection, write_concern) as collection:
+            result = collection.delete_many(queryset._query)
+            if result.acknowledged:
+                return result.deleted_count
 
     def update(self, upsert=False, multi=True, write_concern=None,
                full_result=False, **update):

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -1857,8 +1857,8 @@ class QuerySetTest(unittest.TestCase):
         self.Person.objects()[:1].delete()
         self.assertEqual(1, BlogPost.objects.count())
 
-    def test_limit_with_write_concern_0(self):
-
+    def test_delete_edge_case_with_write_concern_0_return_None(self):
+        """Return None when write is unacknowledged"""
         p1 = self.Person(name="User Z", age=20).save()
         del_result = p1.delete(w=0)
         self.assertEqual(None, del_result)


### PR DESCRIPTION
Relates to #1491, its just a step forward but we still have some pymongo deprecated methods being called