### PR TITLE
Add read_concern to cloned properties. Add read_concern to aggregate().

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 Development
 ===========
 - (Fill this out as you fix issues and develop your features).
+- Fixed a bug that made the queryset drop the read_preference after clone(). 
 
 Changes in 0.20.0
 =================

--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -789,6 +789,7 @@ class BaseQuerySet:
             "_snapshot",
             "_timeout",
             "_read_preference",
+            "_read_concern",
             "_iter",
             "_scalar",
             "_as_pymongo",
@@ -1311,10 +1312,11 @@ class BaseQuerySet:
         final_pipeline = initial_pipeline + user_pipeline
 
         collection = self._collection
-        if self._read_preference is not None:
+        if self._read_preference is not None or self._read_concern is not None:
             collection = self._collection.with_options(
-                read_preference=self._read_preference
+                read_preference=self._read_preference, read_concern=self._read_concern
             )
+
         return collection.aggregate(final_pipeline, cursor={}, **kwargs)
 
     # JS functionality

--- a/tests/queryset/test_queryset.py
+++ b/tests/queryset/test_queryset.py
@@ -4040,9 +4040,9 @@ class TestQueryset(unittest.TestCase):
         assert qs._read_preference == ReadPreference.PRIMARY_PREFERRED
         assert qs._read_preference == qs_clone._read_preference
 
-        qs = Number.objects.read_concern({'level': 'majority'})
+        qs = Number.objects.read_concern({"level": "majority"})
         qs_clone = qs.clone()
-        assert qs._read_concern.document == {'level': 'majority'}
+        assert qs._read_concern.document == {"level": "majority"}
         assert qs._read_concern == qs_clone._read_concern
 
         Number.drop_collection()

--- a/tests/queryset/test_queryset.py
+++ b/tests/queryset/test_queryset.py
@@ -4021,6 +4021,32 @@ class TestQueryset(unittest.TestCase):
 
         Number.drop_collection()
 
+    def test_clone_retains_settings(self):
+        """Ensure that cloning retains the read_preference and read_concern
+        """
+
+        class Number(Document):
+            n = IntField()
+
+        Number.drop_collection()
+
+        qs = Number.objects
+        qs_clone = qs.clone()
+        assert qs._read_preference == qs_clone._read_preference
+        assert qs._read_concern == qs_clone._read_concern
+
+        qs = Number.objects.read_preference(ReadPreference.PRIMARY_PREFERRED)
+        qs_clone = qs.clone()
+        assert qs._read_preference == ReadPreference.PRIMARY_PREFERRED
+        assert qs._read_preference == qs_clone._read_preference
+
+        qs = Number.objects.read_concern({'level': 'majority'})
+        qs_clone = qs.clone()
+        assert qs._read_concern.document == {'level': 'majority'}
+        assert qs._read_concern == qs_clone._read_concern
+
+        Number.drop_collection()
+
     def test_using(self):
         """Ensure that switching databases for a queryset is possible
         """


### PR DESCRIPTION
The read_concern property was getting dropped during clone(), which is used by a lot of operations that would be affected by the read concern setting.

Also set the read_concern value on aggregate() calls.

Fixes: https://github.com/MongoEngine/mongoengine/issues/2332