### PR TITLE
fix compatibility issue in CI

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -53,7 +53,7 @@ jobs:
             PYMONGO: $PYMONGO_3_9
           - python-version: 3.7
             MONGODB: $MONGODB_4_2
-            PYMONGO: $PYMONGO_3_6
+            PYMONGO: $PYMONGO_3_9
           - python-version: 3.7
             MONGODB: $MONGODB_4_4
             PYMONGO: $PYMONGO_3_11

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 Sphinx==3.3.0
 sphinx-rtd-theme==0.5.0
 readthedocs-sphinx-ext==2.1.1
+docutils==0.17.1


### PR DESCRIPTION
As pointed here (https://github.com/MongoEngine/mongoengine/pull/2578#issuecomment-945092623) , there was a problem in the pymongo-mongodb versions matrix