### PR TITLE
Document function parameters in correct order

### DIFF
--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -178,8 +178,8 @@ def register_connection(
 
     : param alias: the name that will be used to refer to this connection
         throughout MongoEngine
-    : param name: the name of the specific database to use
     : param db: the name of the database to use, for compatibility with connect
+    : param name: the name of the specific database to use
     : param host: the host name of the: program: `mongod` instance to connect to
     : param port: the port that the: program: `mongod` instance is running on
     : param read_preference: The read preference for the collection


### PR DESCRIPTION
Put the documentation of the parameter 'name' of the function
'register_connection' in order of appearance in the function signature.