### PR TITLE
Add dynamic check in EmbeddedDocumentField lookup_member

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Development
 ===========
 - (Fill this out as you fix issues and develop your features).
 - Add Mongo 4.0 to Travis
+- Fix querying and updating dynamic fields on DynamicEmbeddedDocuments
 
 Changes in 0.19.1
 =================

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -777,6 +777,9 @@ class EmbeddedDocumentField(BaseField):
             if field:
                 return field
 
+        if any(doc_type._dynamic for doc_type in doc_and_subclasses):
+            return DynamicField(db_field=member_name)
+
     def prepare_query_value(self, op, value):
         if value is not None and not isinstance(value, self.document_type):
             try:


### PR DESCRIPTION
- Add check for _dynamic in lookup_member that returns DynamicField for DynamicEmbeddedDocument subclasses
- Add test for DynamicEmbeddedDocument in test_embedded_document_field
- Updated changelog

closes #2251