### PR TITLE
Drop support for positional arguments when instantiating a document

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 Development
 ===========
 - (Fill this out as you fix issues and develop your features).
-- BREAKING CHANGE: Drop support for positional arguments when instantiating a document. #?
+- BREAKING CHANGE: Drop support for positional arguments when instantiating a document. #2103
   - From now on keyword arguments (e.g. `Doc(field_name=value)`) are required.
 
 Changes in 0.18.1

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,8 @@ Changelog
 Development
 ===========
 - (Fill this out as you fix issues and develop your features).
+- BREAKING CHANGE: Drop support for positional arguments when instantiating a document. #?
+  - From now on keyword arguments (e.g. `Doc(field_name=value)`) are required.
 
 Changes in 0.18.1
 =================

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -60,18 +60,10 @@ class BaseDocument(object):
         self._created = True
 
         if args:
-            # Combine positional arguments with named arguments.
-            # We only want named arguments.
-            field = iter(self._fields_ordered)
-            # If its an automatic id field then skip to the first defined field
-            if getattr(self, '_auto_id_field', False):
-                next(field)
-            for value in args:
-                name = next(field)
-                if name in values:
-                    raise TypeError(
-                        'Multiple values for keyword argument "%s"' % name)
-                values[name] = value
+            raise TypeError(
+                'Instantiating a document with positional arguments is not '
+                'supported. Please use `field_name=value` keyword arguments.'
+            )
 
         __auto_convert = values.pop('__auto_convert', True)
 

--- a/mongoengine/base/metaclasses.py
+++ b/mongoengine/base/metaclasses.py
@@ -1,3 +1,4 @@
+import itertools
 import warnings
 
 import six
@@ -440,7 +441,7 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
             return id_name, id_db_name
 
         id_basename, id_db_basename, i = ('auto_id', '_auto_id', 0)
-        while True:
+        for i in itertools.count():
             id_name = '{0}_{1}'.format(id_basename, i)
             id_db_name = '{0}_{1}'.format(id_db_basename, i)
             if (
@@ -448,8 +449,6 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
                 id_db_name not in existing_db_fields
             ):
                 return id_name, id_db_name
-            else:
-                i += 1
 
 
 class MetaDict(dict):

