### PR TITLE
Only set no_cursor_timeout when requested

### DIFF
--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -1576,7 +1576,9 @@ class BaseQuerySet(object):
         if self._snapshot:
             msg = "The snapshot option is not anymore available with PyMongo 3+"
             warnings.warn(msg, DeprecationWarning)
-        cursor_args = {"no_cursor_timeout": not self._timeout}
+        cursor_args = {}
+        if not self._timeout:
+            cursor_args["no_cursor_timeout"] = True
 
         if self._loaded_fields:
             cursor_args[fields_name] = self._loaded_fields.as_dict()

--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -1576,6 +1576,7 @@ class BaseQuerySet(object):
         if self._snapshot:
             msg = "The snapshot option is not anymore available with PyMongo 3+"
             warnings.warn(msg, DeprecationWarning)
+
         cursor_args = {}
         if not self._timeout:
             cursor_args["no_cursor_timeout"] = True

--- a/tests/queryset/test_queryset.py
+++ b/tests/queryset/test_queryset.py
@@ -5809,8 +5809,18 @@ class TestQueryset(unittest.TestCase):
         self.Person.objects.create(name="Baz")
         self.assertEqual(self.Person.objects.count(with_limit_and_skip=True), 3)
 
-        newPerson = self.Person.objects.create(name="Foo_1")
+        self.Person.objects.create(name="Foo_1")
         self.assertEqual(self.Person.objects.count(with_limit_and_skip=True), 4)
+
+    def test_no_cursor_timeout(self):
+        qs = self.Person.objects()
+        self.assertEqual(qs._cursor_args, {})  # ensure no regression of  #2148
+
+        qs = self.Person.objects().timeout(True)
+        self.assertEqual(qs._cursor_args, {})
+
+        qs = self.Person.objects().timeout(False)
+        self.assertEqual(qs._cursor_args, {"no_cursor_timeout": True})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously this was always set for all requests. The parameter is only
documented as supported for certain queries, so this was probably wrong.

Mongo version 4.2 fails update queries that have this parameter set making
mongoengine unusable there. Fixes #2148.