### PR TITLE
Fix Python 3.5 compatibility

### DIFF
--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -54,7 +54,7 @@ def _get_connection_settings(
     password=None,
     authentication_source=None,
     authentication_mechanism=None,
-    **kwargs,
+    **kwargs
 ):
     """Get the connection settings as a dict
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+target-version = ['py33', 'py34', 'py35', 'py36', 'py37', 'py38']


### PR DESCRIPTION
This was a TIL for me!

A trailing comma with **kwargs is a SyntaxError in Python 3.5.

```python
Python 3.5.6 (default, Feb  8 2019, 15:08:20)
[GCC 8.2.1 20181127] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> class A:
...     def __init__(self, **kwargs,):
  File "<stdin>", line 2
    def __init__(self, **kwargs,):
                               ^
SyntaxError: invalid syntax
```