--- a/mongoengine/base/metaclasses.py
+++ b/mongoengine/base/metaclasses.py
@@ -431,8 +431,8 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
         of ('auto_id_X', '_auto_id_X') if the default name is already taken.
         """
         id_name, id_db_name = ('id', '_id')
-        existing_fields = new_class._fields
-        existing_db_fields = (v.db_field for v in new_class._fields.values())
+        existing_fields = {field_name for field_name in new_class._fields}
+        existing_db_fields = {v.db_field for v in new_class._fields.values()}
         if (
             id_name not in existing_fields and
             id_db_name not in existing_db_fields

--- a/tests/document/instance.py
+++ b/tests/document/instance.py
@@ -3137,7 +3137,7 @@ class InstanceTest(MongoDBTestCase):
             'Instantiating a document with positional arguments is not '
             'supported. Please use `field_name=value` keyword arguments.'
         )
-        self.assertEqual(e.exception.message, expected_msg)
+        self.assertEqual(str(e.exception), expected_msg)
 
     def test_mixed_creation(self):
         """Document cannot be instantiated using mixed arguments."""
@@ -3147,7 +3147,7 @@ class InstanceTest(MongoDBTestCase):
             'Instantiating a document with positional arguments is not '
             'supported. Please use `field_name=value` keyword arguments.'
         )
-        self.assertEqual(e.exception.message, expected_msg)
+        self.assertEqual(str(e.exception), expected_msg)
 
     def test_positional_creation_embedded(self):
         """Embedded document cannot be created using positional arguments."""
@@ -3157,7 +3157,7 @@ class InstanceTest(MongoDBTestCase):
             'Instantiating a document with positional arguments is not '
             'supported. Please use `field_name=value` keyword arguments.'
         )
-        self.assertEqual(e.exception.message, expected_msg)
+        self.assertEqual(str(e.exception), expected_msg)
 
     def test_mixed_creation_embedded(self):
         """Embedded document cannot be created using mixed arguments."""
@@ -3167,7 +3167,7 @@ class InstanceTest(MongoDBTestCase):
             'Instantiating a document with positional arguments is not '
             'supported. Please use `field_name=value` keyword arguments.'
         )
-        self.assertEqual(e.exception.message, expected_msg)
+        self.assertEqual(str(e.exception), expected_msg)
 
     def test_data_contains_id_field(self):
         """Ensure that asking for _data returns 'id'."""

--- a/tests/document/instance.py
+++ b/tests/document/instance.py
@@ -3130,48 +3130,44 @@ class InstanceTest(MongoDBTestCase):
         self.assertEqual(classic_doc._data, dict_doc._data)
 
     def test_positional_creation(self):
-        """Ensure that document may be created using positional arguments."""
-        person = self.Person("Test User", 42)
-        self.assertEqual(person.name, "Test User")
-        self.assertEqual(person.age, 42)
+        """Document cannot be instantiated using positional arguments."""
+        with self.assertRaises(TypeError) as e:
+            person = self.Person("Test User", 42)
+        expected_msg = (
+            'Instantiating a document with positional arguments is not '
+            'supported. Please use `field_name=value` keyword arguments.'
+        )
+        self.assertEqual(e.exception.message, expected_msg)
 
     def test_mixed_creation(self):
-        """Ensure that document may be created using mixed arguments."""
-        person = self.Person("Test User", age=42)
-        self.assertEqual(person.name, "Test User")
-        self.assertEqual(person.age, 42)
+        """Document cannot be instantiated using mixed arguments."""
+        with self.assertRaises(TypeError) as e:
+            person = self.Person("Test User", age=42)
+        expected_msg = (
+            'Instantiating a document with positional arguments is not '
+            'supported. Please use `field_name=value` keyword arguments.'
+        )
+        self.assertEqual(e.exception.message, expected_msg)
 
     def test_positional_creation_embedded(self):
-        """Ensure that embedded document may be created using positional
-        arguments.
-        """
-        job = self.Job("Test Job", 4)
-        self.assertEqual(job.name, "Test Job")
-        self.assertEqual(job.years, 4)
+        """Embedded document cannot be created using positional arguments."""
+        with self.assertRaises(TypeError) as e:
+            job = self.Job("Test Job", 4)
+        expected_msg = (
+            'Instantiating a document with positional arguments is not '
+            'supported. Please use `field_name=value` keyword arguments.'
+        )
+        self.assertEqual(e.exception.message, expected_msg)
 
     def test_mixed_creation_embedded(self):
-        """Ensure that embedded document may be created using mixed
-        arguments.
-        """
-        job = self.Job("Test Job", years=4)
-        self.assertEqual(job.name, "Test Job")
-        self.assertEqual(job.years, 4)
-
-    def test_mixed_creation_dynamic(self):
-        """Ensure that document may be created using mixed arguments."""
-        class Person(DynamicDocument):
-            name = StringField()
-
-        person = Person("Test User", age=42)
-        self.assertEqual(person.name, "Test User")
-        self.assertEqual(person.age, 42)
-
-    def test_bad_mixed_creation(self):
-        """Ensure that document gives correct error when duplicating
-        arguments.
-        """
-        with self.assertRaises(TypeError):
-            return self.Person("Test User", 42, name="Bad User")
+        """Embedded document cannot be created using mixed arguments."""
+        with self.assertRaises(TypeError) as e:
+            job = self.Job("Test Job", years=4)
+        expected_msg = (
+            'Instantiating a document with positional arguments is not '
+            'supported. Please use `field_name=value` keyword arguments.'
+        )
+        self.assertEqual(e.exception.message, expected_msg)
 
     def test_data_contains_id_field(self):
         """Ensure that asking for _data returns 'id'."""

--- a/tests/fields/test_lazy_reference_field.py
+++ b/tests/fields/test_lazy_reference_field.py
@@ -303,8 +303,8 @@ class TestLazyReferenceField(MongoDBTestCase):
         Animal.drop_collection()
         Ocurrence.drop_collection()
 
-        animal1 = Animal('doggo').save()
-        animal2 = Animal('cheeta').save()
+        animal1 = Animal(name='doggo').save()
+        animal2 = Animal(name='cheeta').save()
 
         def check_fields_type(occ):
             self.assertIsInstance(occ.direct, LazyReference)
@@ -542,8 +542,8 @@ class TestGenericLazyReferenceField(MongoDBTestCase):
         Animal.drop_collection()
         Ocurrence.drop_collection()
 
-        animal1 = Animal('doggo').save()
-        animal2 = Animal('cheeta').save()
+        animal1 = Animal(name='doggo').save()
+        animal2 = Animal(name='cheeta').save()
 
         def check_fields_type(occ):
             self.assertIsInstance(occ.direct, LazyReference)


### PR DESCRIPTION
For example, if you had the following class:
```py
class Person(Document):
    name = StringField()
    age = IntField()
```

You could instantiate an object of such class by doing one of the following:
1. `new_person = Person('Tom', 30)`
2. `new_person = Person('Tom', age=30)`
3. `new_person = Person(name='Tom', age=30)`

**From now on, only option (3) is allowed.**

Supporting positional arguments may sound like a reasonable idea in this heavily simplified example, but in real life it's almost never what you want (especially if you use inheritance in your document definitions) and it may lead to ugly bugs. We should not rely on the *order* of fields to match a given
value to a given name.

This also helps us simplify the code e.g. by dropping the confusing (and undocumented) `BaseDocument._auto_id_field` attribute.