### PR TITLE
Adding to_dict

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -342,7 +342,7 @@ class BaseDocument:
         return_data = {}
 
         Document = _import_class("Document")
-        EmbeddedDocument = _import_class("EmbeddedDocument")
+        EmbeddedDocumentField = _import_class("EmbeddedDocumentField")
         ListField = _import_class("ListField")
         DictField = _import_class("DictField")
 
@@ -360,25 +360,26 @@ class BaseDocument:
             data = self._data[field_name]
 
             if isinstance(self._fields[field_name], ListField):
-                return_data[field_name] = list_field_to_dict(data)
-            elif isinstance(self._fields[field_name], EmbeddedDocument):
-                return_data[field_name] = self._fields[field_name].to_dict()
+                return_data[field_name] = self.list_field_to_dict(data)
+            elif isinstance(self._fields[field_name], EmbeddedDocumentField):
+                return_data[field_name] = data.to_dict()
             elif isinstance(self._fields[field_name], DictField):
                 return_data[field_name] = data
             else:
                 return_data[field_name] = self.mongo_to_python_type(
                     self._fields[field_name], data
                 )
-        
+
         return return_data
 
     def list_field_to_dict(self, list_field):
         return_data = []
-        
+
+        Document = _import_class("Document")
         EmbeddedDocument = _import_class("EmbeddedDocument")
 
         for item in list_field:
-            if isinstance(item, EmbeddedDocument):
+            if isinstance(item, (EmbeddedDocument, Document)):
                 return_data.append(item.to_dict())
             else:
                 return_data.append(self.mongo_to_python_type(item, item))
@@ -402,7 +403,7 @@ class BaseDocument:
             rv = data.isoformat()
         elif field_type is ComplexDateTimeField:
             rv = field.to_python(data).isoformat()
-        elif rv is FloatField:
+        elif field_type is FloatField:
             rv = float(data)
         elif field_type is IntField:
             rv = int(data)

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -17,23 +17,12 @@ from mongoengine.base.datastructures import (
 )
 from mongoengine.base.fields import ComplexBaseField
 from mongoengine.common import _import_class
-from mongoengine.document import Document, EmbeddedDocument
 from mongoengine.errors import (
     FieldDoesNotExist,
     InvalidDocumentError,
     LookUpError,
     OperationError,
     ValidationError,
-)
-from mongoengine.fields import (
-    ListField,
-    DictField,
-    DateTimeField,
-    ComplexDateTimeField,
-    FloatField,
-    IntField,
-    BooleanField,
-    DecimalField,
 )
 
 __all__ = ("BaseDocument", "NON_FIELD_ERRORS")
