### PR TITLE
Fields with null=True we're always set to default None even default value was set to field

### DIFF
--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -145,7 +145,7 @@ class BaseField(object):
         if value is None:
             if self.null:
                 value = None
-            elif self.default is not None:
+            if self.default is not None:
                 value = self.default
                 if callable(value):
                     value = value()

--- a/tests/fields/test_fields.py
+++ b/tests/fields/test_fields.py
@@ -156,6 +156,21 @@ class TestField(MongoDBTestCase):
         data_to_be_saved = sorted(person.to_mongo().keys())
         assert data_to_be_saved == ["age", "created", "userid"]
 
+    def test_boolean_field_default_false_and_null_true(self):
+        """Ensure that False default is used in boolean field when
+        null is enabled for a field"""
+        class Person(Document):
+            name = StringField(default="default name", null=True)
+            deleted = BooleanField(default=False, null=True)
+        # Trying setting values to None
+        person = Person()
+        # Confirm saving now would store values
+        data_to_be_saved = sorted(person.to_mongo().keys())
+        assert data_to_be_saved == ["deleted", "name"]
+        assert person.validate() is None
+        assert person.name == "default name"
+        assert person.deleted == False
+
     def test_default_values_when_setting_to_None(self):
         """Ensure that default field values are used when creating
         a document.


### PR DESCRIPTION
Fixes null=True with default value when no value provided:

field = StringField(null=True, default="123")

Field value was initialized with None instead of logical default "123".
