### PR TITLE
BaseDocument.to_dict

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 Development
 ===========
 - (Fill this out as you fix issues and develop your features).
+- Add a `BaseDocument.to_dict` method #2101
 
 Changes in 0.18.1
 =================


### PR DESCRIPTION
`BaseDocument.to_dict` serializes a document/embedded document into a dict, which can be easily consumed by other modules (which in this case don't need to be aware of MongoEngine-specific object types).

The output dict contains key-value pairs where:
* Keys are field names as they're defined on the document (as opposed to e.g. how they're stored in MongoDB).
* Values are field values in their deserialized form (i.e. the same form that you get when you access `doc.some_field_name`).

This is inspired by the `to_dict` method in the "MongoMallard" fork of MongoEngine: https://github.com/closeio/mongoengine/blob/ae71f046d6b7c5930adb439e3688fb73765e4f64/mongoengine/base/document.py#L146-L147 (although that one was missing recursion). Over the next few weeks I'll be working on bridging the gap between the two repos, porting performance and functional improvements from the fork (of course, only if it makes sense for those changes to exist in this upstream repo).

cc @bagerard @erdenezul @thomasst 