### PR TITLE
Fix the duplicate ListField max_length test

### DIFF
--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -1026,21 +1026,16 @@ class FieldTest(MongoDBTestCase):
                     foo.save()
                 self.assertIn("List is too long", str(cm.exception))
 
-    def test_list_field_max_length(self):
-        """Ensure ListField's max_length is respected."""
+    def test_list_field_max_length_set_operator(self):
+        """Ensure ListField's max_length is respected for a "set" operator."""
 
         class Foo(Document):
-            items = ListField(IntField(), max_length=5)
+            items = ListField(IntField(), max_length=3)
 
-        foo = Foo()
-        for i in range(1, 7):
-            foo.items.append(i)
-            if i < 6:
-                foo.save()
-            else:
-                with self.assertRaises(ValidationError) as cm:
-                    foo.save()
-                self.assertIn("List is too long", str(cm.exception))
+        foo = Foo.objects.create(items=[1, 2, 3])
+        with self.assertRaises(ValidationError) as cm:
+            foo.modify(set__items=[1, 2, 3, 4])
+        self.assertIn("List is too long", str(cm.exception))
 
     def test_list_field_rejects_strings(self):
         """Strings aren't valid list field data types."""


### PR DESCRIPTION
This is a follow-up after #2107.

Not sure what happened here, but in https://github.com/MongoEngine/mongoengine/pull/2107/commits/87194856ecc5076bec2a186bae60c5d5b25c01ed I committed a copy-paste of the same test instead of a test validating the `ListField.max_length` behavior along with a "set" operator 🤦‍♂ 

See https://github.com/MongoEngine/mongoengine/pull/2107#issuecomment-506353904 for context.