### PR TITLE
Drop Python 3.5 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,6 @@ CLASSIFIERS = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
@@ -140,7 +139,7 @@ setup(
     long_description=LONG_DESCRIPTION,
     platforms=["any"],
     classifiers=CLASSIFIERS,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     install_requires=["pymongo>=3.4, <4.0"],
     cmdclass={"test": PyTest},
     **extra_opts

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py35,pypy3}-{mg34,mg36,mg39,mg311}
+envlist = pypy3-{mg34,mg36,mg39,mg311}
 
 [testenv]
 commands =


### PR DESCRIPTION
The changelog for 0.22 indicates that Python 3.5 support was removed:

> Drop support for Python 3.5 by introducing f-strings in the codebase

The package should no longer declare that it supports 3.5