### PR TITLE
Fix deepcopy on EmbeddedDocument

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -259,3 +259,4 @@ that much better:
  * Agustin Barto (https://github.com/abarto)
  * Stankiewicz Mateusz (https://github.com/mas15)
  * Felix Schultheiß (https://github.com/felix-smashdocs)
+ * Timothé Perez (https://github.com/AchilleAsh)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Development
 ===========
 - (Fill this out as you fix issues and develop your features).
 - Improve connection doc #2481
+- Fix deepcopy on EmbeddedDocument
 
 Changes in 0.23.0
 =================

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -90,6 +90,15 @@ class EmbeddedDocument(BaseDocument, metaclass=DocumentMetaclass):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __getstate__(self):
+        data = super().__getstate__()
+        data["_instance"] = self._instance
+        return data
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        self._instance = state["_instance"]
+
     def to_mongo(self, *args, **kwargs):
         data = super().to_mongo(*args, **kwargs)
 

--- a/tests/document/test_instance.py
+++ b/tests/document/test_instance.py
@@ -3,6 +3,7 @@ import pickle
 import unittest
 import uuid
 import weakref
+from copy import deepcopy
 from datetime import datetime
 
 import bson
@@ -73,6 +74,14 @@ class TestDocumentInstance(MongoDBTestCase):
             assert field._instance.__eq__(instance)
         else:
             assert field._instance == instance
+
+    def test_deepcopy(self):
+        """Ensure that the _instance attribute on EmbeddedDocument exists after a deepcopy"""
+
+        doc = self.Job()
+        assert doc._instance is None
+        copied = deepcopy(doc)
+        assert copied._instance is None
 
     def test_capped_collection(self):
         """Ensure that capped collections work properly."""


### PR DESCRIPTION
Hi,

getstate / setstate magic methods on EmbeddedDocument now properly handle the _instance attribute, making deepcopy work on EmbeddedDocument.

Added the proper test case for this behavior, which fails on the current mongoengine version.

Fixes #2202
Fixes #1962 

Thanks!