### PR TITLE
adding upsert option to save

### DIFF
--- a/tests/document/test_instance.py
+++ b/tests/document/test_instance.py
@@ -1457,6 +1457,53 @@ class TestDocumentInstance(MongoDBTestCase):
 
         assert 2 == self.Person.objects.count()
 
+    def test_save_upsert_false_doesnt_insert_when_deleted(self):
+        class Person(Document):
+            name = StringField()
+
+        Person.drop_collection()
+
+        p1 = Person(name="Wilson Snr")
+        p1.save()
+        p2 = Person.objects().first()
+        p1.delete()
+        p2.name = " Bob Snr"
+        p2.save(upsert=False)
+
+        assert Person.objects.count() == 0
+
+    def test_save_upsert_true_inserts_when_deleted(self):
+        class Person(Document):
+            name = StringField()
+
+        Person.drop_collection()
+
+        p1 = Person(name="Wilson Snr")
+        p1.save()
+        p2 = Person.objects().first()
+        p1.delete()
+        p2.name = "Bob Snr"
+        p2.save(upsert=True)
+
+        assert Person.objects.count() == 1
+
+    def test_save_upsert_null_inserts_when_deleted(self):
+        # probably want to remove this as this is bad but preserved for backwards compatibility
+        # see https://github.com/MongoEngine/mongoengine/issues/564
+        class Person(Document):
+            name = StringField()
+
+        Person.drop_collection()
+
+        p1 = Person(name="Wilson Snr")
+        p1.save()
+        p2 = Person.objects().first()
+        p1.delete()
+        p2.name = "Bob Snr"
+        p2.save(upsert=None)  # default if you dont pass it
+
+        assert Person.objects.count() == 1
+
     def test_can_save_if_not_included(self):
         class EmbeddedDoc(EmbeddedDocument):
             pass


### PR DESCRIPTION
I believe this addresses #564 without breaking backwards compatibility.  Allowing you to explicitly choose not to upsert so you don't create bad documents in your database.  

This may not be the correct solve long term as save as it is can literally break your database if you delete the backing object between when you loaded this one but it does maintain backwards compatibility in case someone is using that "feature".  

Includes tests as well, my first pull request here so let me know if I need to do anything else.