### PR TITLE
define a base exception for engine

### DIFF
--- a/mongoengine/errors.py
+++ b/mongoengine/errors.py
@@ -16,12 +16,14 @@ __all__ = (
     "DeprecatedError",
 )
 
+class MongoEngineException(Exception):
+    pass
 
-class NotRegistered(Exception):
+class NotRegistered(MongoEngineException):
     pass
 
 
-class InvalidDocumentError(Exception):
+class InvalidDocumentError(MongoEngineException):
     pass
 
 
@@ -29,19 +31,19 @@ class LookUpError(AttributeError):
     pass
 
 
-class DoesNotExist(Exception):
+class DoesNotExist(MongoEngineException):
     pass
 
 
-class MultipleObjectsReturned(Exception):
+class MultipleObjectsReturned(MongoEngineException):
     pass
 
 
-class InvalidQueryError(Exception):
+class InvalidQueryError(MongoEngineException):
     pass
 
 
-class OperationError(Exception):
+class OperationError(MongoEngineException):
     pass
 
 
@@ -57,7 +59,7 @@ class SaveConditionError(OperationError):
     pass
 
 
-class FieldDoesNotExist(Exception):
+class FieldDoesNotExist(MongoEngineException):
     """Raised when trying to set a field
     not declared in a :class:`~mongoengine.Document`
     or an :class:`~mongoengine.EmbeddedDocument`.
@@ -155,7 +157,7 @@ class ValidationError(AssertionError):
         return " ".join([f"{k}: {v}" for k, v in error_dict.items()])
 
 
-class DeprecatedError(Exception):
+class DeprecatedError(MongoEngineException):
     """Raise when a user uses a feature that has been Deprecated"""
 
     pass

--- a/mongoengine/errors.py
+++ b/mongoengine/errors.py
@@ -16,8 +16,10 @@ __all__ = (
     "DeprecatedError",
 )
 
+
 class MongoEngineException(Exception):
     pass
+
 
 class NotRegistered(MongoEngineException):
     pass


### PR DESCRIPTION
all engine exception extends the primitive **Exception** class.
it would be better to define a base exception class for Engine that can be wrapped:

```python
try:
    # do something
except MongoEngineException as e:
    # code
```

in this way i can capture a base exception raised by the mongoengine module