### PR TITLE
Fix LazyReferenceField dereferencing in embedded documents

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -2570,6 +2570,7 @@ class LazyReferenceField(BaseField):
         if not isinstance(value, (DBRef, Document, EmbeddedDocument)):
             collection = self.document_type._get_collection_name()
             value = DBRef(collection, self.document_type.id.to_python(value))
+            value = self.build_lazyref(value)
         return value
 
     def validate(self, value):

--- a/tests/fields/test_lazy_reference_field.py
+++ b/tests/fields/test_lazy_reference_field.py
@@ -371,7 +371,7 @@ class TestLazyReferenceField(MongoDBTestCase):
 
         for ref in book.authors:
             with pytest.raises(AttributeError):
-                x = ref["author"].name
+                ref["author"].name
             assert isinstance(ref.author, LazyReference)
             assert isinstance(ref.author.id, ObjectId)
 


### PR DESCRIPTION
See #2375 for details. Test included.