### PR TITLE
Specify version of requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ setup(
     long_description=LONG_DESCRIPTION,
     platforms=["any"],
     classifiers=CLASSIFIERS,
-    install_requires=["pymongo>=3.4", "six"],
+    install_requires=["pymongo>=3.4", "six>=1.10.0"],
     cmdclass={"test": PyTest},
     **extra_opts
 )


### PR DESCRIPTION
In `README.rst`, a version of `six` of at least `1.10.0` is specified. This was missing from the requirements, potentially leading to broken installations.