### PR TITLE
Fix error if DBRef exists in DynamicEmbeddedDocument

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -470,6 +470,14 @@ class BaseDocument:
         # If the value is a dict with '_cls' in it, turn it into a document
         is_dict = isinstance(value, dict)
         if is_dict and "_cls" in value:
+
+            # If the value is a referenced document, dereference it
+            if "_ref" in value:
+                _dereference = _import_class("DeReference")()
+                documents = _dereference([value])
+                if documents:
+                    return documents[0]
+
             cls = get_document(value["_cls"])
             return cls(**value)
 

--- a/tests/test_dereference.py
+++ b/tests/test_dereference.py
@@ -1352,6 +1352,28 @@ class FieldTest(unittest.TestCase):
         page = Page.objects.first()
         assert page.tags[0] == page.posts[0].tags[0]
 
+    def test_dereferencing_dynamic_embedded_field_referencefield(self):
+        class Tag(Document):
+            meta = {"collection": "tags"}
+            name = StringField()
+
+        class Post(DynamicEmbeddedDocument):
+            pass
+
+        class Page(Document):
+            meta = {"collection": "pages"}
+            post = EmbeddedDocumentField(Post)
+
+        Tag.drop_collection()
+        Page.drop_collection()
+
+        tag = Tag(name="test").save()
+        post = Post(book_tag=tag)
+        Page(post=post).save()
+
+        page = Page.objects.first()
+        assert page.post.book_tag == post.book_tag
+
     def test_select_related_follows_embedded_referencefields(self):
         class Song(Document):
             title = StringField()


### PR DESCRIPTION
If assign a document to DynamicEmbeddedDocument, DBRef will be used to store the reference. The data can be stored successfully. But mongoengine.errors.FieldDoesNotExist error raised while reading the data from the database.
```python
class Tag(Document):
    meta = {"collection": "tags"}
    name = StringField()

class Post(DynamicEmbeddedDocument):
    pass

class Page(Document):
    meta = {"collection": "pages"}
    post = EmbeddedDocumentField(Post)

tag = Tag(name="test").save()
post = Post(book_tag=tag)
Page(post=post).save()

page = Page.objects.first()  # mongoengine.errors.FieldDoesNotExist raised here
```
**Error message:**
mongoengine.errors.FieldDoesNotExist: The fields "{'_ref'}" do not exist on the document "XXX"
**Solution:**
Dereference the field value if it is a dict with both '_cls' and '_ref' in it.