### PR TITLE
Rename MongoEngineConnectionError to ConnectionFailure

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 Development
 ===========
 - (Fill this out as you fix issues and develop your features).
-- BREAKING CHANGE: Renamed `MongoEngineConnectionError` to `ConnectionFailure` #TBD
+- BREAKING CHANGE: Renamed `MongoEngineConnectionError` to `ConnectionFailure` #2111
   - If you catch/use `MongoEngineConnectionError` in your code, you'll have to rename it.
 - BREAKING CHANGE: Positional arguments when instantiating a document are no longer supported. #2103
   - From now on keyword arguments (e.g. `Doc(field_name=value)`) are required.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,8 @@ Changelog
 Development
 ===========
 - (Fill this out as you fix issues and develop your features).
+- BREAKING CHANGE: Renamed `MongoEngineConnectionError` to `ConnectionFailure` #TBD
+  - If you catch/use `MongoEngineConnectionError` in your code, you'll have to rename it.
 - BREAKING CHANGE: Positional arguments when instantiating a document are no longer supported. #2103
   - From now on keyword arguments (e.g. `Doc(field_name=value)`) are required.
 - The codebase is now formatted using `black`. #2109

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -23,7 +23,7 @@ from mongoengine import (
 )
 import mongoengine.connection
 from mongoengine.connection import (
-    MongoEngineConnectionError,
+    ConnectionFailure,
     get_db,
     get_connection,
     disconnect,
@@ -92,10 +92,10 @@ class ConnectionTest(unittest.TestCase):
         disconnect("db1")
         disconnect("db2")
 
-        with self.assertRaises(MongoEngineConnectionError):
+        with self.assertRaises(ConnectionFailure):
             list(History1.objects().as_pymongo())
 
-        with self.assertRaises(MongoEngineConnectionError):
+        with self.assertRaises(ConnectionFailure):
             list(History2.objects().as_pymongo())
 
         connect("db1", alias="db1")
@@ -149,7 +149,7 @@ class ConnectionTest(unittest.TestCase):
     def test_connect_fails_if_connect_2_times_with_default_alias(self):
         connect("mongoenginetest")
 
-        with self.assertRaises(MongoEngineConnectionError) as ctx_err:
+        with self.assertRaises(ConnectionFailure) as ctx_err:
             connect("mongoenginetest2")
         self.assertEqual(
             "A different connection with alias `default` was already registered. Use disconnect() first",
@@ -159,7 +159,7 @@ class ConnectionTest(unittest.TestCase):
     def test_connect_fails_if_connect_2_times_with_custom_alias(self):
         connect("mongoenginetest", alias="alias1")
 
-        with self.assertRaises(MongoEngineConnectionError) as ctx_err:
+        with self.assertRaises(ConnectionFailure) as ctx_err:
             connect("mongoenginetest2", alias="alias1")
 
         self.assertEqual(
@@ -175,7 +175,7 @@ class ConnectionTest(unittest.TestCase):
         db_alias = "alias1"
         connect(db=db_name, alias=db_alias, host="localhost", port=27017)
 
-        with self.assertRaises(MongoEngineConnectionError):
+        with self.assertRaises(ConnectionFailure):
             connect(host="mongodb://localhost:27017/%s" % db_name, alias=db_alias)
 
     def test_connect_passes_silently_connect_multiple_times_with_same_config(self):
@@ -353,7 +353,7 @@ class ConnectionTest(unittest.TestCase):
 
         self.assertIsNone(History._collection)
 
-        with self.assertRaises(MongoEngineConnectionError) as ctx_err:
+        with self.assertRaises(ConnectionFailure) as ctx_err:
             History.objects.first()
         self.assertEqual(
             "You have not defined a default connection", str(ctx_err.exception)
@@ -379,7 +379,7 @@ class ConnectionTest(unittest.TestCase):
         disconnect()
 
         # Make sure save doesnt work at this stage
-        with self.assertRaises(MongoEngineConnectionError):
+        with self.assertRaises(ConnectionFailure):
             User(name="Wont work").save()
 
         # Save in db2
@@ -433,10 +433,10 @@ class ConnectionTest(unittest.TestCase):
         self.assertEqual(len(dbs), 0)
         self.assertEqual(len(connection_settings), 0)
 
-        with self.assertRaises(MongoEngineConnectionError):
+        with self.assertRaises(ConnectionFailure):
             History.objects.first()
 
-        with self.assertRaises(MongoEngineConnectionError):
+        with self.assertRaises(ConnectionFailure):
             History1.objects.first()
 
     def test_disconnect_all_silently_pass_if_no_connection_exist(self):
@@ -557,7 +557,7 @@ class ConnectionTest(unittest.TestCase):
         """
         register_connection("testdb", "mongoenginetest2")
 
-        self.assertRaises(MongoEngineConnectionError, get_connection)
+        self.assertRaises(ConnectionFailure, get_connection)
         conn = get_connection("testdb")
         self.assertIsInstance(conn, pymongo.mongo_client.MongoClient)
 

--- a/tests/test_replicaset_connection.py
+++ b/tests/test_replicaset_connection.py
@@ -4,7 +4,7 @@ from pymongo import ReadPreference
 from pymongo import MongoClient
 
 import mongoengine
-from mongoengine.connection import MongoEngineConnectionError
+from mongoengine.connection import ConnectionFailure
 
 
 CONN_CLASS = MongoClient
@@ -32,7 +32,7 @@ class ConnectionTest(unittest.TestCase):
                 host="mongodb://localhost/mongoenginetest?replicaSet=rs",
                 read_preference=READ_PREF,
             )
-        except MongoEngineConnectionError as e:
+        except ConnectionFailure as e:
             return
 
         if not isinstance(conn, CONN_CLASS):


### PR DESCRIPTION
I originally changed the exception name from `ConnectionError` to `MongoEngineConnectionError` in
https://github.com/MongoEngine/mongoengine/pull/1428/commits/b02904ee750a30f8e2246a326376b40358543101, inspired by landscape.io's package health report, which argued that `ConnectionError` is already a [built-in exception in Python 3](https://docs.python.org/3/library/exceptions.html#ConnectionError).

I do agree that we shouldn't override built-in exceptions. [0] That said, it’s silly to add a "MongoEngine" prefix to any class within the `mongoengine` module (and *especially* to *just one* exception class out of many). I've decided to do [what PyMongo does](
https://github.com/mongodb/mongo-python-driver/blob/8855a510a80a30268ffd4b90be65fb26929648e2/pymongo/errors.py#L59) and call this exception `ConnectionFailure`.

Note that this is a breaking change and people will need to rename `MongoEngineConnectionError`s in their code to `ConnectionFailure`. Moreover, if they use PyMongo's `ConnectionFailure` for anything, they'll need to take extra care to avoid conflicts, e.g. by using:
```py
from mongoengine import ConnectionFailure as MongoEngineConnectionFailure
```

---

[0] Note that some popular packages still overwrite `ConnectionError`, e.g.
https://github.com/kennethreitz/requests/blob/4983a9bde39c6320aa4f3e34e50dac6e263dab6f/requests/exceptions.py#L32
or
https://github.com/andymccurdy/redis-py/blob/0be4d2920684345eb52115c7142c39d65356e7d4/redis/exceptions.py#L8