### PR TITLE
Mention DynamicEmbeddedDocument in usage docs.

### DIFF
--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -27,6 +27,8 @@ objects** as class attributes to the document class::
 As BSON (the binary format for storing data in mongodb) is order dependent,
 documents are serialized based on their field order.
 
+.. _dynamic-document-schemas:
+
 Dynamic document schemas
 ========================
 One of the benefits of MongoDB is dynamic schemas for a collection, whilst data
@@ -230,6 +232,9 @@ document class as the first argument::
     comment1 = Comment(content='Good work!')
     comment2 = Comment(content='Nice article!')
     page = Page(comments=[comment1, comment2])
+
+Embedded documents can also leverage the flexibility of :ref:`dynamic-document-schemas:`
+by inheriting :class:`~mongoengine.DynamicEmbeddedDocument`.
 
 Dictionary Fields
 -----------------


### PR DESCRIPTION
Though hidden away in the generated [api reference](https://docs.mongoengine.org/apireference.html#mongoengine.DynamicEmbeddedDocument), DynamicEmbeddedDocument isn't mentioned at all in the usage sections, and web searches for terms like "dynamic embeddeddocument [mongoengine]"  bring up stackoverflow posts such as [this one](https://stackoverflow.com/questions/14400963/dynamic-embeddeddocument-with-mongodb-mongoengine) where the answer actually links to the dynamic documents section of the docs...but doesn't actually mention that DynamicEmbeddedDocument exists. This small change should hopefully improve discoverability.