### PR TITLE
Pymongo >= 3.70 no longer supports count

### DIFF
--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -398,22 +398,14 @@ class BaseQuerySet:
         )
         return results[0] if return_one else results
 
-    def count(self, with_limit_and_skip=False):
+    def count(self, *args, **kwargs):
         """Count the selected elements in the query.
 
         :param with_limit_and_skip (optional): take any :meth:`limit` or
             :meth:`skip` that has been applied to this cursor into account when
             getting the count
         """
-        if (
-            self._limit == 0
-            and with_limit_and_skip is False
-            or self._none
-            or self._empty
-        ):
-            return 0
-        count = self._cursor.count(with_limit_and_skip=with_limit_and_skip)
-        self._cursor_obj = None
+        count = self._collection_obj.count_documents(*args,**kwargs)
         return count
 
     def delete(self, write_concern=None, _from_doc_delete=False, cascade_refs=None):


### PR DESCRIPTION
I updated `count` in `queryset/base` to use the recently added [`Collection.count_documents`](https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.count_documents) function from `pymongo` instead of the depreciated[`Cursor.count`](https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.counts). 


The previous function took specific parameters, where mine is transparent. Let me know if you would prefer me to change or add anything.


