### PR TITLE
Fix .read() of FileField to close the file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -252,3 +252,4 @@ that much better:
  * Paulo Amaral (https://github.com/pauloAmaral)
  * Gaurav Dadhania (https://github.com/GVRV)
  * Yurii Andrieiev (https://github.com/yandrieiev)
+ * Tristan Brown (https://github.com/tristanbrown)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 Development
 ===========
+- Fix the `.read()` feature of FileField to properly close the file.
 - (Fill this out as you fix issues and develop your features).
 
 Changes in 0.18.1

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -1632,6 +1632,8 @@ class GridFSProxy(object):
                 return gridout.read(size)
             except Exception:
                 return ''
+            finally:
+                gridout.seek(0)
 
     def delete(self):
         # Delete file from GridFS, FileField still remains


### PR DESCRIPTION
If you try to `.read()` a FileField twice without reloading the document, you will get an empty bytestring the second time. This is because `.read()` does not close out the GridOut file-like object. To replicate the functionality of closing a file, it is sufficient to call `.seek(0)` on the GridOut object (note that `GridOut.close()` doesn't reset the buffer).