### PR TITLE
Drop the deprecated "format" param from BaseQuerySet.explain

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 Development
 ===========
 - (Fill this out as you fix issues and develop your features).
+- BREAKING CHANGE: Removed the deprecated `format` param from `QuerySet.explain` #2113
 - BREAKING CHANGE: Renamed `MongoEngineConnectionError` to `ConnectionFailure` #2111
   - If you catch/use `MongoEngineConnectionError` in your code, you'll have to rename it.
 - BREAKING CHANGE: Positional arguments when instantiating a document are no longer supported. #2103

--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import copy
 import itertools
-import pprint
 import re
 import warnings
 
@@ -1109,25 +1108,11 @@ class BaseQuerySet(object):
         """
         return self._chainable_method("comment", text)
 
-    def explain(self, format=False):
+    def explain(self):
         """Return an explain plan record for the
         :class:`~mongoengine.queryset.QuerySet`\ 's cursor.
-
-        :param format: format the plan before returning it
         """
-        plan = self._cursor.explain()
-
-        # TODO remove this option completely - it's useless. If somebody
-        # wants to pretty-print the output, they easily can.
-        if format:
-            msg = (
-                '"format" param of BaseQuerySet.explain has been '
-                "deprecated and will be removed in future versions."
-            )
-            warnings.warn(msg, DeprecationWarning)
-            plan = pprint.pformat(plan)
-
-        return plan
+        return self._cursor.explain()
 
     # DEPRECATED. Has no more impact on PyMongo 3+
     def snapshot(self, enabled):


### PR DESCRIPTION
This param has been deprecated for a while and indeed it's useless. You can very easily do:
```py
import pprint
(...)

plan = SomeDoc.objects(...).explain()
pprint.pformat(plan)
```