### PR TITLE
Add return info in the save function docstring

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -255,3 +255,4 @@ that much better:
  * Filip Kucharczyk (https://github.com/Pacu2)
  * Eric Timmons (https://github.com/daewok)
  * Matthew Simpson (https://github.com/mcsimps2)
+ * Leonardo Domingues (https://github.com/leodmgs)

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -332,7 +332,7 @@ class Document(six.with_metaclass(TopLevelDocumentMetaclass, BaseDocument)):
     ):
         """Save the :class:`~mongoengine.Document` to the database. If the
         document already exists, it will be updated, otherwise it will be
-        created.
+        created. Returns the saved object instance.
 
         :param force_insert: only try to create a new document, don't allow
             updates of existing documents.


### PR DESCRIPTION
In the documentation of the `save()` function, it is not clear that after execution the saved object (Document) will be returned.