### PR TITLE
Fix readthedocs build that failed

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,20 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+  - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pymongo>=3.4
-Sphinx==1.5.5
-sphinx-rtd-theme==0.2.4
+pymongo>=3.11
+Sphinx==3.2.1
+sphinx-rtd-theme==0.5.0


### PR DESCRIPTION
Fixes #2395
Force it to use python 3.7 instead of the default 2.7
Python 3 is the default for readthedocs but since the project is old, it still defaults to 2.7 unless explicitly stated (through a .readthedocs.yml) 