### PR TITLE
Regex and whole word text search query

### DIFF
--- a/docs/guide/querying.rst
+++ b/docs/guide/querying.rst
@@ -543,7 +543,10 @@ Documents may be updated atomically by using the
 There are several different "modifiers" that you may use with these methods:
 
 * ``set`` -- set a particular value
+* ``set_on_insert`` -- set only if this is new document  `need to add upsert=True`_
 * ``unset`` -- delete a particular value (since MongoDB v1.3)
+* ``max`` -- update only if value is bigger
+* ``min`` -- update only if value is smaller
 * ``inc`` -- increment a value by a given amount
 * ``dec`` -- decrement a value by a given amount
 * ``push`` -- append a value to a list
@@ -552,6 +555,7 @@ There are several different "modifiers" that you may use with these methods:
 * ``pull`` -- remove a value from a list
 * ``pull_all`` -- remove several values from a list
 * ``add_to_set`` -- add value to a list only if its not in the list already
+* ``rename`` -- rename the key name
 
 .. _depending on the value: http://docs.mongodb.org/manual/reference/operator/update/pop/
 

--- a/docs/guide/querying.rst
+++ b/docs/guide/querying.rst
@@ -86,6 +86,10 @@ expressions:
 * ``istartswith`` -- string field starts with value (case insensitive)
 * ``endswith`` -- string field ends with value
 * ``iendswith`` -- string field ends with value (case insensitive)
+* ``wholeword`` -- string field contains whole word
+* ``iwholeword`` -- string field contains whole word (case insensitive)
+* ``regex`` -- string field match by regex
+* ``iregex`` -- string field match by regex (case insensitive)
 * ``match``  -- performs an $elemMatch so you can match an entire document within an array
 
 

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -157,10 +157,17 @@ class StringField(BaseField):
                 regex = r"%s$"
             elif op == "exact":
                 regex = r"^%s$"
+            elif op == "has_word":
+                regex = r"\b%s\b"
+            elif op == "regex":
+                regex = value
 
             # escape unsafe characters which could lead to a re.error
-            value = re.escape(value)
-            value = re.compile(regex % value, flags)
+            if op == 'regex':
+                value = re.compile(regex, flags)
+            else:
+                value = re.escape(value)
+                value = re.compile(regex % value, flags)
         return super().prepare_query_value(op, value)
 
 

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -157,7 +157,7 @@ class StringField(BaseField):
                 regex = r"%s$"
             elif op == "exact":
                 regex = r"^%s$"
-            elif op == "has_word":
+            elif op == "wholeword":
                 regex = r"\b%s\b"
             elif op == "regex":
                 regex = value
@@ -1094,14 +1094,7 @@ class DictField(ComplexBaseField):
 
     def prepare_query_value(self, op, value):
         match_operators = [
-            "contains",
-            "icontains",
-            "startswith",
-            "istartswith",
-            "endswith",
-            "iendswith",
-            "exact",
-            "iexact",
+            *STRING_OPERATORS
         ]
 
         if op in match_operators and isinstance(value, str):

