### PR TITLE
Fix embedded instance deepcopy

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -260,3 +260,4 @@ that much better:
  * Stankiewicz Mateusz (https://github.com/mas15)
  * Felix Schultheiß (https://github.com/felix-smashdocs)
  * Jan Stein (https://github.com/janste63)
+ * Timothé Perez (https://github.com/AchilleAsh)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,13 +8,12 @@ Development
 ===========
 - (Fill this out as you fix issues and develop your features).
 - EnumField improvements: now `choices` limits the values of an enum to allow
-- Missing `._instance` field after deepcopy of EmbeddedField (#2202
+- Fix deepcopy of EmbeddedDocument #2202
 
 Changes in 0.23.1
 ===========
 - Bug fix: ignore LazyReferenceFields when clearing _changed_fields #2484
 - Improve connection doc #2481
-- Fix deepcopy on EmbeddedDocument
 
 Changes in 0.23.0
 =================

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Development
 ===========
 - (Fill this out as you fix issues and develop your features).
 - EnumField improvements: now `choices` limits the values of an enum to allow
+- Missing `._instance` field after deepcopy of EmbeddedField (#2202
 
 Changes in 0.23.1
 ===========

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ Changes in 0.23.1
 ===========
 - Bug fix: ignore LazyReferenceFields when clearing _changed_fields #2484
 - Improve connection doc #2481
+- Fix deepcopy on EmbeddedDocument
 
 Changes in 0.23.0
 =================

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -99,6 +99,15 @@ class EmbeddedDocument(BaseDocument, metaclass=DocumentMetaclass):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __getstate__(self):
+        data = super().__getstate__()
+        data["_instance"] = self._instance
+        return data
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        self._instance = state["_instance"]
+
     def to_mongo(self, *args, **kwargs):
         data = super().to_mongo(*args, **kwargs)
 

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -101,7 +101,7 @@ class EmbeddedDocument(BaseDocument, metaclass=DocumentMetaclass):
 
     def __getstate__(self):
         data = super().__getstate__()
-        data["_instance"] = self._instance
+        data["_instance"] = None
         return data
 
     def __setstate__(self, state):
@@ -135,7 +135,7 @@ class Document(BaseDocument, metaclass=TopLevelDocumentMetaclass):
     create a specialised version of the document that will be stored in the
     same collection. To facilitate this behaviour a `_cls`
     field is added to documents (hidden though the MongoEngine interface).
-    To enable this behaviourset :attr:`allow_inheritance` to ``True`` in the
+    To enable this behaviour set :attr:`allow_inheritance` to ``True`` in the
     :attr:`meta` dictionary.
 
     A :class:`~mongoengine.Document` may use a **Capped Collection** by

--- a/tests/document/test_instance.py
+++ b/tests/document/test_instance.py
@@ -3,7 +3,6 @@ import pickle
 import unittest
 import uuid
 import weakref
-from copy import deepcopy
 from datetime import datetime
 
 import bson
@@ -78,14 +77,6 @@ class TestDocumentInstance(MongoDBTestCase):
             assert field._instance.__eq__(instance)
         else:
             assert field._instance == instance
-
-    def test_deepcopy(self):
-        """Ensure that the _instance attribute on EmbeddedDocument exists after a deepcopy"""
-
-        doc = self.Job()
-        assert doc._instance is None
-        copied = deepcopy(doc)
-        assert copied._instance is None
 
     def test_capped_collection(self):
         """Ensure that capped collections work properly."""

--- a/tests/document/test_instance.py
+++ b/tests/document/test_instance.py
@@ -66,12 +66,12 @@ class TestDocumentInstance(MongoDBTestCase):
         for collection in list_collection_names(self.db):
             self.db.drop_collection(collection)
 
-    def assertDbEqual(self, docs):
+    def _assert_db_equal(self, docs):
         assert list(self.Person._get_collection().find().sort("id")) == sorted(
             docs, key=lambda doc: doc["_id"]
         )
 
-    def assertHasInstance(self, field, instance):
+    def _assert_has_instance(self, field, instance):
         assert hasattr(field, "_instance")
         assert field._instance is not None
         if isinstance(field._instance, weakref.ProxyType):
@@ -749,11 +749,11 @@ class TestDocumentInstance(MongoDBTestCase):
         Doc.drop_collection()
 
         doc = Doc(embedded_field=Embedded(string="Hi"))
-        self.assertHasInstance(doc.embedded_field, doc)
+        self._assert_has_instance(doc.embedded_field, doc)
 
         doc.save()
         doc = Doc.objects.get()
-        self.assertHasInstance(doc.embedded_field, doc)
+        self._assert_has_instance(doc.embedded_field, doc)
 
     def test_embedded_document_complex_instance(self):
         """Ensure that embedded documents in complex fields can reference
@@ -768,11 +768,11 @@ class TestDocumentInstance(MongoDBTestCase):
 
         Doc.drop_collection()
         doc = Doc(embedded_field=[Embedded(string="Hi")])
-        self.assertHasInstance(doc.embedded_field[0], doc)
+        self._assert_has_instance(doc.embedded_field[0], doc)
 
         doc.save()
         doc = Doc.objects.get()
-        self.assertHasInstance(doc.embedded_field[0], doc)
+        self._assert_has_instance(doc.embedded_field[0], doc)
 
     def test_embedded_document_complex_instance_no_use_db_field(self):
         """Ensure that use_db_field is propagated to list of Emb Docs."""
@@ -801,11 +801,11 @@ class TestDocumentInstance(MongoDBTestCase):
 
         acc = Account()
         acc.email = Email(email="test@example.com")
-        self.assertHasInstance(acc._data["email"], acc)
+        self._assert_has_instance(acc._data["email"], acc)
         acc.save()
 
         acc1 = Account.objects.first()
-        self.assertHasInstance(acc1._data["email"], acc1)
+        self._assert_has_instance(acc1._data["email"], acc1)
 
     def test_instance_is_set_on_setattr_on_embedded_document_list(self):
         class Email(EmbeddedDocument):
@@ -817,11 +817,11 @@ class TestDocumentInstance(MongoDBTestCase):
         Account.drop_collection()
         acc = Account()
         acc.emails = [Email(email="test@example.com")]
-        self.assertHasInstance(acc._data["emails"][0], acc)
+        self._assert_has_instance(acc._data["emails"][0], acc)
         acc.save()
 
         acc1 = Account.objects.first()
-        self.assertHasInstance(acc1._data["emails"][0], acc1)
+        self._assert_has_instance(acc1._data["emails"][0], acc1)
 
     def test_save_checks_that_clean_is_called(self):
         class CustomError(Exception):
@@ -930,7 +930,7 @@ class TestDocumentInstance(MongoDBTestCase):
         with pytest.raises(InvalidDocumentError):
             self.Person().modify(set__age=10)
 
-        self.assertDbEqual([dict(doc.to_mongo())])
+        self._assert_db_equal([dict(doc.to_mongo())])
 
     def test_modify_invalid_query(self):
         doc1 = self.Person(name="bob", age=10).save()
@@ -940,7 +940,7 @@ class TestDocumentInstance(MongoDBTestCase):
         with pytest.raises(InvalidQueryError):
             doc1.modify({"id": doc2.id}, set__value=20)
 
-        self.assertDbEqual(docs)
+        self._assert_db_equal(docs)
 
     def test_modify_match_another_document(self):
         doc1 = self.Person(name="bob", age=10).save()
@@ -950,7 +950,7 @@ class TestDocumentInstance(MongoDBTestCase):
         n_modified = doc1.modify({"name": doc2.name}, set__age=100)
         assert n_modified == 0
 
-        self.assertDbEqual(docs)
+        self._assert_db_equal(docs)
 
     def test_modify_not_exists(self):
         doc1 = self.Person(name="bob", age=10).save()
@@ -960,7 +960,7 @@ class TestDocumentInstance(MongoDBTestCase):
         n_modified = doc2.modify({"name": doc2.name}, set__age=100)
         assert n_modified == 0
 
-        self.assertDbEqual(docs)
+        self._assert_db_equal(docs)
 
     def test_modify_update(self):
         other_doc = self.Person(name="bob", age=10).save()
@@ -986,7 +986,7 @@ class TestDocumentInstance(MongoDBTestCase):
         assert doc.to_json() == doc_copy.to_json()
         assert doc._get_changed_fields() == []
 
-        self.assertDbEqual([dict(other_doc.to_mongo()), dict(doc.to_mongo())])
+        self._assert_db_equal([dict(other_doc.to_mongo()), dict(doc.to_mongo())])
 
     def test_modify_with_positional_push(self):
         class Content(EmbeddedDocument):

--- a/tests/document/test_instance.py
+++ b/tests/document/test_instance.py
@@ -3,6 +3,7 @@ import pickle
 import unittest
 import uuid
 import weakref
+from copy import deepcopy
 from datetime import datetime
 
 import bson
@@ -77,6 +78,14 @@ class TestDocumentInstance(MongoDBTestCase):
             assert field._instance.__eq__(instance)
         else:
             assert field._instance == instance
+
+    def test_deepcopy(self):
+        """Ensure that the _instance attribute on EmbeddedDocument exists after a deepcopy"""
+
+        doc = self.Job()
+        assert doc._instance is None
+        copied = deepcopy(doc)
+        assert copied._instance is None
 
     def test_capped_collection(self):
         """Ensure that capped collections work properly."""

--- a/tests/fields/test_embedded_document_field.py
+++ b/tests/fields/test_embedded_document_field.py
@@ -377,7 +377,7 @@ class TestGenericEmbeddedDocumentField(MongoDBTestCase):
         )
         assert doc.wallet._instance == doc
         copied_emb_doc = deepcopy(doc.wallet)
-        assert copied_emb_doc._instance == doc
+        assert copied_emb_doc._instance is None
 
         copied_map_emb_doc = deepcopy(doc.wallet_map)
-        assert copied_map_emb_doc["test"]._instance == doc
+        assert copied_map_emb_doc["test"]._instance is None

--- a/tests/queryset/test_modify.py
+++ b/tests/queryset/test_modify.py
@@ -19,7 +19,7 @@ class TestFindAndModify(unittest.TestCase):
         connect(db="mongoenginetest")
         Doc.drop_collection()
 
-    def assertDbEqual(self, docs):
+    def _assert_db_equal(self, docs):
         assert list(Doc._collection.find().sort("id")) == docs
 
     def test_modify(self):
@@ -28,7 +28,7 @@ class TestFindAndModify(unittest.TestCase):
 
         old_doc = Doc.objects(id=1).modify(set__value=-1)
         assert old_doc.to_json() == doc.to_json()
-        self.assertDbEqual([{"_id": 0, "value": 0}, {"_id": 1, "value": -1}])
+        self._assert_db_equal([{"_id": 0, "value": 0}, {"_id": 1, "value": -1}])
 
     def test_modify_with_new(self):
         Doc(id=0, value=0).save()
@@ -37,18 +37,18 @@ class TestFindAndModify(unittest.TestCase):
         new_doc = Doc.objects(id=1).modify(set__value=-1, new=True)
         doc.value = -1
         assert new_doc.to_json() == doc.to_json()
-        self.assertDbEqual([{"_id": 0, "value": 0}, {"_id": 1, "value": -1}])
+        self._assert_db_equal([{"_id": 0, "value": 0}, {"_id": 1, "value": -1}])
 
     def test_modify_not_existing(self):
         Doc(id=0, value=0).save()
         assert Doc.objects(id=1).modify(set__value=-1) is None
-        self.assertDbEqual([{"_id": 0, "value": 0}])
+        self._assert_db_equal([{"_id": 0, "value": 0}])
 
     def test_modify_with_upsert(self):
         Doc(id=0, value=0).save()
         old_doc = Doc.objects(id=1).modify(set__value=1, upsert=True)
         assert old_doc is None
-        self.assertDbEqual([{"_id": 0, "value": 0}, {"_id": 1, "value": 1}])
+        self._assert_db_equal([{"_id": 0, "value": 0}, {"_id": 1, "value": 1}])
 
     def test_modify_with_upsert_existing(self):
         Doc(id=0, value=0).save()
@@ -56,13 +56,13 @@ class TestFindAndModify(unittest.TestCase):
 
         old_doc = Doc.objects(id=1).modify(set__value=-1, upsert=True)
         assert old_doc.to_json() == doc.to_json()
-        self.assertDbEqual([{"_id": 0, "value": 0}, {"_id": 1, "value": -1}])
+        self._assert_db_equal([{"_id": 0, "value": 0}, {"_id": 1, "value": -1}])
 
     def test_modify_with_upsert_with_new(self):
         Doc(id=0, value=0).save()
         new_doc = Doc.objects(id=1).modify(upsert=True, new=True, set__value=1)
         assert new_doc.to_mongo() == {"_id": 1, "value": 1}
-        self.assertDbEqual([{"_id": 0, "value": 0}, {"_id": 1, "value": 1}])
+        self._assert_db_equal([{"_id": 0, "value": 0}, {"_id": 1, "value": 1}])
 
     def test_modify_with_remove(self):
         Doc(id=0, value=0).save()
@@ -70,12 +70,12 @@ class TestFindAndModify(unittest.TestCase):
 
         old_doc = Doc.objects(id=1).modify(remove=True)
         assert old_doc.to_json() == doc.to_json()
-        self.assertDbEqual([{"_id": 0, "value": 0}])
+        self._assert_db_equal([{"_id": 0, "value": 0}])
 
     def test_find_and_modify_with_remove_not_existing(self):
         Doc(id=0, value=0).save()
         assert Doc.objects(id=1).modify(remove=True) is None
-        self.assertDbEqual([{"_id": 0, "value": 0}])
+        self._assert_db_equal([{"_id": 0, "value": 0}])
 
     def test_modify_with_order_by(self):
         Doc(id=0, value=3).save()
@@ -85,7 +85,7 @@ class TestFindAndModify(unittest.TestCase):
 
         old_doc = Doc.objects().order_by("-id").modify(set__value=-1)
         assert old_doc.to_json() == doc.to_json()
-        self.assertDbEqual(
+        self._assert_db_equal(
             [
                 {"_id": 0, "value": 3},
                 {"_id": 1, "value": 2},
@@ -100,7 +100,7 @@ class TestFindAndModify(unittest.TestCase):
 
         old_doc = Doc.objects(id=1).only("id").modify(set__value=-1)
         assert old_doc.to_mongo() == {"_id": 1}
-        self.assertDbEqual([{"_id": 0, "value": 0}, {"_id": 1, "value": -1}])
+        self._assert_db_equal([{"_id": 0, "value": 0}, {"_id": 1, "value": -1}])
 
     def test_modify_with_push(self):
         class BlogPost(Document):


### PR DESCRIPTION
This is based on #2495 , it's a slightly modified version

I decided to set `_instance` to None instead of its initial value because I don't see why we would want the deepcopy of an EmbeddedDoc to point to the initial parent Document and it may create some weird bugs.

I believe it's safer that the deepcopied instance isn't attached to any parent Document, like it is when it is instantiated