### PR TITLE
Fix EmbeddedDocumentList docstring

### DIFF
--- a/mongoengine/base/datastructures.py
+++ b/mongoengine/base/datastructures.py
@@ -303,11 +303,11 @@ class EmbeddedDocumentList(BaseList):
 
     def create(self, **values):
         """
-        Creates a new embedded document and saves it to the database.
+        Creates a new instance of the EmbeddedDocument and appends it to this EmbeddedDocumentList.
 
         .. note::
-            The embedded document changes are not automatically saved
-            to the database after calling this method.
+            the instance of the EmbeddedDocument is not automatically saved to the database.
+            You still need to call save() o this EmbeddedDocumentList.
 
         :param values: A dictionary of values for the embedded document.
         :return: The new embedded document instance.

--- a/mongoengine/base/datastructures.py
+++ b/mongoengine/base/datastructures.py
@@ -307,7 +307,7 @@ class EmbeddedDocumentList(BaseList):
 
         .. note::
             the instance of the EmbeddedDocument is not automatically saved to the database.
-            You still need to call save() o this EmbeddedDocumentList.
+            You still need to call save() on this EmbeddedDocumentList.
 
         :param values: A dictionary of values for the embedded document.
         :return: The new embedded document instance.


### PR DESCRIPTION
The docstring on EmbeddedDocumentList.create() is a bit confusing since, from my understanding, it does no saving to the db at all. It also seems to contradict itself. I corrected this and made the behavior description a bit more explicit.