### PR TITLE
Adding EnumField 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -257,3 +257,4 @@ that much better:
  * Matthew Simpson (https://github.com/mcsimps2)
  * Leonardo Domingues (https://github.com/leodmgs)
  * Agustin Barto (https://github.com/abarto)
+ * François Schmidts (https://github.com/jaesivsm)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 Development
 ===========
 - (Fill this out as you fix issues and develop your features).
+- Add support for python enum in Mongoengine with the ``mongoengine.fields.EnumField`` #2348
 - Fix a bug that made the queryset drop the read_preference after clone().
 - Fix the behavior of Doc.objects.limit(0) which should return all documents (similar to mongodb) #2311
 

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -2642,7 +2642,7 @@ class EnumField(BaseField):
 
     def __init__(self, enum, *args, **kwargs):
         self.enum = enum
-        kwargs['choices'] = [choice for choice in enum]
+        kwargs["choices"] = [choice for choice in enum]
         super().__init__(*args, **kwargs)
 
     def __set__(self, instance, value):

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -2642,8 +2642,7 @@ class EnumField(BaseField):
 
     def __init__(self, enum, *args, **kwargs):
         self.enum = enum
-        if kwargs.get('required'):
-            kwargs['choices'] = [choice for choice in enum]
+        kwargs['choices'] = [choice for choice in enum]
         super().__init__(*args, **kwargs)
 
     def __set__(self, instance, value):

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -2636,8 +2636,7 @@ class GenericLazyReferenceField(GenericReferenceField):
 
 class EnumField(BaseField):
     """A field limited to choices available in the provided enumeration.
-    If `required` is True, the choices are limited to the ones of the provided
-    enumeration.
+    Choices are limited to the ones of the provided enumeration.
     """
 
     def __init__(self, enum, *args, **kwargs):

--- a/tests/fields/test_enum_fields.py
+++ b/tests/fields/test_enum_fields.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+import unittest
+from enum import Enum
+from mongoengine import Document, EnumField
+from tests.utils import MongoDBTestCase
+
+
+class TestField(MongoDBTestCase):
+
+    def test_enum_field(self):
+        class Letters(Enum):
+            A = 'a'
+            B = 'b'
+            C = 'c'
+
+        class Model(Document):
+            letter_required = EnumField(Letters, required=True)
+            letter_optional = EnumField(Letters)
+
+        m = Model(letter_required='a')
+        assert m.letter_required is Letters.A
+        assert m.letter_optional is None
+        assert m.validate() is None
+
+        m.letter_required = Letters.C
+        m.letter_optional = Letters.B
+        assert m.letter_required is Letters.C
+        assert m.letter_optional is Letters.B
+        assert m.validate() is None
+
+        m.letter_required = 'd'
+        validation = None
+        try:
+            m.validate()
+        except Exception as error:
+            validation = error
+        assert validation is not None
+
+        m.letter_required = 'a'
+        m.letter_optional = 'd'
+        validation = None
+        try:
+            m.validate()
+        except Exception as error:
+            validation = error
+        assert validation is not None
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/fields/test_enum_fields.py
+++ b/tests/fields/test_enum_fields.py
@@ -6,18 +6,17 @@ from tests.utils import MongoDBTestCase
 
 
 class TestField(MongoDBTestCase):
-
     def test_enum_field(self):
         class Letters(Enum):
-            A = 'a'
-            B = 'b'
-            C = 'c'
+            A = "a"
+            B = "b"
+            C = "c"
 
         class Model(Document):
             letter_required = EnumField(Letters, required=True)
             letter_optional = EnumField(Letters)
 
-        m = Model(letter_required='a')
+        m = Model(letter_required="a")
         assert m.letter_required is Letters.A
         assert m.letter_optional is None
         assert m.validate() is None
@@ -28,7 +27,7 @@ class TestField(MongoDBTestCase):
         assert m.letter_optional is Letters.B
         assert m.validate() is None
 
-        m.letter_required = 'd'
+        m.letter_required = "d"
         validation = None
         try:
             m.validate()
@@ -36,8 +35,8 @@ class TestField(MongoDBTestCase):
             validation = error
         assert validation is not None
 
-        m.letter_required = 'a'
-        m.letter_optional = 'd'
+        m.letter_required = "a"
+        m.letter_optional = "d"
         validation = None
         try:
             m.validate()


### PR DESCRIPTION
I wrote a while ago in the no longer maintained `extras-mongoengine` package support and validation for python Enum. 

I would like to integrate it in the main repository as well has refreshing a bit the code that, at the time relied on now outdated syntax.