### PR TITLE
Pass upsert=True to find_one_and_replace() on Document.save() method.

### DIFF
--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -467,18 +467,14 @@ class Document(BaseDocument, metaclass=TopLevelDocumentMetaclass):
         """
         collection = self._get_collection()
         with set_write_concern(collection, write_concern) as wc_collection:
-            if force_insert:
-                return wc_collection.insert_one(doc).inserted_id
-            # insert_one will provoke UniqueError alongside save does not
-            # therefore, it need to catch and call replace_one.
-            if "_id" in doc:
+            if force_insert or "_id" not in doc:
+                insert_one_result = wc_collection.insert_one(doc)
+                return insert_one_result.inserted_id
+            else:
                 select_dict = {"_id": doc["_id"]}
                 select_dict = self._integrate_shard_key(doc, select_dict)
                 wc_collection.find_one_and_replace(select_dict, doc, upsert=True)
                 return doc["_id"]
-
-            insert_one_result = wc_collection.insert_one(doc)
-            return insert_one_result.inserted_id
 
     def _get_update_doc(self):
         """Return a dict containing all the $set and $unset operations


### PR DESCRIPTION
Following the discussion found in https://github.com/MongoEngine/mongoengine/pull/1944#discussion_r232464849.

In my company, we have faced an edge case where we might have concurrent "save()" calls failing, please imagine the following situation:

If we have at least two processes running in parallel that tries to save a document with the same new ``id`` in the same collection, both processes will get ``None`` when invoking PyMongo's ``find_one_and_replace`` in [this line](https://github.com/MongoEngine/mongoengine/blob/v0.23.1/mongoengine/document.py#L468) because the document with such ``_id`` doesn't exist in the collection, and then MongoEngine will invoke to PyMongo's ``insert_one`` [here](https://github.com/MongoEngine/mongoengine/blob/v0.23.1/mongoengine/document.py#L472), so one of these two processes will get the document inserted and the other will obtain a ``NotUniqueError`` exception raised.

Instead, if we pass ``upsert=True`` to ``find_one_and_replace`` method, we will make sure that the document is saved and won't fail, even more because conceptually ``save()`` should never fail with such exception, at least not for the unique index on ``_id`` field. Also, note that we can ignore the returning value from ``find_one_and_replace`` since all what we need to return is the ``doc["_id"]`` that we already have in that trace.

Note: I've tried to reproduce it in unit tests using a thread pool but it's quite hard :(