### PR TITLE
Use full qualified class name on _document_registry

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -257,3 +257,4 @@ that much better:
  * Matthew Simpson (https://github.com/mcsimps2)
  * Leonardo Domingues (https://github.com/leodmgs)
  * Agustin Barto (https://github.com/abarto)
+ * Cesar Charria (https://github.com/ceorcham)

--- a/mongoengine/base/common.py
+++ b/mongoengine/base/common.py
@@ -29,6 +29,11 @@ def get_document(name):
     """Get a registered Document class by name."""
     doc = _document_registry.get(name, None)
     if not doc:
+        # Look for qualified name
+        possible_match = [k for k in _document_registry if k.endswith(name)]
+        if len(possible_match) == 1:
+            return _document_registry.get(possible_match.pop(), None)
+
         # Possible old style name
         single_end = name.split(".")[-1]
         compound_end = ".%s" % single_end

--- a/mongoengine/base/metaclasses.py
+++ b/mongoengine/base/metaclasses.py
@@ -166,7 +166,13 @@ class DocumentMetaclass(type):
             new_class._collection = None
 
         # Add class to the _document_registry
-        _document_registry[new_class._class_name] = new_class
+        registry_path = []
+        if new_class.__module__:
+            registry_path.append(new_class.__module__)
+        registry_path.extend(new_class.__qualname__.split(".")[:-1])
+        registry_path.append(new_class._class_name)
+
+        _document_registry[".".join(registry_path)] = new_class
 
         # Handle delete rules
         for field in new_class._fields.values():

--- a/tests/document/test_delta.py
+++ b/tests/document/test_delta.py
@@ -4,7 +4,7 @@ import unittest
 from bson import SON
 from mongoengine import *
 from mongoengine.pymongo_support import list_collection_names
-from tests.utils import MongoDBTestCase
+from tests.utils import MongoDBTestCase, clear_document_registry
 
 
 class TestDelta(MongoDBTestCase):
@@ -292,6 +292,8 @@ class TestDelta(MongoDBTestCase):
         self.circular_reference_deltas(DynamicDocument, DynamicDocument)
 
     def circular_reference_deltas(self, DocClass1, DocClass2):
+        clear_document_registry()
+
         class Person(DocClass1):
             name = StringField()
             owns = ListField(ReferenceField("Organization"))
@@ -324,6 +326,8 @@ class TestDelta(MongoDBTestCase):
         self.circular_reference_deltas_2(DynamicDocument, DynamicDocument)
 
     def circular_reference_deltas_2(self, DocClass1, DocClass2, dbref=True):
+        clear_document_registry()
+
         class Person(DocClass1):
             name = StringField()
             owns = ListField(ReferenceField("Organization", dbref=dbref))
@@ -641,6 +645,8 @@ class TestDelta(MongoDBTestCase):
         )
 
     def test_delta_for_dynamic_documents(self):
+        clear_document_registry()
+
         class Person(DynamicDocument):
             name = StringField()
             meta = {"allow_inheritance": True}

--- a/tests/document/test_dynamic.py
+++ b/tests/document/test_dynamic.py
@@ -3,7 +3,7 @@ import unittest
 import pytest
 
 from mongoengine import *
-from tests.utils import MongoDBTestCase
+from tests.utils import MongoDBTestCase, clear_document_registry
 
 __all__ = ("TestDynamicDocument",)
 
@@ -153,6 +153,8 @@ class TestDynamicDocument(MongoDBTestCase):
         assert 22 == p.age
 
     def test_complex_dynamic_document_queries(self):
+        clear_document_registry()
+
         class Person(DynamicDocument):
             name = StringField()
 
@@ -335,6 +337,7 @@ class TestDynamicDocument(MongoDBTestCase):
 
     def test_dynamic_and_embedded(self):
         """Ensure embedded documents play nicely"""
+        clear_document_registry()
 
         class Address(EmbeddedDocument):
             city = StringField()
@@ -365,6 +368,7 @@ class TestDynamicDocument(MongoDBTestCase):
 
     def test_dynamic_embedded_works_with_only(self):
         """Ensure custom fieldnames on a dynamic embedded document are found by qs.only()"""
+        clear_document_registry()
 
         class Address(DynamicEmbeddedDocument):
             city = StringField()
@@ -386,6 +390,7 @@ class TestDynamicDocument(MongoDBTestCase):
 
     def test_dynamic_and_embedded_dict_access(self):
         """Ensure embedded dynamic documents work with dict[] style access"""
+        clear_document_registry()
 
         class Address(EmbeddedDocument):
             city = StringField()

--- a/tests/document/test_inheritance.py
+++ b/tests/document/test_inheritance.py
@@ -15,7 +15,6 @@ from mongoengine import (
     StringField,
 )
 from mongoengine.pymongo_support import list_collection_names
-from tests.fixtures import Base
 from tests.utils import MongoDBTestCase
 
 
@@ -78,6 +77,9 @@ class TestInheritance(MongoDBTestCase):
         """Ensure that the correct list of super classes is assembled when
         importing part of the model.
         """
+
+        class Base(Document):
+            meta = {"allow_inheritance": True}
 
         class Animal(Base):
             pass
@@ -148,6 +150,9 @@ class TestInheritance(MongoDBTestCase):
         """Ensure that the correct list of _subclasses (subclasses) is
         assembled when importing part of the model.
         """
+
+        class Base(Document):
+            meta = {"allow_inheritance": True}
 
         class Animal(Base):
             pass

--- a/tests/fields/test_fields.py
+++ b/tests/fields/test_fields.py
@@ -1667,7 +1667,9 @@ class TestField(MongoDBTestCase):
 
         # Mimic User and Link definitions being in a different file
         # and the Link model not being imported in the User file.
-        del _document_registry["Link"]
+        del _document_registry[
+            "tests.fields.test_fields.TestField.test_generic_reference_document_not_registered.<locals>.Link"
+        ]
 
         user = User.objects.first()
         try:
@@ -2280,6 +2282,7 @@ class TestEmbeddedDocumentListField(MongoDBTestCase):
         Create two BlogPost entries in the database, each with
         several EmbeddedDocuments.
         """
+        super(TestEmbeddedDocumentListField, self).setUp()
 
         class Comments(EmbeddedDocument):
             author = StringField()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -55,7 +55,3 @@ signals.post_delete.connect(PickleSignalsTest.post_delete, sender=PickleSignalsT
 
 class Mixin(object):
     name = StringField()
-
-
-class Base(Document):
-    meta = {"allow_inheritance": True}

--- a/tests/queryset/test_queryset.py
+++ b/tests/queryset/test_queryset.py
@@ -25,6 +25,8 @@ from mongoengine.queryset import (
     queryset_manager,
 )
 
+from tests.utils import clear_document_registry
+
 
 class db_ops_tracker(query_counter):
     def get_ops(self):
@@ -43,6 +45,7 @@ def get_key_compat(mongo_ver):
 
 class TestQueryset(unittest.TestCase):
     def setUp(self):
+        clear_document_registry()
         connect(db="mongoenginetest")
         connect(db="mongoenginetest2", alias="test2")
 
@@ -1084,6 +1087,7 @@ class TestQueryset(unittest.TestCase):
         """Make sure we don't perform unnecessary db operations when
         none of document's fields were updated.
         """
+        clear_document_registry()
 
         class Person(Document):
             name = StringField()
@@ -2731,6 +2735,7 @@ class TestQueryset(unittest.TestCase):
         """
         Test map/reduce custom output
         """
+        clear_document_registry()
         register_connection("test2", "mongoenginetest2")
 
         class Family(Document):
@@ -3061,6 +3066,7 @@ class TestQueryset(unittest.TestCase):
     def test_item_frequencies_on_embedded(self):
         """Ensure that item frequencies are properly generated from lists.
         """
+        clear_document_registry()
 
         class Phone(EmbeddedDocument):
             number = StringField()
@@ -3122,6 +3128,8 @@ class TestQueryset(unittest.TestCase):
         test_assertions(map_reduce)
 
     def test_item_frequencies_null_values(self):
+        clear_document_registry()
+
         class Person(Document):
             name = StringField()
             city = StringField()
@@ -3142,6 +3150,8 @@ class TestQueryset(unittest.TestCase):
         assert freq == {"CRB": 0.5, None: 0.5}
 
     def test_item_frequencies_with_null_embedded(self):
+        clear_document_registry()
+
         class Data(EmbeddedDocument):
             name = StringField()
 
@@ -4286,6 +4296,8 @@ class TestQueryset(unittest.TestCase):
         assert ulist == [(u"Tayza"), (u"Wilson Jr"), (u"Eliana"), (u"Wilson")]
 
     def test_scalar_embedded(self):
+        clear_document_registry()
+
         class Profile(EmbeddedDocument):
             name = StringField()
             age = IntField()
@@ -4339,6 +4351,8 @@ class TestQueryset(unittest.TestCase):
     def test_scalar_decimal(self):
         from decimal import Decimal
 
+        clear_document_registry()
+
         class Person(Document):
             name = StringField()
             rating = DecimalField()
@@ -4350,6 +4364,8 @@ class TestQueryset(unittest.TestCase):
         assert ulist == [(u"Wilson Jr", Decimal("1.0"))]
 
     def test_scalar_reference_field(self):
+        clear_document_registry()
+
         class State(Document):
             name = StringField()
 
@@ -4369,6 +4385,8 @@ class TestQueryset(unittest.TestCase):
         assert plist == [(u"Wilson JR", s1)]
 
     def test_scalar_generic_reference_field(self):
+        clear_document_registry()
+
         class State(Document):
             name = StringField()
 
@@ -5144,6 +5162,8 @@ class TestQueryset(unittest.TestCase):
         assert isinstance(org.members[0].user, DBRef)
 
     def test_cached_queryset(self):
+        clear_document_registry()
+
         class Person(Document):
             name = StringField()
 
@@ -5175,6 +5195,8 @@ class TestQueryset(unittest.TestCase):
             assert q == 1
 
     def test_no_cached_queryset(self):
+        clear_document_registry()
+
         class Person(Document):
             name = StringField()
 
@@ -5196,6 +5218,8 @@ class TestQueryset(unittest.TestCase):
             assert q == 3
 
     def test_no_cached_queryset__repr__(self):
+        clear_document_registry()
+
         class Person(Document):
             name = StringField()
 
@@ -5204,6 +5228,8 @@ class TestQueryset(unittest.TestCase):
         assert repr(qs) == "[]"
 
     def test_no_cached_on_a_cached_queryset_raise_error(self):
+        clear_document_registry()
+
         class Person(Document):
             name = StringField()
 
@@ -5215,6 +5241,8 @@ class TestQueryset(unittest.TestCase):
             qs.no_cache()
 
     def test_no_cached_queryset_no_cache_back_to_cache(self):
+        clear_document_registry()
+
         class Person(Document):
             name = StringField()
 
@@ -5473,6 +5501,8 @@ class TestQueryset(unittest.TestCase):
             )
 
     def test_bool_performance(self):
+        clear_document_registry()
+
         class Person(Document):
             name = StringField()
 
@@ -5492,6 +5522,7 @@ class TestQueryset(unittest.TestCase):
             assert op["nreturned"] == 1
 
     def test_bool_with_ordering(self):
+        clear_document_registry()
         ORDER_BY_KEY, CMD_QUERY_KEY = get_key_compat(self.mongodb_version)
 
         class Person(Document):
@@ -5528,6 +5559,7 @@ class TestQueryset(unittest.TestCase):
             assert ORDER_BY_KEY in op[CMD_QUERY_KEY]
 
     def test_bool_with_ordering_from_meta_dict(self):
+        clear_document_registry()
         ORDER_BY_KEY, CMD_QUERY_KEY = get_key_compat(self.mongodb_version)
 
         class Person(Document):
@@ -5598,6 +5630,8 @@ class TestQueryset(unittest.TestCase):
         assert Animal.objects(whiskers_length=5.1).count() == 1
 
     def test_loop_over_invalid_id_does_not_crash(self):
+        clear_document_registry()
+
         class Person(Document):
             name = StringField()
 

--- a/tests/test_context_managers.py
+++ b/tests/test_context_managers.py
@@ -3,6 +3,7 @@ import unittest
 import pytest
 
 from mongoengine import *
+from mongoengine.base.common import _document_registry
 from mongoengine.connection import get_db
 from mongoengine.context_managers import (
     no_dereference,
@@ -14,6 +15,8 @@ from mongoengine.context_managers import (
     switch_db,
 )
 from mongoengine.pymongo_support import count_documents
+
+from tests.utils import clear_document_registry
 
 
 class TestContextManagers:
@@ -38,6 +41,7 @@ class TestContextManagers:
         assert original_write_concern.document == collection.write_concern.document
 
     def test_set_read_write_concern(self):
+        clear_document_registry()
         connect("mongoenginetest")
 
         class User(Document):
@@ -64,6 +68,7 @@ class TestContextManagers:
         assert original_write_concern.document == collection.write_concern.document
 
     def test_switch_db_context_manager(self):
+        clear_document_registry()
         connect("mongoenginetest")
         register_connection("testdb-1", "mongoenginetest2")
 
@@ -89,6 +94,7 @@ class TestContextManagers:
         assert 1 == Group.objects.count()
 
     def test_switch_collection_context_manager(self):
+        clear_document_registry()
         connect("mongoenginetest")
         register_connection(alias="testdb-1", db="mongoenginetest2")
 
@@ -119,6 +125,7 @@ class TestContextManagers:
     def test_no_dereference_context_manager_object_id(self):
         """Ensure that DBRef items in ListFields aren't dereferenced.
         """
+        clear_document_registry()
         connect("mongoenginetest")
 
         class User(Document):
@@ -157,6 +164,7 @@ class TestContextManagers:
     def test_no_dereference_context_manager_dbref(self):
         """Ensure that DBRef items in ListFields aren't dereferenced.
         """
+        clear_document_registry()
         connect("mongoenginetest")
 
         class User(Document):
@@ -191,6 +199,8 @@ class TestContextManagers:
         assert isinstance(group.generic, User)
 
     def test_no_sub_classes(self):
+        clear_document_registry()
+
         class A(Document):
             x = IntField()
             meta = {"allow_inheritance": True}
@@ -237,6 +247,8 @@ class TestContextManagers:
         assert C.objects.count() == 1
 
     def test_no_sub_classes_modification_to_document_class_are_temporary(self):
+        clear_document_registry()
+
         class A(Document):
             x = IntField()
             meta = {"allow_inheritance": True}
@@ -255,6 +267,8 @@ class TestContextManagers:
         assert B._subclasses == ("A.B",)
 
     def test_no_subclass_context_manager_does_not_swallow_exception(self):
+        clear_document_registry()
+
         class User(Document):
             name = StringField()
 
@@ -332,6 +346,7 @@ class TestContextManagers:
 
     def test_query_counter_alias(self):
         """query_counter works properly with db aliases?"""
+        clear_document_registry()
         # Register a connection with db_alias testdb-1
         register_connection("testdb-1", "mongoenginetest2")
 

--- a/tests/test_dereference.py
+++ b/tests/test_dereference.py
@@ -6,6 +6,8 @@ from bson import DBRef, ObjectId
 from mongoengine import *
 from mongoengine.context_managers import query_counter
 
+from tests.utils import clear_document_registry
+
 
 class FieldTest(unittest.TestCase):
     @classmethod
@@ -15,6 +17,12 @@ class FieldTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.db.drop_database("mongoenginetest")
+
+    def setUp(self):
+        clear_document_registry()
+
+    def tearDown(self):
+        clear_document_registry()
 
     def test_list_item_dereference(self):
         """Ensure that DBRef items in ListFields are dereferenced.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,7 @@ import unittest
 import pytest
 
 from mongoengine import connect
+from mongoengine.base.common import _document_registry
 from mongoengine.connection import disconnect_all, get_db
 from mongoengine.mongodb_support import get_mongodb_version
 
@@ -10,10 +11,22 @@ from mongoengine.mongodb_support import get_mongodb_version
 MONGO_TEST_DB = "mongoenginetest"  # standard name for the test database
 
 
+def clear_document_registry():
+    to_delete = [x for x in _document_registry if not x.startswith("tests.fixtures.")]
+    for x in to_delete:
+        del _document_registry[x]
+
+
 class MongoDBTestCase(unittest.TestCase):
     """Base class for tests that need a mongodb connection
     It ensures that the db is clean at the beginning and dropped at the end automatically
     """
+
+    def setUp(self):
+        clear_document_registry()
+
+    def tearDown(self):
+        clear_document_registry()
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Store class references using the __module__ and __qualname__ instead of _class_name.

This allows to have classes with same name on different modules,
nested classes or local classes

See https://github.com/MongoEngine/mongoengine/issues/1319