### PR TITLE
Fix a bug when using None values in a list of floats

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -256,3 +256,4 @@ that much better:
  * Eric Timmons (https://github.com/daewok)
  * Matthew Simpson (https://github.com/mcsimps2)
  * Leonardo Domingues (https://github.com/leodmgs)
+ * Adam Edry (https://github.com/Adam-Edry)

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -391,7 +391,7 @@ class FloatField(BaseField):
     def to_python(self, value):
         try:
             value = float(value)
-        except ValueError:
+        except (ValueError, TypeError):
             pass
         return value
 
@@ -401,6 +401,9 @@ class FloatField(BaseField):
                 value = float(value)
             except OverflowError:
                 self.error("The value is too large to be converted to float")
+
+        if value is None:
+            return
 
         if not isinstance(value, float):
             self.error("FloatField only accepts float and integer values")

--- a/tests/fields/test_float_field.py
+++ b/tests/fields/test_float_field.py
@@ -20,6 +20,35 @@ class TestFloatField(MongoDBTestCase):
         assert 1 == TestDocument.objects(float_fld__ne=None).count()
         assert 1 == TestDocument.objects(float_fld__ne=1).count()
 
+    def test_list_of_floats_can_be_none(self):
+        class TestFloatListNone(Document):
+            list_of_float_fld = ListField(FloatField())
+
+        TestFloatListNone.drop_collection()
+
+        # Verifies that validate works with None
+        TestFloatListNone(list_of_float_fld=[None]).save()
+
+    def test_list_of_floats_can_update_none(self):
+        class TestFloatListUpdateNone(Document):
+            list_of_float_fld = ListField(FloatField())
+
+        TestFloatListUpdateNone.drop_collection()
+
+        doc = TestFloatListUpdateNone()
+        doc.list_of_float_fld = [1.2]
+        doc.save()
+
+        # Verifies that to_python works with None
+        res = TestFloatListUpdateNone.objects(id=doc.id).update(
+            set__list_of_float_fld=[None],
+        )
+        assert res == 1
+
+        # Retrive data from db and verify it.
+        ret = TestFloatListUpdateNone.objects.all()[0]
+        assert ret.list_of_float_fld == [None]
+
     def test_validation(self):
         """Ensure that invalid values cannot be assigned to float fields.
         """


### PR DESCRIPTION
Fixing a bug reported in issue #2290. 

When trying to use None values in a List of Floats there would be an exception thrown from either to_python or validate methods.

Added two failing tests that cover each of those functions and then fixed them.