@@ -352,6 +341,11 @@ class BaseDocument:
         """
         return_data = {}
 
+        Document = _import_class("Document")
+        EmbeddedDocument = _import_class("EmbeddedDocument")
+        ListField = _import_class("ListField")
+        DictField = _import_class("DictField")
+
         if isinstance(self, Document):
             return_data["id"] = str(self.id)
 
@@ -372,24 +366,35 @@ class BaseDocument:
             elif isinstance(self._fields[field_name], DictField):
                 return_data[field_name] = data
             else:
-                return_data[field_name] = mongo_to_python_type(
+                return_data[field_name] = self.mongo_to_python_type(
                     self._fields[field_name], data
                 )
+        
+        return return_data
 
-    def list_field_to_dict(list_field):
+    def list_field_to_dict(self, list_field):
         return_data = []
+        
+        EmbeddedDocument = _import_class("EmbeddedDocument")
 
         for item in list_field:
             if isinstance(item, EmbeddedDocument):
                 return_data.append(item.to_dict())
             else:
-                return_data.append(mongo_to_python_type(item, item))
+                return_data.append(self.mongo_to_python_type(item, item))
 
         return return_data
 
-    def mongo_to_python_type(field, data):
+    def mongo_to_python_type(self, field, data):
         rv = None
         field_type = type(field)
+
+        DateTimeField = _import_class("DateTimeField")
+        ComplexDateTimeField = _import_class("ComplexDateTimeField")
+        FloatField = _import_class("FloatField")
+        IntField = _import_class("IntField")
+        BooleanField = _import_class("BooleanField")
+        DecimalField = _import_class("DecimalField")
 
         if data is None:
             rv = None

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -2179,6 +2179,43 @@ class SequenceField(BaseField):
         return value
 
 
+class EnumField(BaseField):
+    """
+    https://github.com/MongoEngine/extras-mongoengine/blob/master/
+    extras_mongoengine/fields.py
+    A class to register Enum type (from the package enum34) into mongo
+    :param choices: must be of :class:`enum.Enum`: type
+        and will be used as possible choices
+    """
+
+    def __init__(self, enum, *args, **kwargs):
+        self.enum = enum
+        kwargs['choices'] = [choice for choice in enum]
+        super(EnumField, self).__init__(*args, **kwargs)
+
+    def __get_value(self, enum):
+        return enum.value if hasattr(enum, 'value') else enum
+
+    def to_python(self, value):
+        return self.enum(super(EnumField, self).to_python(value))
+
+    def to_mongo(self, value):
+        return self.__get_value(value)
+
+    def prepare_query_value(self, op, value):
+        return super(EnumField, self).prepare_query_value(
+            op, self.__get_value(value)
+        )
+
+    def validate(self, value):
+        return super(EnumField, self).validate(self.__get_value(value))
+
+    def _validate(self, value, **kwargs):
+        return super(EnumField, self)._validate(
+            self.enum(self.__get_value(value)), **kwargs
+        )
+
+
 class UUIDField(BaseField):
     """A UUID field.
 

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -2179,43 +2179,6 @@ class SequenceField(BaseField):
         return value
 
 
