### PR TITLE
Bugfix #2154

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -257,3 +257,4 @@ that much better:
  * Matthew Simpson (https://github.com/mcsimps2)
  * Leonardo Domingues (https://github.com/leodmgs)
  * Agustin Barto (https://github.com/abarto)
+ * Felix Schultheiß (https://github.com/felix-smashdocs)

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -492,6 +492,9 @@ class Document(BaseDocument, metaclass=TopLevelDocumentMetaclass):
         return update_doc
 
     def _integrate_shard_key(self, doc, select_dict):
+        """Integrates the collection's shard key to the `select_dict`, which will be used for the query.
+        The value from the shard key is taken from the `doc` and finally the select_dict is returned.
+        """
 
         # Need to add shard key to query, or you get an error
         shard_key = self._meta.get("shard_key", tuple())
@@ -504,7 +507,6 @@ class Document(BaseDocument, metaclass=TopLevelDocumentMetaclass):
             select_dict[".".join(actual_key)] = val
 
         return select_dict
-
 
     def _save_update(self, doc, save_condition, write_concern):
         """Update an existing document.

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -466,9 +466,7 @@ class Document(BaseDocument, metaclass=TopLevelDocumentMetaclass):
             if "_id" in doc:
                 select_dict = {"_id": doc["_id"]}
                 select_dict = self._integrate_shard_key(doc, select_dict)
-                raw_object = wc_collection.find_one_and_replace(
-                    select_dict, doc
-                )
+                raw_object = wc_collection.find_one_and_replace(select_dict, doc)
                 if raw_object:
                     return doc["_id"]
 
@@ -930,7 +928,7 @@ class Document(BaseDocument, metaclass=TopLevelDocumentMetaclass):
 
     @classmethod
     def list_indexes(cls):
-        """ Lists all of the indexes that should be created for given
+        """Lists all of the indexes that should be created for given
         collection. It includes all the indexes from super- and sub-classes.
         """
         if cls._meta.get("abstract"):
@@ -995,7 +993,7 @@ class Document(BaseDocument, metaclass=TopLevelDocumentMetaclass):
 
     @classmethod
     def compare_indexes(cls):
-        """ Compares the indexes defined in MongoEngine with the ones
+        """Compares the indexes defined in MongoEngine with the ones
         existing in the database. Returns any missing/extra indexes.
         """
 

--- a/tests/document/test_instance.py
+++ b/tests/document/test_instance.py
@@ -543,19 +543,12 @@ class TestDocumentInstance(MongoDBTestCase):
         Animal.drop_collection()
         doc = Animal(is_mammal=True, name="Dog")
 
-        mongo_db = get_mongodb_version()
-
         with query_counter() as q:
             doc.save()
             query_op = q.db.system.profile.find({"ns": "mongoenginetest.animal"})[0]
             assert query_op["op"] == "command"
             assert query_op["command"]["findAndModify"] == "animal"
-            if mongo_db <= MONGODB_34:
-                assert set(query_op["query"].keys()) == set(["_id", "is_mammal"])
-            else:
-                assert set(query_op["command"]["query"].keys()) == set(
-                    ["_id", "is_mammal"]
-                )
+            assert set(query_op["command"]["query"].keys()) == set(["_id", "is_mammal"])
 
         Animal.drop_collection()
 

--- a/tests/document/test_instance.py
+++ b/tests/document/test_instance.py
@@ -501,7 +501,7 @@ class TestDocumentInstance(MongoDBTestCase):
         doc.reload()
         Animal.drop_collection()
 
-    def test_update_shard_key_routing(self):
+    def test_save_update_shard_key_routing(self):
         """Ensures updating a doc with a specified shard_key includes it in
         the query.
         """
@@ -526,6 +526,36 @@ class TestDocumentInstance(MongoDBTestCase):
                 assert set(query_op["query"].keys()) == set(["_id", "is_mammal"])
             else:
                 assert set(query_op["command"]["q"].keys()) == set(["_id", "is_mammal"])
+
+        Animal.drop_collection()
+
+    def test_save_create_shard_key_routing(self):
+        """Ensures inserting a doc with a specified shard_key includes it in
+        the query.
+        """
+
+        class Animal(Document):
+            _id = UUIDField(binary=False, primary_key=True, default=uuid.uuid4)
+            is_mammal = BooleanField()
+            name = StringField()
+            meta = {"shard_key": ("is_mammal",)}
+
+        Animal.drop_collection()
+        doc = Animal(is_mammal=True, name="Dog")
+
+        mongo_db = get_mongodb_version()
+
+        with query_counter() as q:
+            doc.save()
+            query_op = q.db.system.profile.find({"ns": "mongoenginetest.animal"})[0]
+            assert query_op["op"] == "command"
+            assert query_op["command"]["findAndModify"] == "animal"
+            if mongo_db <= MONGODB_34:
+                assert set(query_op["query"].keys()) == set(["_id", "is_mammal"])
+            else:
+                assert set(query_op["command"]["query"].keys()) == set(
+                    ["_id", "is_mammal"]
+                )
 
         Animal.drop_collection()
 


### PR DESCRIPTION
Fix for https://github.com/MongoEngine/mongoengine/issues/2154

Inside the function def `_save_update()`, we have the logic that adds the shard key to the query. This is not only needed for `update_one()` of the pymongo lib, but also for `find_one_and_replace()`, which is used in `_save_create()`.

Therefore it makes sense to strip this functionality out of `_save_update()` and use it as well in `_save_create()`, which is done in this PR.