### PR TITLE
Adding `SetField`

### DIFF
--- a/mongoengine/base/__init__.py
+++ b/mongoengine/base/__init__.py
@@ -18,6 +18,7 @@ __all__ = (
     # datastructures
     "BaseDict",
     "BaseList",
+    "BaseSet",
     "EmbeddedDocumentList",
     "LazyReference",
     # document

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -11,6 +11,7 @@ from mongoengine.base.common import get_document
 from mongoengine.base.datastructures import (
     BaseDict,
     BaseList,
+    BaseSet,
     EmbeddedDocumentList,
     LazyReference,
     StrictDict,
@@ -477,7 +478,7 @@ class BaseDocument:
 
     def __expand_dynamic_values(self, name, value):
         """Expand any dynamic values to their correct types / values."""
-        if not isinstance(value, (dict, list, tuple)):
+        if not isinstance(value, (dict, list, tuple, set)):
             return value
 
         # If the value is a dict with '_cls' in it, turn it into a document
@@ -498,6 +499,8 @@ class BaseDocument:
                 value = EmbeddedDocumentList(value, self, name)
             else:
                 value = BaseList(value, self, name)
+        elif isinstance(value, set) and not isinstance(value, BaseSet):
+            value = BaseSet(value, self, name)
         elif isinstance(value, dict) and not isinstance(value, BaseDict):
             value = BaseDict(value, self, name)
 

--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -6,7 +6,7 @@ from bson import DBRef, ObjectId, SON
 import pymongo
 
 from mongoengine.base.common import UPDATE_OPERATORS
-from mongoengine.base.datastructures import BaseDict, BaseList, EmbeddedDocumentList
+from mongoengine.base.datastructures import BaseDict, BaseList, BaseSet, EmbeddedDocumentList
 from mongoengine.common import _import_class
 from mongoengine.errors import DeprecatedError, ValidationError
 
@@ -316,6 +316,9 @@ class ComplexBaseField(BaseField):
             elif not isinstance(value, BaseList):
                 value = BaseList(value, instance, self.name)
             instance._data[self.name] = value
+        elif isinstance(value, set) and not isinstance(value, BaseSet):
+            value = BaseSet(value, instance, self.name)
+            instance._data[self.name] = value
         elif isinstance(value, dict) and not isinstance(value, BaseDict):
             value = BaseDict(value, instance, self.name)
             instance._data[self.name] = value
@@ -323,7 +326,7 @@ class ComplexBaseField(BaseField):
         if (
             auto_dereference
             and instance._initialised
-            and isinstance(value, (BaseList, BaseDict))
+            and isinstance(value, (BaseList, BaseSet, BaseDict))
             and not value._dereferenced
         ):
             value = _dereference(value, max_depth=1, instance=instance, name=self.name)

--- a/mongoengine/dereference.py
+++ b/mongoengine/dereference.py
@@ -3,6 +3,7 @@ from bson import DBRef, SON
 from mongoengine.base import (
     BaseDict,
     BaseList,
+    BaseSet,
     EmbeddedDocumentList,
     TopLevelDocumentMetaclass,
     get_document,
@@ -215,12 +216,14 @@ class DeReference:
             :class:`~mongoengine.base.ComplexBaseField`
         """
         if not items:
-            if isinstance(items, (BaseDict, BaseList)):
+            if isinstance(items, (BaseDict, BaseList, BaseSet)):
                 return items
 
             if instance:
                 if isinstance(items, dict):
                     return BaseDict(items, instance, name)
+                elif isinstance(items, set):
+                    return BaseSet(items, instance, name)
                 else:
                     return BaseList(items, instance, name)
 
@@ -238,8 +241,16 @@ class DeReference:
                     doc._data["_cls"] = _cls
                 return doc
 
-        if not hasattr(items, "items"):
-            is_list = True
+        SET = "set"
+        LIST = "list"
+        DICT = "dict"
+
+        if isinstance(items, set):
+            iterable_type = SET
+            iterator = enumerate(items)
+            data = set()
+        elif not hasattr(items, "items"):
+            iterable_type = LIST
             list_type = BaseList
             if isinstance(items, EmbeddedDocumentList):
                 list_type = EmbeddedDocumentList
@@ -247,18 +258,20 @@ class DeReference:
             iterator = enumerate(items)
             data = []
         else:
-            is_list = False
+            iterable_type = DICT
             iterator = items.items()
             data = {}
 
         depth += 1
         for k, v in iterator:
-            if is_list:
+            if iterable_type == SET:
+                data.add(v)
+            elif iterable_type == LIST:
                 data.append(v)
             else:
                 data[k] = v
 
-            if k in self.object_map and not is_list:
+            if k in self.object_map and iterable_type == DICT:
                 data[k] = self.object_map[k]
             elif isinstance(v, (Document, EmbeddedDocument)):
                 for field_name in v._fields:
@@ -271,12 +284,12 @@ class DeReference:
                         data[k]._data[field_name] = self.object_map.get(
                             (v["_ref"].collection, v["_ref"].id), v
                         )
-                    elif isinstance(v, (dict, list, tuple)) and depth <= self.max_depth:
+                    elif isinstance(v, (dict, list, tuple, set)) and depth <= self.max_depth:
                         item_name = "{}.{}.{}".format(name, k, field_name)
                         data[k]._data[field_name] = self._attach_objects(
                             v, depth, instance=instance, name=item_name
                         )
-            elif isinstance(v, (dict, list, tuple)) and depth <= self.max_depth:
+            elif isinstance(v, (dict, list, tuple, set)) and depth <= self.max_depth:
                 item_name = "{}.{}".format(name, k) if name else name
                 data[k] = self._attach_objects(
                     v, depth - 1, instance=instance, name=item_name
@@ -285,7 +298,9 @@ class DeReference:
                 data[k] = self.object_map.get((v.collection, v.id), v)
 
         if instance and name:
-            if is_list:
+            if iterable_type == SET:
+                return BaseSet(data, instance, name)
+            if iterable_type == LIST:
                 return tuple(data) if as_tuple else list_type(data, instance, name)
             return BaseDict(data, instance, name)
         depth += 1

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -10,6 +10,7 @@ from mongoengine.base import (
     BaseDict,
     BaseDocument,
     BaseList,
+    BaseSet,
     DocumentMetaclass,
     EmbeddedDocumentList,
     TopLevelDocumentMetaclass,
@@ -780,6 +781,9 @@ class Document(BaseDocument, metaclass=TopLevelDocumentMetaclass):
         elif isinstance(value, BaseList):
             value = [self._reload(key, v) for v in value]
             value = BaseList(value, self, key)
+        elif isinstance(value, BaseSet):
+            value = {self._reload(key, v) for v in value}
+            value = BaseSet(value, self, key)
         elif isinstance(value, (EmbeddedDocument, DynamicEmbeddedDocument)):
             value._instance = None
             value._changed_fields = []

--- a/tests/fields/test_set_field.py
+++ b/tests/fields/test_set_field.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+from bson import InvalidDocument
+import pytest
+
+from mongoengine import *
+from mongoengine.base import BaseSet
+from mongoengine.mongodb_support import MONGODB_36, get_mongodb_version
+
+from tests.utils import MongoDBTestCase, get_as_pymongo
+
+
+def get_from_db(doc):
+    """Fetch the Document from the database"""
+    return doc.__class__.objects.get(id=doc.id)
+
+
+class TestSetField(MongoDBTestCase):
+    def test_storage(self):
+        class BlogPost(Document):
+            info = SetField()
+
+        BlogPost.drop_collection()
+        info = {"testvalue1", "testvalue2"}
+        post = BlogPost(info=info)
+        assert isinstance(post.info, BaseSet)
+
+        post.save()
+        assert isinstance(post.info, BaseSet)
+
+        post = get_from_db(post)
+        assert isinstance(post.info, BaseSet)
+
+        assert get_as_pymongo(post) == {"_id": post.id, "info": sorted(list(info))}
+
+    def test_validate_invalid_type(self):
+        class BlogPost(Document):
+            info = SetField()
+
+        BlogPost.drop_collection()
+
+        invalid_infos = ["my post", {1: "test"}]
+        for invalid_info in invalid_infos:
+            with pytest.raises(ValidationError):
+                BlogPost(info=invalid_info).validate()
+
+    def test_general_things(self):
+        """Ensure that set types work as expected."""
+
+        class BlogPost(Document):
+            info = SetField()
+
+        BlogPost.drop_collection()
+
+        post = BlogPost(info=["test1", "test2"])
+        post.save()
+
+        post = BlogPost()
+        post.info = {"test3"}
+        post.save()
+
+        post = BlogPost()
+        post.info = ["test3", "test3", "test4"]
+        post.save()
+
+        post = BlogPost()
+        post.info = {"test2", "test3", "test4"}
+        post.save()
+
+        assert BlogPost.objects.count() == 4
+        assert BlogPost.objects.filter(info="test3").count() == 3
+        assert BlogPost.objects.filter(info__0="test1").count() == 1
+        assert BlogPost.objects.filter(info__0="test2").count() == 1
+        assert BlogPost.objects.filter(info__in=["test2", "test4"]).count() == 3
+
+        post = BlogPost.objects.create(info={"test5", "test6"})
+        post.info.update({"updated"})
+        post.save()
+        post.reload()
+        assert "updated" in post.info
+
+    def test_list_and_tuples(self):
+        """Ensure that sets can be created from lists and tuples."""
+
+        class BlogPost(Document):
+            info = SetField()
+
+        BlogPost.drop_collection()
+
+        post = BlogPost(info=[1, 2, 2])
+        assert post.info == {1, 2}
+        post.save()
+        assert post.info == {1, 2}
+        post.reload()
+        assert post.info == {1, 2}
+        post = get_from_db(post)
+        assert post.info == {1, 2}
+
+        post = BlogPost()
+        post.info = [1, 2, 2]
+        assert post.info == {1, 2}
+        post.save()
+        assert post.info == {1, 2}
+        post.reload()
+        assert post.info == {1, 2}
+        post = get_from_db(post)
+        assert post.info == {1, 2}
+
+        post = BlogPost(info=(1, 2, 2))
+        assert post.info == {1, 2}
+        post.save()
+        assert post.info == {1, 2}
+        post.reload()
+        assert post.info == {1, 2}
+        post = get_from_db(post)
+        assert post.info == {1, 2}
+
+        post = BlogPost()
+        post.info = (1, 2, 2)
+        assert post.info == {1, 2}
+        post.save()
+        assert post.info == {1, 2}
+        post.reload()
+        assert post.info == {1, 2}
+        post = get_from_db(post)
+        assert post.info == {1, 2}
+
+    def test_set_field_field(self):
+        """Ensure subfields are validated."""
+        class BlogPost(Document):
+            info = SetField(BooleanField())
+
+        BlogPost.drop_collection()
+
+        with pytest.raises(ValidationError):
+            post = BlogPost()
+            post.info = {"a", "b"}
+            post.validate()

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -3,7 +3,7 @@ import unittest
 import pytest
 
 from mongoengine import Document
-from mongoengine.base.datastructures import BaseDict, BaseList, StrictDict
+from mongoengine.base.datastructures import BaseDict, BaseList, BaseSet, StrictDict
 
 
 class DocumentStub(object):
@@ -14,7 +14,7 @@ class DocumentStub(object):
         self._changed_fields.append(key)
 
 
-class TestBaseDict:
+class TestBaseDict(unittest.TestCase):
     @staticmethod
     def _get_basedict(dict_items):
         """Get a BaseList bound to a fake document instance"""
@@ -150,7 +150,7 @@ class TestBaseDict:
         assert base_dict._instance._changed_fields == ["my_name.a_new_attr"]
 
 
-class TestBaseList:
+class TestBaseList(unittest.TestCase):
     @staticmethod
     def _get_baselist(list_items):
         """Get a BaseList bound to a fake document instance"""
@@ -356,6 +356,115 @@ class TestBaseList:
         base_list = self._get_baselist([1, 2, 11])
         base_list.sort(key=lambda i: str(i))
         assert base_list == [1, 11, 2]
+
+
+class TestBaseSet(unittest.TestCase):
+    @staticmethod
+    def _get_baseset(set_items):
+        """Get a BaseSet bound to a fake document instance"""
+        fake_doc = DocumentStub()
+        base_set = BaseSet(set_items, instance=None, name="my_name")
+        base_set._instance = (
+            fake_doc  # hack to inject the mock, it does not work in the constructor
+        )
+        return base_set
+
+    def test___init___(self):
+        class MyDoc(Document):
+            pass
+
+        set_items = {True}
+        doc = MyDoc()
+        base_set = BaseSet(set_items, instance=doc, name="my_name")
+        assert isinstance(base_set._instance, Document)
+        assert base_set._name == "my_name"
+        assert base_set == set_items
+
+    def test___iter__(self):
+        values = {0, 1, 2, 2}
+        base_set = BaseSet(values, instance=None, name="my_name")
+        assert values == set(base_set)
+
+    def test_add_calls_mark_as_changed(self):
+        base_set = self._get_baseset({})
+        assert not base_set._instance._changed_fields
+        base_set.add(True)
+        assert base_set._instance._changed_fields == ["my_name"]
+
+    def test_subclass_add(self):
+        # Due to the way mark_as_changed_wrapper is implemented
+        # it is good to test subclasses
+        class SubBaseSet(BaseSet):
+            pass
+
+        base_set = SubBaseSet({}, instance=None, name="my_name")
+        base_set.add(True)
+
+    def test_update_calls_mark_as_changed(self):
+        base_set = self._get_baseset({})
+        base_set.update({True})
+        assert base_set._instance._changed_fields == ["my_name"]
+
+    def test_intersection_update_calls_mark_as_changed(self):
+        base_set = self._get_baseset({True, False})
+        base_set.intersection_update({True})
+        assert base_set._instance._changed_fields == ["my_name"]
+
+    def test_difference_update_calls_mark_as_changed(self):
+        base_set = self._get_baseset({True, False})
+        base_set.difference_update({True})
+        assert base_set._instance._changed_fields == ["my_name"]
+
+    def test_symmetric_difference_update_calls_mark_as_changed(self):
+        base_set = self._get_baseset({0, 1})
+        base_set.symmetric_difference_update({1, 2})
+        assert base_set._instance._changed_fields == ["my_name"]
+
+    def test_remove_calls_mark_as_changed(self):
+        base_set = self._get_baseset({True})
+        base_set.remove(True)
+        assert base_set._instance._changed_fields == ["my_name"]
+
+    def test_remove_not_mark_as_changed_when_it_fails(self):
+        base_set = self._get_baseset({True})
+        with pytest.raises(KeyError):
+            base_set.remove(False)
+        assert not base_set._instance._changed_fields
+
+    def test_discard_calls_mark_as_changed(self):
+        base_set = self._get_baseset({True})
+        base_set.discard(True)
+        assert base_set._instance._changed_fields == ["my_name"]
+
+    def test_pop_calls_mark_as_changed(self):
+        base_set = self._get_baseset({True})
+        base_set.pop()
+        assert base_set._instance._changed_fields == ["my_name"]
+
+    def test_clear_calls_mark_as_changed(self):
+        base_set = self._get_baseset({True})
+        base_set.clear()
+        assert base_set._instance._changed_fields == ["my_name"]
+
+    def test___ior___calls_mark_as_changed(self):
+        base_set = self._get_baseset({})
+        base_set |= {True}
+        assert base_set._instance._changed_fields == ["my_name"]
+
+    def test___iand___calls_mark_as_changed(self):
+        base_set = self._get_baseset({True, False})
+        base_set &= {True}
+        assert base_set._instance._changed_fields == ["my_name"]
+
+    def test___isub___calls_mark_as_changed(self):
+        base_set = self._get_baseset({True, False})
+        base_set -= {True}
+        assert base_set._instance._changed_fields == ["my_name"]
+
+    def test___ixor___calls_mark_as_changed(self):
+        base_set = self._get_baseset({0, 1})
+        base_set ^= {1, 2}
+        assert base_set._instance._changed_fields == ["my_name"]
 
 
 class TestStrictDict(unittest.TestCase):


### PR DESCRIPTION
`SetField` inherits from `ListField` and is represented as a list on the database side of things. The differences from `ListField` are that instead of containing a `BaseList` object, a document's field contains a `BaseSet` object.

A `SetField` can be assigned a list or tuple, but will be cast as a set.

In order to make sets stored to the database deterministic, sets are stored as sorted lists.

I have not changed the documentation. If everything seems good I'll make the effort.

- [X] support for `SetField`
- [X] tests
- [ ] documentation

Closes #2336