### PR TITLE
Bump version to 0.19.1 + force pillow to be < 7.0.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,10 @@ Changelog
 Development
 ===========
 - (Fill this out as you fix issues and develop your features).
+
+Changes in 0.19.1
+=================
+- Requires Pillow < 7.0.0 as it dropped Python2 support
 - DEPRECATION: The interface of ``QuerySet.aggregate`` method was changed, it no longer takes an unpacked list of
     pipeline steps (*pipeline) but simply takes the pipeline list just like ``pymongo.Collection.aggregate`` does. #2079
 

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -28,7 +28,7 @@ __all__ = (
 )
 
 
-VERSION = (0, 19, 0)
+VERSION = (0, 19, 1)
 
 
 def get_version():

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ extra_opts = {
         "pytest-cov",
         "coverage<5.0",  # recent coverage switched to sqlite format for the .coverage file which isn't handled properly by coveralls
         "blinker",
-        "Pillow>=2.0.0",
+        "Pillow>=2.0.0, <7.0.0",    # 7.0.0 dropped Python2 support
     ],
 }
 if sys.version_info[0] == 3:

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ extra_opts = {
         "pytest-cov",
         "coverage<5.0",  # recent coverage switched to sqlite format for the .coverage file which isn't handled properly by coveralls
         "blinker",
-        "Pillow>=2.0.0, <7.0.0",    # 7.0.0 dropped Python2 support
+        "Pillow>=2.0.0, <7.0.0",  # 7.0.0 dropped Python2 support
     ],
 }
 if sys.version_info[0] == 3:


### PR DESCRIPTION
I've seen in a recent PR that travis was failing with a SyntaxError in the Pillow library.
It turned out that Pillow did a recent release (7.0.0) and they dropped support for Python2 (which finally reached EOL). To avoid users from hitting this issue, let's limit the pillow release and release 0.19.1 asap. 