### PR TITLE
Document no async driver support

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,0 +1,13 @@
+==========================
+Frequently Asked Questions
+==========================
+
+Does MongoEngine support asynchronous drivers (Motor, TxMongo)?
+---------------------------------------------------------------
+
+No, MongoEngine is exclusively based on PyMongo and isn't designed to support other driver.
+If this is a requirement for your project, check the alternative:  `uMongo`_ and `MotorEngine`_.
+
+.. _uMongo: https://umongo.readthedocs.io/
+.. _MotorEngine: https://motorengine.readthedocs.io/
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,12 @@ MongoDB. To install it, simply run
 :doc:`django`
   Using MongoEngine and Django
 
+MongoDB and driver support
+--------------------------
+
+MongoEngine is based on the PyMongo driver and tested against multiple versions of MongoDB.
+For further details, please refer to the `readme <https://github.com/MongoEngine/mongoengine#mongoengine>`_.
+
 Community
 ---------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,9 @@ MongoDB. To install it, simply run
 :doc:`upgrade`
   How to upgrade MongoEngine.
 
+:doc:`faq`
+  Frequently Asked Questions
+
 :doc:`django`
   Using MongoEngine and Django
 
@@ -73,6 +76,7 @@ formats for offline reading.
     apireference
     changelog
     upgrade
+    faq
     django
 
 Indices and tables


### PR DESCRIPTION
Added a FAQ to RTD and documented the fact that mongoengine is based on PyMongo and offers no support for async driver

Fixes  #2155