### PR TITLE
Prevent override custom manager

### DIFF
--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -583,7 +583,11 @@ class Document(BaseDocument, metaclass=TopLevelDocumentMetaclass):
     def _qs(self):
         """Return the default queryset corresponding to this document."""
         if not hasattr(self, "__objects"):
-            self.__objects = QuerySet(self.__class__, self._get_collection())
+            queryset_class = self._meta.get("queryset_class")
+            if queryset_class is not None:
+                self.__objects = queryset_class(self.__class__, self._get_collection())
+            else:
+                self.__objects = QuerySet(self.__class__, self._get_collection())
         return self.__objects
 
     @property

--- a/tests/queryset/test_queryset.py
+++ b/tests/queryset/test_queryset.py
@@ -3914,6 +3914,33 @@ class TestQueryset(unittest.TestCase):
 
         Post.drop_collection()
 
+    def test_custom_querysets_set_manager_methods(self):
+        """Ensure that custom QuerySet classes methods may be used."""
+
+        class CustomQuerySet(QuerySet):
+            def delete(self, *args, **kwargs):
+                """Example of method when one want to change default behaviour of it"""
+                return 0
+
+        class CustomQuerySetManager(QuerySetManager):
+            queryset_class = CustomQuerySet
+
+        class Post(Document):
+            objects = CustomQuerySetManager()
+
+        Post.drop_collection()
+
+        assert isinstance(Post.objects, CustomQuerySet)
+        assert not Post.objects.delete()
+
+        post = Post()
+        post.save()
+        assert Post.objects.count() == 1
+        post.delete()
+        assert Post.objects.count() == 1
+
+        Post.drop_collection()
+
     def test_custom_querysets_managers_directly(self):
         """Ensure that custom QuerySet classes may be used."""
 


### PR DESCRIPTION
Prevent from overriding custom QuerySet by new default QuerySet.
```mongoengine.document.Document._qs(self)```

For example:
Post.objects.delete()
post.delete() 

Internally both methods should use the same QuerySet if custom class was configured.