### PR TITLE
Fix inconsistency with example

### DIFF
--- a/docs/guide/connecting.rst
+++ b/docs/guide/connecting.rst
@@ -44,7 +44,7 @@ the :attr:`host` to
         )
 
     will establish connection to ``production`` database using
-    ``admin`` username and ``qwerty`` password.
+    ``admin`` username and ``12345`` password.
 
 .. note:: Calling :func:`~mongoengine.connect` without argument will establish
     a connection to the "test" database by default


### PR DESCRIPTION
connection example shows a password of 12345, but text spoke of qwerty