### PR TITLE
Fix: DictField are always marked as changed

### DIFF
--- a/mongoengine/base/datastructures.py
+++ b/mongoengine/base/datastructures.py
@@ -31,9 +31,9 @@ def mark_key_as_changed_wrapper(parent_method):
 
     def wrapper(self, key, *args, **kwargs):
         # Can't use super() in the decorator.
-        result = parent_method(self, key, *args, **kwargs)
-        self._mark_as_changed(key)
-        return result
+        if not args or not key or key not in self or self[key] != args[0]:
+            self._mark_as_changed(key)
+        return parent_method(self, key, *args, **kwargs)
 
     return wrapper
 


### PR DESCRIPTION
Only triggering `_mark_as_changed` on DictField if the value is actually
changed.

Limit the number of field accumulated in `_changed_fields`.