-class EnumField(BaseField):
-    """
-    https://github.com/MongoEngine/extras-mongoengine/blob/master/
-    extras_mongoengine/fields.py
-    A class to register Enum type (from the package enum34) into mongo
-    :param choices: must be of :class:`enum.Enum`: type
-        and will be used as possible choices
-    """
-
-    def __init__(self, enum, *args, **kwargs):
-        self.enum = enum
-        kwargs['choices'] = [choice for choice in enum]
-        super(EnumField, self).__init__(*args, **kwargs)
-
-    def __get_value(self, enum):
-        return enum.value if hasattr(enum, 'value') else enum
-
-    def to_python(self, value):
-        return self.enum(super(EnumField, self).to_python(value))
-
-    def to_mongo(self, value):
-        return self.__get_value(value)
-
-    def prepare_query_value(self, op, value):
-        return super(EnumField, self).prepare_query_value(
-            op, self.__get_value(value)
-        )
-
-    def validate(self, value):
-        return super(EnumField, self).validate(self.__get_value(value))
-
-    def _validate(self, value, **kwargs):
-        return super(EnumField, self)._validate(
-            self.enum(self.__get_value(value)), **kwargs
-        )
-
-
 class UUIDField(BaseField):
     """A UUID field.
 

--- a/tests/document/test_instance.py
+++ b/tests/document/test_instance.py
@@ -3746,6 +3746,77 @@ class TestDocumentInstance(MongoDBTestCase):
             value
         )
 
+    def test_doc_to_dict(self):
+        class Character(EmbeddedDocument):
+            name = StringField()
+            age = IntField()
+            appears = ListField()
+
+            meta = {"allow_inheritance": False}
+
+        class DataSheet(EmbeddedDocument):
+            year = StringField()
+            author = StringField()
+            rank = DecimalField()
+
+            meta = {"allow_inheritance": False}
+
+        class Series(Document):
+            title = StringField()
+            number_of_chapters = IntField()
+            active = BooleanField()
+            rating = FloatField()
+            info = EmbeddedDocumentField(DataSheet)
+            characters = ListField()
+            secret_code = StringField()
+            extras = StringField()
+            additional_info = DictField()
+            created_at = DateTimeField(default=datetime.now)
+            updated_at = ComplexDateTimeField(default=datetime.now)
+
+        serie = Series(
+            title="Some Random Series",
+            number_of_chapters=12,
+            active=True,
+            rating=4.8,
+            characters=[
+                Character(
+                    name="Emma", age=11, appears=["chapter 1", "chapter 2", "chapter 3"]
+                ),
+                Character(
+                    name="Ray", age=12, appears=["chapter 1", "chapter 2", "chapter 3"]
+                ),
+                Character(
+                    name="Norman",
+                    age=11,
+                    appears=["chapter 1", "chapter 2", "chapter 3"],
+                ),
+            ],
+            info=DataSheet(year="2019", author="Kaiu", rank=4.4),
+            secret_code="super_secret_code",
+            additional_info={"data": "he63oc48r5jv"},
+        )
+
+        serie.save()
+
+        res = serie.to_dict(exclude_fields=["secret_code"])
+
+        assert type(res['title']) is str
+        assert type(res['number_of_chapters']) is int
+        assert type(res['active']) is bool
+        assert type(res['rating']) is float
+        assert type(res['characters']) is list
+        assert type(res['characters'][0]) is dict
+        assert type(res['characters'][0]['name']) is str
+        assert type(res['characters'][0]['age']) is int
+        assert type(res['characters'][0]['appears']) is list
+        assert type(res['info']) is dict
+        assert type(res['info']['author']) is str
+        assert 'secret_code' not in res
+        assert type(res['additional_info']) is dict
+        assert type(res['created_at']) is str
+        assert type(res['updated_at']) is str
+
 
 class ObjectKeyTestCase(MongoDBTestCase):
     def test_object_key_simple_document(self):

--- a/tests/document/test_instance.py
+++ b/tests/document/test_instance.py
@@ -3801,21 +3801,21 @@ class TestDocumentInstance(MongoDBTestCase):
 
         res = serie.to_dict(exclude_fields=["secret_code"])
 
-        assert type(res['title']) is str
-        assert type(res['number_of_chapters']) is int
-        assert type(res['active']) is bool
-        assert type(res['rating']) is float
-        assert type(res['characters']) is list
-        assert type(res['characters'][0]) is dict
-        assert type(res['characters'][0]['name']) is str
-        assert type(res['characters'][0]['age']) is int
-        assert type(res['characters'][0]['appears']) is list
-        assert type(res['info']) is dict
-        assert type(res['info']['author']) is str
-        assert 'secret_code' not in res
-        assert type(res['additional_info']) is dict
-        assert type(res['created_at']) is str
-        assert type(res['updated_at']) is str
+        assert type(res["title"]) is str
+        assert type(res["number_of_chapters"]) is int
+        assert type(res["active"]) is bool
+        assert type(res["rating"]) is float
+        assert type(res["characters"]) is list
+        assert type(res["characters"][0]) is dict
+        assert type(res["characters"][0]["name"]) is str
+        assert type(res["characters"][0]["age"]) is int
+        assert type(res["characters"][0]["appears"]) is list
+        assert type(res["info"]) is dict
+        assert type(res["info"]["author"]) is str
+        assert "secret_code" not in res
+        assert type(res["additional_info"]) is dict
+        assert type(res["created_at"]) is str
+        assert type(res["updated_at"]) is str
 
 
 class ObjectKeyTestCase(MongoDBTestCase):


### PR DESCRIPTION
Added a `to_dict` functionality in the `BaseDocument` class. This transforms a class that inherits from this class, into a dictionary with the possibility of excluding certain fields.

Related issue: #2347

No longer implementing EnumField since it has an open PR (#2348) 