### PR TITLE
Add support for the elemMatch projection operator

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Development
 - (Fill this out as you fix issues and develop your features).
 - Add Mongo 4.0 to Travis
 - Fixed a bug causing inaccurate query results, while combining ``__raw__`` and regular filters for the same field #2264
+- Add support for the `elemMatch` projection operator in .fields (e.g BlogPost.objects.fields(elemMatch__comments="test")) #2267
 
 Changes in 0.19.1
 =================

--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -1026,9 +1026,11 @@ class BaseQuerySet(object):
 
             posts = BlogPost.objects(...).fields(comments=0)
 
-        To retrieve a subrange of array elements:
+        To retrieve a subrange or sublist of array elements,
+        support exist for both the `slice` and `elemMatch` projection operator:
 
             posts = BlogPost.objects(...).fields(slice__comments=5)
+            posts = BlogPost.objects(...).fields(elemMatch__comments="test")
 
         :param kwargs: A set of keyword arguments identifying what to
             include, exclude, or slice.

--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -1037,7 +1037,7 @@ class BaseQuerySet(object):
         """
 
         # Check for an operator and transform to mongo-style if there is
-        operators = ["slice"]
+        operators = ["slice", "elemMatch"]
         cleaned_fields = []
         for key, value in kwargs.items():
             parts = key.split("__")

--- a/tests/queryset/test_queryset.py
+++ b/tests/queryset/test_queryset.py
@@ -4481,51 +4481,68 @@ class TestQueryset(unittest.TestCase):
             v = StringField()
             z = StringField()
 
-
         class Foo(Document):
             x = StringField()
             y = IntField()
             items = EmbeddedDocumentListField(Bar)
 
-
         Foo.drop_collection()
 
-        Foo(x='foo1', y=1).save()
-        Foo(x='foo2', y=2, items=[]).save()
-        Foo(x='foo3', y=3, items=[Bar(z='a', v='V')]).save()
-        Foo(x='foo4', y=4, items=[Bar(z='a', v='V'), Bar(z='b', v='W'), Bar(z='b', v='X'), Bar(z='c', v='V')]).save()
-        Foo(x='foo5', y=5, items=[Bar(z='b', v='X'), Bar(z='c', v='V'), Bar(z='d', v='V'), Bar(z='e', v='V')]).save()
+        Foo(x="foo1", y=1).save()
+        Foo(x="foo2", y=2, items=[]).save()
+        Foo(x="foo3", y=3, items=[Bar(z="a", v="V")]).save()
+        Foo(
+            x="foo4",
+            y=4,
+            items=[
+                Bar(z="a", v="V"),
+                Bar(z="b", v="W"),
+                Bar(z="b", v="X"),
+                Bar(z="c", v="V"),
+            ],
+        ).save()
+        Foo(
+            x="foo5",
+            y=5,
+            items=[
+                Bar(z="b", v="X"),
+                Bar(z="c", v="V"),
+                Bar(z="d", v="V"),
+                Bar(z="e", v="V"),
+            ],
+        ).save()
 
-        foos_with_x = list(Foo.objects.order_by('y').fields(x=1))
+        foos_with_x = list(Foo.objects.order_by("y").fields(x=1))
 
         assert all(o.x is not None for o in foos_with_x)
 
-        foos_without_y = list(Foo.objects.order_by('y').fields(y=0))
+        foos_without_y = list(Foo.objects.order_by("y").fields(y=0))
 
         assert all(o.y is None for o in foos_with_x)
 
-        foos_with_sliced_items = list(Foo.objects.order_by('y').fields(slice__items=1))
+        foos_with_sliced_items = list(Foo.objects.order_by("y").fields(slice__items=1))
 
         assert foos_with_sliced_items[0].items == []
         assert foos_with_sliced_items[1].items == []
         assert len(foos_with_sliced_items[2].items) == 1
-        assert foos_with_sliced_items[2].items[0].z == 'a'
+        assert foos_with_sliced_items[2].items[0].z == "a"
         assert len(foos_with_sliced_items[3].items) == 1
-        assert foos_with_sliced_items[3].items[0].z == 'a'
+        assert foos_with_sliced_items[3].items[0].z == "a"
         assert len(foos_with_sliced_items[4].items) == 1
-        assert foos_with_sliced_items[4].items[0].z == 'b'
+        assert foos_with_sliced_items[4].items[0].z == "b"
 
-        foos_with_elem_match_items = list(Foo.objects.order_by('y').fields(elemMatch__items={'z': 'b'}))
+        foos_with_elem_match_items = list(
+            Foo.objects.order_by("y").fields(elemMatch__items={"z": "b"})
+        )
 
         assert foos_with_elem_match_items[0].items == []
         assert foos_with_elem_match_items[1].items == []
         assert foos_with_elem_match_items[2].items == []
         assert len(foos_with_elem_match_items[3].items) == 1
-        assert foos_with_elem_match_items[3].items[0].z == 'b'
-        assert foos_with_elem_match_items[3].items[0].v == 'W'
+        assert foos_with_elem_match_items[3].items[0].z == "b"
+        assert foos_with_elem_match_items[3].items[0].v == "W"
         assert len(foos_with_elem_match_items[4].items) == 1
-        assert foos_with_elem_match_items[4].items[0].z == 'b'
-
+        assert foos_with_elem_match_items[4].items[0].z == "b"
 
     def test_elem_match(self):
         class Foo(EmbeddedDocument):


### PR DESCRIPTION
Add support for the [$elemMatch](https://docs.mongodb.com/manual/reference/operator/projection/elemMatch/) projection operator on querysets. It works the same way "slice" does. Take for instance the following document structure:

```python
class Bar(EmbeddedDocument):
            v = StringField()
            z = StringField()


        class Foo(Document):
            x = StringField()
            y = IntField()
            items = EmbeddedDocumentListField(Bar)
```

The following query

```
Foo.objects.fields(elemMatch__items={'z': 'some value'})
```

will return `Foo` objects where the `items` contain only the first Bar embedded document for which `z` is `"some value"`, otherwise, the field will contain an empty string. 
Closes #2268