### PR TITLE
Save with cascade fix for unsaved child documents

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -263,3 +263,4 @@ that much better:
  * Timothé Perez (https://github.com/AchilleAsh)
  * oleksandr-l5 (https://github.com/oleksandr-l5)
  * Ido Shraga (https://github.com/idoshr)
+ * Nick Freville (https://github.com/nickfrev)

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -411,14 +411,6 @@ class Document(BaseDocument, metaclass=TopLevelDocumentMetaclass):
             self.ensure_indexes()
 
         try:
-            # Save a new document or update an existing one
-            if created:
-                object_id = self._save_create(doc, force_insert, write_concern)
-            else:
-                object_id, created = self._save_update(
-                    doc, save_condition, write_concern
-                )
-
             if cascade is None:
                 cascade = self._meta.get("cascade", False) or cascade_kwargs is not None
 
@@ -433,6 +425,14 @@ class Document(BaseDocument, metaclass=TopLevelDocumentMetaclass):
                     kwargs.update(cascade_kwargs)
                 kwargs["_refs"] = _refs
                 self.cascade_save(**kwargs)
+
+            # Save a new document or update an existing one
+            if created:
+                object_id = self._save_create(doc, force_insert, write_concern)
+            else:
+                object_id, created = self._save_update(
+                    doc, save_condition, write_concern
+                )
 
         except pymongo.errors.DuplicateKeyError as err:
             message = "Tried to save duplicate unique keys (%s)"

--- a/tests/document/test_class_methods.py
+++ b/tests/document/test_class_methods.py
@@ -362,7 +362,5 @@ class TestClassMethods(unittest.TestCase):
         job_obj = Job.objects[0]
         assert job_obj.employee == job.employee
 
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/document/test_class_methods.py
+++ b/tests/document/test_class_methods.py
@@ -344,6 +344,25 @@ class TestClassMethods(unittest.TestCase):
 
         Person.drop_collection()
 
+    def test_save_with_cascade_on_new_referencefield(self):
+        """Ensure that a new and unsaved ReferenceField is saved before 
+        the parent Document is saved to avoid validation issues.
+        """
+
+        class Job(Document):
+            employee = ReferenceField(self.Person)
+
+        person = self.Person(name="Test User")
+        job = Job(employee=person)
+        job.save(cascade=True)
+
+        employee_obj = self.Person.objects[0]
+        assert employee_obj["name"] == "Test User"
+
+        job_obj = Job.objects[0]
+        assert job_obj.employee == job.employee
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A fix for https://github.com/MongoEngine/mongoengine/issues/1236

Moved the cascade save portion of the Document.save method above the validation check. This does mean that there is a possibility that a child document could be saved while the parent document is not valid for another reason but this would already occur anyway with the current work arounds to this issue.

This move also removed this code block from the try-catch statement however all errors should be being caught by Document.cascade_save anyway.