### PR TITLE
Fix CI dependency that dropped python 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,7 @@ install:
 before_script:
   - mkdir ${PWD}/mongodb-linux-x86_64-${MONGODB}/data
   - ${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --dbpath ${PWD}/mongodb-linux-x86_64-${MONGODB}/data --logpath ${PWD}/mongodb-linux-x86_64-${MONGODB}/mongodb.log --fork
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install "pyparsing<2.0.0"; fi # fix a package dropping python2 support 
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then flake8 .; else echo "flake8 only runs on py27"; fi   # Run flake8 for Python 2.7 only
   - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then black --check .; else echo "black only runs on py37"; fi   # Run black for Python 3.7 only
   - mongo --eval 'db.version();'    # Make sure mongo is awake

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,7 @@ extra_opts = {
         "blinker",
         "Pillow>=2.0.0, <7.0.0",  # 7.0.0 dropped Python2 support
         "zipp<2.0.0",  # (dependency of pytest) dropped python2 support
+        "configparser<5.0.0", # 5.0.0 dropped python2 support
     ],
 }
 if PY3:

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,6 @@ extra_opts = {
         "Pillow>=2.0.0, <7.0.0",  # 7.0.0 dropped Python2 support
         "zipp<2.0.0",  # (dependency of pytest) dropped python2 support
         "configparser<5.0.0", # 5.0.0 dropped python2 support
-        "pyparsing<2.0.0", # Another package that dropped python2 support
     ],
 }
 if PY3:

--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,7 @@ extra_opts = {
         "Pillow>=2.0.0, <7.0.0",  # 7.0.0 dropped Python2 support
         "zipp<2.0.0",  # (dependency of pytest) dropped python2 support
         "configparser<5.0.0", # 5.0.0 dropped python2 support
+        "pyparsing<2.0.0", # Another package that dropped python2 support
     ],
 }
 if PY3:


### PR DESCRIPTION
configparser is causing an error in CI builds since configparser 5.0.0 released. Added dependency tests_require of setup.py

```
creating /home/travis/build/MongoEngine/mongoengine/.eggs/configparser-0.0.0-py2.7.egg

Extracting configparser-0.0.0-py2.7.egg to /home/travis/build/MongoEngine/mongoengine/.eggs

Installed /home/travis/build/MongoEngine/mongoengine/.eggs/configparser-0.0.0-py2.7.egg

Traceback (most recent call last):

  File "setup.py", line 153, in <module>

    **extra_opts

  File "/home/travis/build/MongoEngine/mongoengine/.tox/pypy-mg310/site-packages/setuptools/__init__.py", line 145, in setup

    return distutils.core.setup(**attrs)

  File "/opt/python/pypy2.7-7.1.1/lib-python/2.7/distutils/core.py", line 151, in setup

    dist.run_commands()

  File "/opt/python/pypy2.7-7.1.1/lib-python/2.7/distutils/dist.py", line 953, in run_commands

    self.run_command(cmd)

  File "/opt/python/pypy2.7-7.1.1/lib-python/2.7/distutils/dist.py", line 972, in run_command

    cmd_obj.run()

  File "/home/travis/build/MongoEngine/mongoengine/.tox/pypy-mg310/site-packages/setuptools/command/test.py", line 216, in run

    installed_dists = self.install_dists(self.distribution)

  File "/home/travis/build/MongoEngine/mongoengine/.tox/pypy-mg310/site-packages/setuptools/command/test.py", line 208, in install_dists

    tr_d = dist.fetch_build_eggs(dist.tests_require or [])

  File "/home/travis/build/MongoEngine/mongoengine/.tox/pypy-mg310/site-packages/setuptools/dist.py", line 724, in fetch_build_eggs

    replace_conflicting=True,

  File "/home/travis/build/MongoEngine/mongoengine/.tox/pypy-mg310/site-packages/pkg_resources/__init__.py", line 786, in resolve

    raise DistributionNotFound(req, requirers)

DistributionNotFound: The 'configparser>=3.5' distribution was not found and is required by importlib-metadata

ERROR: InvocationError for command /home/travis/build/MongoEngine/mongoengine/.tox/pypy-mg310/bin/python setup.py test -a -k=test_ci_placeholder (exited with code 1)
```