### PR TITLE
Add black badge to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,9 @@ MongoEngine
   :target: https://landscape.io/github/MongoEngine/mongoengine/master
   :alt: Code Health
 
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+  :target: https://github.com/ambv/black
+
 About
 =====
 MongoEngine is a Python Object-Document Mapper for working with MongoDB.


### PR DESCRIPTION
in order to emphasize that repo is using autoformatter black as it is often forgotten in PR and makes CI failing. It seems common to add it