### PR TITLE
fix DecimalField precision

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -482,10 +482,11 @@ class DecimalField(BaseField):
             value = decimal.Decimal("%s" % value)
         except (TypeError, ValueError, decimal.InvalidOperation):
             return value
-        return value.quantize(
-            decimal.Decimal(".%s" % ("0" * self.precision)), rounding=self.rounding
-        )
-
+        if self.precision > 0:
+            return value.quantize(decimal.Decimal(".%s" % ("0" * self.precision)), rounding=self.rounding)
+        else:
+            return value.quantize(decimal.Decimal(), rounding=self.rounding)
+        
     def to_mongo(self, value):
         if value is None:
             return value


### PR DESCRIPTION
fix decimal.InvalidOperation: [<class 'decimal.ConversionSyntax'>] error if DecimalField param precision is zero or less