--- a/mongoengine/queryset/transform.py
+++ b/mongoengine/queryset/transform.py
@@ -53,8 +53,8 @@ STRING_OPERATORS = (
     "iexact",
     "regex",
     "iregex",
-    "has_word",
-    "ihas_word",
+    "wholeword",
+    "iwholeword",
 )
 CUSTOM_OPERATORS = ("match",)
 MATCH_OPERATORS = (

--- a/mongoengine/queryset/transform.py
+++ b/mongoengine/queryset/transform.py
@@ -51,6 +51,10 @@ STRING_OPERATORS = (
     "iendswith",
     "exact",
     "iexact",
+    "regex",
+    "iregex",
+    "has_word",
+    "ihas_word",
 )
 CUSTOM_OPERATORS = ("match",)
 MATCH_OPERATORS = (

--- a/tests/queryset/test_queryset.py
+++ b/tests/queryset/test_queryset.py
@@ -867,6 +867,23 @@ class TestQueryset(unittest.TestCase):
         assert "Bob" == bob.name
         assert 30 == bob.age
 
+    def test_rename(self):
+        self.Person.drop_collection()
+        self.Person.objects.create(name="Foo", age=11)
+
+        bob = self.Person.objects.as_pymongo().first()
+        assert 'age' in bob
+        assert bob['age'] == 11
+
+        self.Person.objects(name="Foo").update(
+            rename__age='person_age'
+        )
+
+        bob = self.Person.objects.as_pymongo().first()
+        assert 'age' not in bob
+        assert 'person_age' in bob
+        assert bob['person_age'] == 11
+
     def test_save_and_only_on_fields_with_default(self):
         class Embed(EmbeddedDocument):
             field = IntField()

--- a/tests/queryset/test_queryset.py
+++ b/tests/queryset/test_queryset.py
@@ -1257,6 +1257,35 @@ class TestQueryset(unittest.TestCase):
         obj = self.Person.objects(name__iexact="gUIDO VAN rOSSU").first()
         assert obj is None
 
+
+        # Test has_word
+        obj = self.Person.objects(name__has_word="Guido").first()
+        assert obj == person
+        obj = self.Person.objects(name__has_word="rossum").first()
+        assert obj is None
+        obj = self.Person.objects(name__has_word="Rossu").first()
+        assert obj is None
+
+        # Test ihas_word
+        obj = self.Person.objects(name__ihas_word="rOSSUM").first()
+        assert obj == person
+        obj = self.Person.objects(name__ihas_word="rOSSU").first()
+        assert obj is None
+
+        # Test regex
+        obj = self.Person.objects(name__regex="^[Guido].*[Rossum]$").first()
+        assert obj == person
+        obj = self.Person.objects(name__regex="^[guido].*[rossum]$").first()
+        assert obj is None
+        obj = self.Person.objects(name__regex="^[uido].*[Rossum]$").first()
+        assert obj is None
+
+        # Test iregex
+        obj = self.Person.objects(name__iregex="^[guido].*[rossum]$").first()
+        assert obj == person
+        obj = self.Person.objects(name__iregex="^[Uido].*[Rossum]$").first()
+        assert obj is None
+
         # Test unsafe expressions
         person = self.Person(name="Guido van Rossum [.'Geek']")
         person.save()
@@ -1341,7 +1370,12 @@ class TestQueryset(unittest.TestCase):
         person.save()
 
         people = self.Person.objects
-        people = people.filter(name__startswith="Gui").filter(name__not__endswith="tum")
+        people = people.filter(name__startswith="Gui")\
+            .filter(name__not__endswith="tum")\
+            .filter(name__icontains="VAN")\
+            .filter(name__regex="^Guido")\
+            .filter(name__has_word="Guido")\
+            .filter(name__has_word="van")
         assert people.count() == 1
 
     def assertSequence(self, qs, expected):

--- a/tests/queryset/test_queryset.py
+++ b/tests/queryset/test_queryset.py
@@ -1258,18 +1258,18 @@ class TestQueryset(unittest.TestCase):
         assert obj is None
 
 
-        # Test has_word
-        obj = self.Person.objects(name__has_word="Guido").first()
+        # Test wholeword
+        obj = self.Person.objects(name__wholeword="Guido").first()
         assert obj == person
-        obj = self.Person.objects(name__has_word="rossum").first()
+        obj = self.Person.objects(name__wholeword="rossum").first()
         assert obj is None
-        obj = self.Person.objects(name__has_word="Rossu").first()
+        obj = self.Person.objects(name__wholeword="Rossu").first()
         assert obj is None
 
-        # Test ihas_word
-        obj = self.Person.objects(name__ihas_word="rOSSUM").first()
+        # Test iwholeword
+        obj = self.Person.objects(name__iwholeword="rOSSUM").first()
         assert obj == person
-        obj = self.Person.objects(name__ihas_word="rOSSU").first()
+        obj = self.Person.objects(name__iwholeword="rOSSU").first()
         assert obj is None
 
         # Test regex
@@ -1374,8 +1374,8 @@ class TestQueryset(unittest.TestCase):
             .filter(name__not__endswith="tum")\
             .filter(name__icontains="VAN")\
             .filter(name__regex="^Guido")\
-            .filter(name__has_word="Guido")\
-            .filter(name__has_word="van")
+            .filter(name__wholeword="Guido")\
+            .filter(name__wholeword="van")
         assert people.count() == 1
 
     def assertSequence(self, qs, expected):


### PR DESCRIPTION
Regex and whole word text search query
I was surprised that there is no easy way to do regex search by MongoEngine so I add that option
and for bonus I add whole word search that I found that is very useful