### PR TITLE
Fix Document._object_key

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,8 +15,9 @@ Development
     - If you catch/use ``MongoEngineConnectionError`` in your code, you'll have to rename it.
 - BREAKING CHANGE: Positional arguments when instantiating a document are no longer supported. #2103
     - From now on keyword arguments (e.g. ``Doc(field_name=value)``) are required.
-- The codebase is now formatted using ``black``. #2109
+- Fix updating/modifying/deleting/reloading a document that's sharded by a field with ``db_field`` specified. #2125
 - ``ListField`` now accepts an optional ``max_length`` parameter. #2110
+- The codebase is now formatted using ``black``. #2109
 
 Changes in 0.18.2
 =================

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -202,6 +202,7 @@ class BaseDocument(object):
             self__initialised = self._initialised
         except AttributeError:
             self__initialised = False
+
         # Check if the user has created a new instance of a class
         if (
             self._is_document

--- a/tests/document/instance.py
+++ b/tests/document/instance.py
@@ -466,21 +466,35 @@ class InstanceTest(MongoDBTestCase):
             meta = {"shard_key": ("superphylum",)}
 
         Animal.drop_collection()
-        doc = Animal(superphylum="Deuterostomia")
-        doc.save()
+        doc = Animal.objects.create(superphylum="Deuterostomia")
 
         mongo_db = get_mongodb_version()
         CMD_QUERY_KEY = "command" if mongo_db >= MONGODB_36 else "query"
-
         with query_counter() as q:
             doc.reload()
             query_op = q.db.system.profile.find({"ns": "mongoenginetest.animal"})[0]
             self.assertEqual(
                 set(query_op[CMD_QUERY_KEY]["filter"].keys()),
-                set(["_id", "superphylum"]),
+                {"_id", "superphylum"},
             )
 
-        Animal.drop_collection()
+    def test_reload_sharded_with_db_field(self):
+        class Person(Document):
+            nationality = StringField(db_field="country")
+            meta = {"shard_key": ("nationality",)}
+
+        Person.drop_collection()
+        doc = Person.objects.create(nationality="Poland")
+
+        mongo_db = get_mongodb_version()
+        CMD_QUERY_KEY = "command" if mongo_db >= MONGODB_36 else "query"
+        with query_counter() as q:
+            doc.reload()
+            query_op = q.db.system.profile.find({"ns": "mongoenginetest.person"})[0]
+            self.assertEqual(
+                set(query_op[CMD_QUERY_KEY]["filter"].keys()),
+                {"_id", "country"},
+            )
 
     def test_reload_sharded_nested(self):
         class SuperPhylum(EmbeddedDocument):
@@ -3614,6 +3628,58 @@ class InstanceTest(MongoDBTestCase):
         # Ensure index creation exception aren't swallowed (#1688)
         with self.assertRaises(DuplicateKeyError):
             User.objects().select_related()
+
+
+class ObjectKeyTestCase(MongoDBTestCase):
+    def test_object_key_simple_document(self):
+        class Book(Document):
+            title = StringField()
+
+        book = Book(title="Whatever")
+        self.assertEqual(book._object_key, {"pk": None})
+
+        book.pk = ObjectId()
+        self.assertEqual(book._object_key, {"pk": book.pk})
+
+    def test_object_key_with_custom_primary_key(self):
+        class Book(Document):
+            isbn = StringField(primary_key=True)
+            title = StringField()
+
+        book = Book(title="Sapiens")
+        self.assertEqual(book._object_key, {"pk": None})
+
+        book = Book(pk="0062316117")
+        self.assertEqual(book._object_key, {"pk": "0062316117"})
+
+    def test_object_key_in_a_sharded_collection(self):
+        class Book(Document):
+            title = StringField()
+            meta = {"shard_key": ("pk", "title")}
+
+        book = Book()
+        self.assertEqual(book._object_key, {"pk": None, "title": None})
+        book = Book(pk=ObjectId(), title="Sapiens")
+        self.assertEqual(book._object_key, {"pk": book.pk, "title": "Sapiens"})
+
+    def test_object_key_with_custom_db_field(self):
+        class Book(Document):
+            author = StringField(db_field="creator")
+            meta = {"shard_key": ("pk", "author")}
+
+        book = Book(pk=ObjectId(), author="Author")
+        self.assertEqual(book._object_key, {"pk": book.pk, "author": "Author"})
+
+    def test_object_key_with_nested_shard_key(self):
+        class Author(EmbeddedDocument):
+            name = StringField()
+
+        class Book(Document):
+            author = EmbeddedDocumentField(Author)
+            meta = {"shard_key": ("pk", "author.name")}
+
+        book = Book(pk=ObjectId(), author=Author(name="Author"))
+        self.assertEqual(book._object_key, {"pk": book.pk, "author__name": "Author"})
 
 
 if __name__ == "__main__":

--- a/tests/document/instance.py
+++ b/tests/document/instance.py
@@ -474,8 +474,7 @@ class InstanceTest(MongoDBTestCase):
             doc.reload()
             query_op = q.db.system.profile.find({"ns": "mongoenginetest.animal"})[0]
             self.assertEqual(
-                set(query_op[CMD_QUERY_KEY]["filter"].keys()),
-                {"_id", "superphylum"},
+                set(query_op[CMD_QUERY_KEY]["filter"].keys()), {"_id", "superphylum"}
             )
 
     def test_reload_sharded_with_db_field(self):
@@ -492,8 +491,7 @@ class InstanceTest(MongoDBTestCase):
             doc.reload()
             query_op = q.db.system.profile.find({"ns": "mongoenginetest.person"})[0]
             self.assertEqual(
-                set(query_op[CMD_QUERY_KEY]["filter"].keys()),
-                {"_id", "country"},
+                set(query_op[CMD_QUERY_KEY]["filter"].keys()), {"_id", "country"}
             )
 
     def test_reload_sharded_nested(self):


### PR DESCRIPTION
Previous implementation of `Document._object_key` was *kinda* working on MongoEngine-level fields (e.g. using `pk` instead of `_id` and separating nested field parts by `__` instead of `.`), but then it was also attempting to transform field names from the `shard_key` into DB-level fields.

This, expectedly, didn't work well. Most of the test cases added in this commit were failing prior to the code fixes.

This fixes updating, modifying, deleting, and reloading documents that specify a shard key where at least one of its fields has a different representation in MongoEngine vs in the database (e.g. the PK or fields specifying a different `db_field`).