### PR TITLE
Fix query transformation regarding special operators

### DIFF
--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -639,7 +639,7 @@ class Document(BaseDocument, metaclass=TopLevelDocumentMetaclass):
                 write_concern=write_concern, _from_doc_delete=True
             )
         except pymongo.errors.OperationFailure as err:
-            message = "Could not delete document (%s)" % err.message
+            message = "Could not delete document (%s)" % err.args
             raise OperationError(message)
         signals.post_delete.send(self.__class__, document=self, **signal_kwargs)
 

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -774,7 +774,7 @@ class EmbeddedDocumentField(BaseField):
     def prepare_query_value(self, op, value):
         if value is not None and not isinstance(value, self.document_type):
             # Short circuit for special operators, returning them as is
-            if isinstance(value, dict) and all(k.startswith('$') for k in value.keys()):
+            if isinstance(value, dict) and all(k.startswith("$") for k in value.keys()):
                 return value
             try:
                 value = self.document_type._from_son(value)

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -773,6 +773,9 @@ class EmbeddedDocumentField(BaseField):
 
     def prepare_query_value(self, op, value):
         if value is not None and not isinstance(value, self.document_type):
+            # Short circuit for special operators, returning them as is
+            if isinstance(value, dict) and all(k.startswith('$') for k in value.keys()):
+                return value
             try:
                 value = self.document_type._from_son(value)
             except ValueError:

--- a/tests/queryset/test_transform.py
+++ b/tests/queryset/test_transform.py
@@ -344,6 +344,36 @@ class TestTransform(unittest.TestCase):
         )
         assert update == {"$pull": {"content.text": {"word": {"$nin": ["foo", "bar"]}}}}
 
+    def test_transform_embedded_document_list_fields(self):
+        """
+        Test added to check filtering
+        EmbeddedDocumentListField which is inside a EmbeddedDocumentField
+        """
+
+        class Drink(EmbeddedDocument):
+            id = StringField()
+            meta = {
+                'strict': False
+            }
+
+        class Shop(Document):
+            drinks = EmbeddedDocumentListField(Drink)
+
+        Shop.drop_collection()
+        drinks = [Drink(id='drink_1'), Drink(id='drink_2')]
+        Shop.objects.create(drinks=drinks)
+        q_obj = transform.query(
+            Shop,
+            drinks__all=[{'$elemMatch': {'_id': x.id}} for x in drinks]
+        )
+        assert q_obj == {
+            'drinks': {
+                '$all': [{'$elemMatch': {'_id': x.id}} for x in drinks]
+            }
+        }
+
+        Shop.drop_collection()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/queryset/test_transform.py
+++ b/tests/queryset/test_transform.py
@@ -352,24 +352,19 @@ class TestTransform(unittest.TestCase):
 
         class Drink(EmbeddedDocument):
             id = StringField()
-            meta = {
-                'strict': False
-            }
+            meta = {"strict": False}
 
         class Shop(Document):
             drinks = EmbeddedDocumentListField(Drink)
 
         Shop.drop_collection()
-        drinks = [Drink(id='drink_1'), Drink(id='drink_2')]
+        drinks = [Drink(id="drink_1"), Drink(id="drink_2")]
         Shop.objects.create(drinks=drinks)
         q_obj = transform.query(
-            Shop,
-            drinks__all=[{'$elemMatch': {'_id': x.id}} for x in drinks]
+            Shop, drinks__all=[{"$elemMatch": {"_id": x.id}} for x in drinks]
         )
         assert q_obj == {
-            'drinks': {
-                '$all': [{'$elemMatch': {'_id': x.id}} for x in drinks]
-            }
+            "drinks": {"$all": [{"$elemMatch": {"_id": x.id}} for x in drinks]}
         }
 
         Shop.drop_collection()


### PR DESCRIPTION
See the test for my failed scenario. It's reduced down from my original query a bit to focus on the culprit.
The query in the test would return something like:
```python
{'drinks': {'$all': [{}, {}]}}
```
Whereas it should really return what I asserted:
```python
{ 'drinks': {'$all': [{'$elemMatch': {'_id': 'drink_1'}, {'$elemMatch': {'_id': 'drink_1'}]}}
```