### PR TITLE
pymongo 4.0 support

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -21,6 +21,7 @@ env:
   PYMONGO_3_9: 3.9
   PYMONGO_3_11: 3.11
   PYMONGO_3_12: 3.12
+  PYMONGO_4_0: 4.0
 
   MAIN_PYTHON_VERSION: 3.7
 
@@ -61,6 +62,9 @@ jobs:
           - python-version: 3.7
             MONGODB: $MONGODB_4_4
             PYMONGO: $PYMONGO_3_12
+          - python-version: 3.9
+            MONGODB: $MONGODB_4_4
+            PYMONGO: $PYMONGO_4_0
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/AUTHORS
+++ b/AUTHORS
@@ -263,3 +263,4 @@ that much better:
  * Timothé Perez (https://github.com/AchilleAsh)
  * oleksandr-l5 (https://github.com/oleksandr-l5)
  * Ido Shraga (https://github.com/idoshr)
+ * Terence Honles (https://github.com/terencehonles)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,11 +7,41 @@ Changelog
 Development
 ===========
 - (Fill this out as you fix issues and develop your features).
-- EnumField improvements: now `choices` limits the values of an enum to allow
+- EnumField improvements: now ``choices`` limits the values of an enum to allow
 - Fix bug that prevented instance queryset from using custom queryset_class #2589
 - Fix deepcopy of EmbeddedDocument #2202
 - Fix error when using precision=0 with DecimalField #2535
 - Add support for regex and whole word text search query #2568
+- BREAKING CHANGE: Updates to support pymongo 4.0. Where possible deprecated
+  functionality has been migrated, but additional care should be taken when
+  migrating to pymongo 4.0 as existing code may have been using deprecated
+  features which have now been removed #2614.
+
+  For the pymongo migration guide see:
+  https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html.
+
+  In addition to the changes in the migration guide, the following is a high
+  level overview of the changes made to MongoEngine when using pymongo 4.0:
+
+  - limited support of geohaystack indexes has been removed
+  - ``QuerySet.map_reduce`` has been migrated from ``Collection.map_reduce``
+    and ``Collection.inline_map_reduce`` to use
+    ``db.command({mapReduce: ..., ...})`` and support between the two may need
+    additional verification.
+  - UUIDs are encoded with the ``pythonLegacy`` encoding by default instead of
+    the newer and cross platform ``standard`` encoding. Existing UUIDs will
+    need to be migrated before changing the encoding, and this should be done
+    explicitly by the user rather than switching to a new default by
+    MongoEngine. This default will change at a later date, but to allow
+    specifying and then migrating to the new format a default ``json_options``
+    has been provided.
+  - ``Queryset.count`` has been using ``Collection.count_documents`` and
+    transparently falling back to ``Collection.count`` when using features that
+    are not supported by ``Collection.count_documents``. ``Collection.count``
+    has been removed and no automatic fallback is possible. The migration guide
+    documents the extended functionality which is no longer supported. Rewrite
+    the unsupported queries or fetch the whole result set and perform the count
+    locally.
 
 Changes in 0.23.1
 ===========

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -1,3 +1,5 @@
+import warnings
+
 from pymongo import MongoClient, ReadPreference, uri_parser
 from pymongo.database import _check_name
 
@@ -161,6 +163,18 @@ def _get_connection_settings(
     # Deprecated parameters that should not be passed on
     kwargs.pop("slaves", None)
     kwargs.pop("is_slave", None)
+
+    if "uuidRepresentation" not in kwargs:
+        warnings.warn(
+            "No uuidRepresentation is specified! Falling back to "
+            "'pythonLegacy' which is the default for pymongo 3.x. "
+            "For compatibility with other MongoDB drivers this should be "
+            "specified as 'standard' or '{java,csharp}Legacy' to work with "
+            "older drivers in those languages. This will be changed to "
+            "'standard' in a future release.",
+            DeprecationWarning,
+        )
+        kwargs["uuidRepresentation"] = "pythonLegacy"
 
     conn_settings.update(kwargs)
     return conn_settings

--- a/mongoengine/context_managers.py
+++ b/mongoengine/context_managers.py
@@ -210,13 +210,14 @@ class query_counter:
         }
 
     def _turn_on_profiling(self):
-        self.initial_profiling_level = self.db.profiling_level()
-        self.db.set_profiling_level(0)
+        profile_update_res = self.db.command({"profile": 0})
+        self.initial_profiling_level = profile_update_res["was"]
+
         self.db.system.profile.drop()
-        self.db.set_profiling_level(2)
+        self.db.command({"profile": 2})
 
     def _resets_profiling(self):
-        self.db.set_profiling_level(self.initial_profiling_level)
+        self.db.command({"profile": self.initial_profiling_level})
 
     def __enter__(self):
         self._turn_on_profiling()

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -888,10 +888,6 @@ class Document(BaseDocument, metaclass=TopLevelDocumentMetaclass):
         index_cls = cls._meta.get("index_cls", True)
 
         collection = cls._get_collection()
-        # 746: when connection is via mongos, the read preference is not necessarily an indication that
-        # this code runs on a secondary
-        if not collection.is_mongos and collection.read_preference > 1:
-            return
 
         # determine if an index which we are creating includes
         # _cls as its first field; if so, we can avoid creating

--- a/mongoengine/pymongo_support.py
+++ b/mongoengine/pymongo_support.py
@@ -4,11 +4,7 @@ Helper functions, constants, and types to aid with PyMongo v2.7 - v3.x support.
 import pymongo
 from pymongo.errors import OperationFailure
 
-_PYMONGO_37 = (3, 7)
-
 PYMONGO_VERSION = tuple(pymongo.version_tuple[:2])
-
-IS_PYMONGO_GTE_37 = PYMONGO_VERSION >= _PYMONGO_37
 
 
 def count_documents(
@@ -29,7 +25,7 @@ def count_documents(
         kwargs["collation"] = collation
 
     # count_documents appeared in pymongo 3.7
-    if IS_PYMONGO_GTE_37:
+    if PYMONGO_VERSION >= (3, 7):
         try:
             return collection.count_documents(filter=filter, **kwargs)
         except OperationFailure:
@@ -49,7 +45,7 @@ def count_documents(
 
 def list_collection_names(db, include_system_collections=False):
     """Pymongo>3.7 deprecates collection_names in favour of list_collection_names"""
-    if IS_PYMONGO_GTE_37:
+    if PYMONGO_VERSION >= (3, 7):
         collections = db.list_collection_names()
     else:
         collections = db.collection_names()

--- a/mongoengine/pymongo_support.py
+++ b/mongoengine/pymongo_support.py
@@ -1,10 +1,15 @@
 """
-Helper functions, constants, and types to aid with PyMongo v2.7 - v3.x support.
+Helper functions, constants, and types to aid with PyMongo support.
 """
 import pymongo
+from bson import binary, json_util
 from pymongo.errors import OperationFailure
 
 PYMONGO_VERSION = tuple(pymongo.version_tuple[:2])
+
+LEGACY_JSON_OPTIONS = json_util.LEGACY_JSON_OPTIONS.with_options(
+    uuid_representation=binary.UuidRepresentation.PYTHON_LEGACY,
+)
 
 
 def count_documents(

--- a/mongoengine/pymongo_support.py
+++ b/mongoengine/pymongo_support.py
@@ -7,9 +7,12 @@ from pymongo.errors import OperationFailure
 
 PYMONGO_VERSION = tuple(pymongo.version_tuple[:2])
 
-LEGACY_JSON_OPTIONS = json_util.LEGACY_JSON_OPTIONS.with_options(
-    uuid_representation=binary.UuidRepresentation.PYTHON_LEGACY,
-)
+if PYMONGO_VERSION >= (4,):
+    LEGACY_JSON_OPTIONS = json_util.LEGACY_JSON_OPTIONS.with_options(
+        uuid_representation=binary.UuidRepresentation.PYTHON_LEGACY,
+    )
+else:
+    LEGACY_JSON_OPTIONS = json_util.DEFAULT_JSON_OPTIONS
 
 
 def count_documents(

--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -28,7 +28,10 @@ from mongoengine.errors import (
     NotUniqueError,
     OperationError,
 )
-from mongoengine.pymongo_support import count_documents
+from mongoengine.pymongo_support import (
+    LEGACY_JSON_OPTIONS,
+    count_documents,
+)
 from mongoengine.queryset import transform
 from mongoengine.queryset.field_list import QueryFieldList
 from mongoengine.queryset.visitor import Q, QNode
@@ -1266,6 +1269,15 @@ class BaseQuerySet:
 
     def to_json(self, *args, **kwargs):
         """Converts a queryset to JSON"""
+        if "json_options" not in kwargs:
+            warnings.warn(
+                "No 'json_options' are specified! Falling back to "
+                "LEGACY_JSON_OPTIONS with uuid_representation=PYTHON_LEGACY. "
+                "For use with other MongoDB drivers specify the UUID "
+                "representation to use.",
+                DeprecationWarning,
+            )
+            kwargs["json_options"] = LEGACY_JSON_OPTIONS
         return json_util.dumps(self.as_pymongo(), *args, **kwargs)
 
     def from_json(self, json_data):

--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -1481,7 +1481,7 @@ class BaseQuerySet:
         code = Code(code, scope=scope)
 
         db = queryset._document._get_db()
-        return db.eval(code, *fields)
+        return db.command("eval", code, args=fields).get("retval")
 
     def where(self, where_clause):
         """Filter ``QuerySet`` results with a ``$where`` clause (a Javascript

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ setup(
     platforms=["any"],
     classifiers=CLASSIFIERS,
     python_requires=">=3.6",
-    install_requires=["pymongo>=3.4, <4.0"],
+    install_requires=["pymongo>=3.4,<=4.0"],
     cmdclass={"test": PyTest},
     **extra_opts
 )

--- a/tests/document/test_dynamic.py
+++ b/tests/document/test_dynamic.py
@@ -28,9 +28,9 @@ class TestDynamicDocument(MongoDBTestCase):
         p.age = 34
 
         assert p.to_mongo() == {"_cls": "Person", "name": "James", "age": 34}
-        assert p.to_mongo().keys() == ["_cls", "name", "age"]
+        assert sorted(p.to_mongo().keys()) == ["_cls", "age", "name"]
         p.save()
-        assert p.to_mongo().keys() == ["_id", "_cls", "name", "age"]
+        assert sorted(p.to_mongo().keys()) == ["_cls", "_id", "age", "name"]
 
         assert self.Person.objects.first().age == 34
 

--- a/tests/document/test_indexes.py
+++ b/tests/document/test_indexes.py
@@ -11,6 +11,7 @@ from mongoengine.mongodb_support import (
     MONGODB_42,
     get_mongodb_version,
 )
+from mongoengine.pymongo_support import PYMONGO_VERSION
 
 
 class TestIndexes(unittest.TestCase):
@@ -247,11 +248,9 @@ class TestIndexes(unittest.TestCase):
 
     def test_explicit_geohaystack_index(self):
         """Ensure that geohaystack indexes work when created via meta[indexes]"""
-        pytest.skip(
-            "GeoHaystack index creation is not supported for now"
-            "from meta, as it requires a bucketSize parameter."
-        )
-
+        # This test can be removed when pymongo 3.x is no longer supported
+        if PYMONGO_VERSION >= (4,):
+            pytest.skip('GEOHAYSTACK has been removed in pymongo 4.0')
         class Place(Document):
             location = DictField()
             name = StringField()
@@ -261,22 +260,32 @@ class TestIndexes(unittest.TestCase):
             {"fields": [("location.point", "geoHaystack"), ("name", 1)]}
         ] == Place._meta["index_specs"]
 
-        Place.ensure_indexes()
-        info = Place._get_collection().index_information()
-        info = [value["key"] for key, value in info.items()]
-        assert [("location.point", "geoHaystack")] in info
+        # GeoHaystack index creation is not supported for now from meta, as it
+        # requires a bucketSize parameter.
+        if False:
+            Place.ensure_indexes()
+            info = Place._get_collection().index_information()
+            info = [value["key"] for key, value in info.items()]
+            assert [("location.point", "geoHaystack")] in info
 
     def test_create_geohaystack_index(self):
         """Ensure that geohaystack indexes can be created"""
-
         class Place(Document):
             location = DictField()
             name = StringField()
 
-        Place.create_index({"fields": (")location.point", "name")}, bucketSize=10)
-        info = Place._get_collection().index_information()
-        info = [value["key"] for key, value in info.items()]
-        assert [("location.point", "geoHaystack"), ("name", 1)] in info
+        # This test can be removed when pymongo 3.x is no longer supported
+        if PYMONGO_VERSION >= (4,):
+            with pytest.raises(NotImplementedError):
+                Place.create_index(
+                    {"fields": (")location.point", "name")},
+                    bucketSize=10,
+                )
+        else:
+            Place.create_index({"fields": (")location.point", "name")}, bucketSize=10)
+            info = Place._get_collection().index_information()
+            info = [value["key"] for key, value in info.items()]
+            assert [("location.point", "geoHaystack"), ("name", 1)] in info
 
     def test_dictionary_indexes(self):
         """Ensure that indexes are used when meta[indexes] contains

--- a/tests/document/test_inheritance.py
+++ b/tests/document/test_inheritance.py
@@ -246,11 +246,15 @@ class TestInheritance(MongoDBTestCase):
         assert ["_cls", "age", "id", "name", "salary"] == sorted(
             Employee._fields.keys()
         )
-        assert Person(name="Bob", age=35).to_mongo().keys() == ["_cls", "name", "age"]
-        assert Employee(name="Bob", age=35, salary=0).to_mongo().keys() == [
+        assert sorted(Person(name="Bob", age=35).to_mongo().keys()) == [
             "_cls",
-            "name",
             "age",
+            "name",
+        ]
+        assert sorted(Employee(name="Bob", age=35, salary=0).to_mongo().keys()) == [
+            "_cls",
+            "age",
+            "name",
             "salary",
         ]
         assert Employee._get_collection_name() == Person._get_collection_name()
@@ -334,7 +338,7 @@ class TestInheritance(MongoDBTestCase):
 
         # Check that _cls etc aren't present on simple documents
         dog = Animal(name="dog").save()
-        assert dog.to_mongo().keys() == ["_id", "name"]
+        assert sorted(dog.to_mongo().keys()) == ["_id", "name"]
 
         collection = self.db[Animal._get_collection_name()]
         obj = collection.find_one()

--- a/tests/document/test_instance.py
+++ b/tests/document/test_instance.py
@@ -704,11 +704,15 @@ class TestDocumentInstance(MongoDBTestCase):
         class Employee(Person):
             salary = IntField()
 
-        assert Person(name="Bob", age=35).to_mongo().keys() == ["_cls", "name", "age"]
-        assert Employee(name="Bob", age=35, salary=0).to_mongo().keys() == [
+        assert sorted(Person(name="Bob", age=35).to_mongo().keys()) == [
             "_cls",
-            "name",
             "age",
+            "name",
+        ]
+        assert sorted(Employee(name="Bob", age=35, salary=0).to_mongo().keys()) == [
+            "_cls",
+            "age",
+            "name",
             "salary",
         ]
 
@@ -717,7 +721,7 @@ class TestDocumentInstance(MongoDBTestCase):
             id = StringField(required=True)
 
         sub_doc = SubDoc(id="abc")
-        assert sub_doc.to_mongo().keys() == ["id"]
+        assert list(sub_doc.to_mongo().keys()) == ["id"]
 
     def test_embedded_document(self):
         """Ensure that embedded documents are set up correctly."""

--- a/tests/document/test_instance.py
+++ b/tests/document/test_instance.py
@@ -28,7 +28,10 @@ from mongoengine.mongodb_support import (
     MONGODB_36,
     get_mongodb_version,
 )
-from mongoengine.pymongo_support import list_collection_names
+from mongoengine.pymongo_support import (
+    PYMONGO_VERSION,
+    list_collection_names,
+)
 from mongoengine.queryset import NULLIFY, Q
 from tests import fixtures
 from tests.fixtures import (
@@ -2943,7 +2946,11 @@ class TestDocumentInstance(MongoDBTestCase):
             }
         )
         assert [str(b) for b in custom_qs] == ["1", "2"]
-        assert custom_qs.count() == 2
+
+        # count only will work with this raw query before pymongo 4.x, but
+        # the length is also implicitly checked above
+        if PYMONGO_VERSION < (4,):
+            assert custom_qs.count() == 2
 
     def test_switch_db_instance(self):
         register_connection("testdb-1", "mongoenginetest2")

--- a/tests/document/test_instance.py
+++ b/tests/document/test_instance.py
@@ -2755,17 +2755,17 @@ class TestDocumentInstance(MongoDBTestCase):
 
         from pymongo.collection import Collection
 
-        orig_update = Collection.update
+        orig_update_one = Collection.update_one
         try:
 
-            def fake_update(*args, **kwargs):
+            def fake_update_one(*args, **kwargs):
                 self.fail("Unexpected update for %s" % args[0].name)
-                return orig_update(*args, **kwargs)
+                return orig_update_one(*args, **kwargs)
 
-            Collection.update = fake_update
+            Collection.update_one = fake_update_one
             person.save()
         finally:
-            Collection.update = orig_update
+            Collection.update_one = orig_update_one
 
     def test_db_alias_tests(self):
         """DB Alias tests."""

--- a/tests/queryset/test_geo.py
+++ b/tests/queryset/test_geo.py
@@ -2,6 +2,7 @@ import datetime
 import unittest
 
 from mongoengine import *
+from mongoengine.pymongo_support import PYMONGO_VERSION
 from tests.utils import MongoDBTestCase
 
 
@@ -47,13 +48,15 @@ class TestGeoQueries(MongoDBTestCase):
         # note that "near" will show the san francisco event, too,
         # although it sorts to last.
         events = self.Event.objects(location__near=[-87.67892, 41.9120459])
-        assert events.count() == 3
+        if PYMONGO_VERSION < (4,):
+            assert events.count() == 3
         assert list(events) == [event1, event3, event2]
 
         # ensure ordering is respected by "near"
         events = self.Event.objects(location__near=[-87.67892, 41.9120459])
         events = events.order_by("-date")
-        assert events.count() == 3
+        if PYMONGO_VERSION < (4,):
+            assert events.count() == 3
         assert list(events) == [event3, event1, event2]
 
     def test_near_and_max_distance(self):
@@ -65,8 +68,9 @@ class TestGeoQueries(MongoDBTestCase):
         # find events within 10 degrees of san francisco
         point = [-122.415579, 37.7566023]
         events = self.Event.objects(location__near=point, location__max_distance=10)
-        assert events.count() == 1
-        assert events[0] == event2
+        if PYMONGO_VERSION < (4,):
+            assert events.count() == 1
+        assert list(events) == [event2]
 
     def test_near_and_min_distance(self):
         """Ensure the "min_distance" operator works alongside the "near"
@@ -77,7 +81,9 @@ class TestGeoQueries(MongoDBTestCase):
         # find events at least 10 degrees away of san francisco
         point = [-122.415579, 37.7566023]
         events = self.Event.objects(location__near=point, location__min_distance=10)
-        assert events.count() == 2
+        if PYMONGO_VERSION < (4,):
+            assert events.count() == 2
+        assert list(events) == [event3, event1]
 
     def test_within_distance(self):
         """Make sure the "within_distance" operator works."""
@@ -153,13 +159,15 @@ class TestGeoQueries(MongoDBTestCase):
         # note that "near" will show the san francisco event, too,
         # although it sorts to last.
         events = self.Event.objects(location__near=[-87.67892, 41.9120459])
-        assert events.count() == 3
+        if PYMONGO_VERSION < (4,):
+            assert events.count() == 3
         assert list(events) == [event1, event3, event2]
 
         # ensure ordering is respected by "near"
         events = self.Event.objects(location__near=[-87.67892, 41.9120459])
         events = events.order_by("-date")
-        assert events.count() == 3
+        if PYMONGO_VERSION < (4,):
+            assert events.count() == 3
         assert list(events) == [event3, event1, event2]
 
     def test_2dsphere_near_and_max_distance(self):
@@ -171,21 +179,25 @@ class TestGeoQueries(MongoDBTestCase):
         # find events within 10km of san francisco
         point = [-122.415579, 37.7566023]
         events = self.Event.objects(location__near=point, location__max_distance=10000)
-        assert events.count() == 1
-        assert events[0] == event2
+        if PYMONGO_VERSION < (4,):
+            assert events.count() == 1
+        assert list(events) == [event2]
 
         # find events within 1km of greenpoint, broolyn, nyc, ny
         events = self.Event.objects(
             location__near=[-73.9509714, 40.7237134], location__max_distance=1000
         )
-        assert events.count() == 0
+        if PYMONGO_VERSION < (4,):
+            assert events.count() == 0
+        assert list(events) == []
 
         # ensure ordering is respected by "near"
         events = self.Event.objects(
             location__near=[-87.67892, 41.9120459], location__max_distance=10000
         ).order_by("-date")
-        assert events.count() == 2
-        assert events[0] == event3
+        if PYMONGO_VERSION < (4,):
+            assert events.count() == 2
+        assert list(events) == [event3, event1]
 
     def test_2dsphere_geo_within_box(self):
         """Ensure the "geo_within_box" operator works with a 2dsphere
@@ -236,15 +248,17 @@ class TestGeoQueries(MongoDBTestCase):
             location__min_distance=1000,
             location__max_distance=10000,
         ).order_by("-date")
-        assert events.count() == 1
-        assert events[0] == event3
+        if PYMONGO_VERSION < (4,):
+            assert events.count() == 1
+        assert list(events) == [event3]
 
         # ensure ordering is respected by "near" with "min_distance"
         events = self.Event.objects(
             location__near=[-87.67892, 41.9120459], location__min_distance=10000
         ).order_by("-date")
-        assert events.count() == 1
-        assert events[0] == event2
+        if PYMONGO_VERSION < (4,):
+            assert events.count() == 1
+        assert list(events) == [event2]
 
     def test_2dsphere_geo_within_center(self):
         """Make sure the "geo_within_center" operator works with a
@@ -289,7 +303,8 @@ class TestGeoQueries(MongoDBTestCase):
         # note that "near" will show the san francisco event, too,
         # although it sorts to last.
         events = Event.objects(venue__location__near=[-87.67892, 41.9120459])
-        assert events.count() == 3
+        if PYMONGO_VERSION < (4,):
+            assert events.count() == 3
         assert list(events) == [event1, event3, event2]
 
     def test_geo_spatial_embedded(self):
@@ -318,7 +333,9 @@ class TestGeoQueries(MongoDBTestCase):
         # Finds both points because they are within 60 km of the reference
         # point equidistant between them.
         points = Point.objects(location__near_sphere=[-122, 37.5])
-        assert points.count() == 2
+        if PYMONGO_VERSION < (4,):
+            assert points.count() == 2
+        assert list(points) == [north_point, south_point]
 
         # Same behavior for _within_spherical_distance
         points = Point.objects(
@@ -329,36 +346,42 @@ class TestGeoQueries(MongoDBTestCase):
         points = Point.objects(
             location__near_sphere=[-122, 37.5], location__max_distance=60 / earth_radius
         )
-        assert points.count() == 2
+        if PYMONGO_VERSION < (4,):
+            assert points.count() == 2
+        assert list(points) == [north_point, south_point]
 
         # Test query works with max_distance, being farer from one point
         points = Point.objects(
             location__near_sphere=[-122, 37.8], location__max_distance=60 / earth_radius
         )
         close_point = points.first()
-        assert points.count() == 1
+        if PYMONGO_VERSION < (4,):
+            assert points.count() == 1
+        assert list(points) == [north_point]
 
         # Test query works with min_distance, being farer from one point
         points = Point.objects(
             location__near_sphere=[-122, 37.8], location__min_distance=60 / earth_radius
         )
-        assert points.count() == 1
+        if PYMONGO_VERSION < (4,):
+            assert points.count() == 1
         far_point = points.first()
+        assert list(points) == [south_point]
         assert close_point != far_point
 
         # Finds both points, but orders the north point first because it's
         # closer to the reference point to the north.
         points = Point.objects(location__near_sphere=[-122, 38.5])
-        assert points.count() == 2
-        assert points[0].id == north_point.id
-        assert points[1].id == south_point.id
+        if PYMONGO_VERSION < (4,):
+            assert points.count() == 2
+        assert list(points) == [north_point, south_point]
 
         # Finds both points, but orders the south point first because it's
         # closer to the reference point to the south.
         points = Point.objects(location__near_sphere=[-122, 36.5])
-        assert points.count() == 2
-        assert points[0].id == south_point.id
-        assert points[1].id == north_point.id
+        if PYMONGO_VERSION < (4,):
+            assert points.count() == 2
+        assert list(points) == [south_point, north_point]
 
         # Finds only one point because only the first point is within 60km of
         # the reference point to the south.
@@ -375,56 +398,72 @@ class TestGeoQueries(MongoDBTestCase):
 
         Road.drop_collection()
 
-        Road(name="66", line=[[40, 5], [41, 6]]).save()
+        road = Road(name="66", line=[[40, 5], [41, 6]])
+        road.save()
 
         # near
         point = {"type": "Point", "coordinates": [40, 5]}
-        roads = Road.objects.filter(line__near=point["coordinates"]).count()
-        assert 1 == roads
+        roads = Road.objects.filter(line__near=point["coordinates"])
+        if PYMONGO_VERSION < (4,):
+            assert roads.count() == 1
+        assert list(roads) == [road]
 
-        roads = Road.objects.filter(line__near=point).count()
-        assert 1 == roads
+        roads = Road.objects.filter(line__near=point)
+        if PYMONGO_VERSION < (4,):
+            assert roads.count() == 1
+        assert list(roads) == [road]
 
-        roads = Road.objects.filter(line__near={"$geometry": point}).count()
-        assert 1 == roads
+        roads = Road.objects.filter(line__near={"$geometry": point})
+        if PYMONGO_VERSION < (4,):
+            assert roads.count() == 1
+        assert list(roads) == [road]
 
         # Within
         polygon = {
             "type": "Polygon",
             "coordinates": [[[40, 5], [40, 6], [41, 6], [41, 5], [40, 5]]],
         }
-        roads = Road.objects.filter(line__geo_within=polygon["coordinates"]).count()
-        assert 1 == roads
+        roads = Road.objects.filter(line__geo_within=polygon["coordinates"])
+        assert roads.count() == 1
+        assert list(roads) == [road]
 
-        roads = Road.objects.filter(line__geo_within=polygon).count()
-        assert 1 == roads
+        roads = Road.objects.filter(line__geo_within=polygon)
+        assert roads.count() == 1
+        assert list(roads) == [road]
 
-        roads = Road.objects.filter(line__geo_within={"$geometry": polygon}).count()
-        assert 1 == roads
+        roads = Road.objects.filter(line__geo_within={"$geometry": polygon})
+        assert roads.count() == 1
+        assert list(roads) == [road]
 
         # Intersects
         line = {"type": "LineString", "coordinates": [[40, 5], [40, 6]]}
-        roads = Road.objects.filter(line__geo_intersects=line["coordinates"]).count()
-        assert 1 == roads
+        roads = Road.objects.filter(line__geo_intersects=line["coordinates"])
+        assert roads.count() == 1
+        assert list(roads) == [road]
 
-        roads = Road.objects.filter(line__geo_intersects=line).count()
-        assert 1 == roads
+        roads = Road.objects.filter(line__geo_intersects=line)
+        assert roads.count() == 1
+        assert list(roads) == [road]
 
-        roads = Road.objects.filter(line__geo_intersects={"$geometry": line}).count()
-        assert 1 == roads
+        roads = Road.objects.filter(line__geo_intersects={"$geometry": line})
+        assert roads.count() == 1
+        assert list(roads) == [road]
 
         polygon = {
             "type": "Polygon",
             "coordinates": [[[40, 5], [40, 6], [41, 6], [41, 5], [40, 5]]],
         }
-        roads = Road.objects.filter(line__geo_intersects=polygon["coordinates"]).count()
-        assert 1 == roads
+        roads = Road.objects.filter(line__geo_intersects=polygon["coordinates"])
+        assert roads.count() == 1
+        assert list(roads) == [road]
 
-        roads = Road.objects.filter(line__geo_intersects=polygon).count()
-        assert 1 == roads
+        roads = Road.objects.filter(line__geo_intersects=polygon)
+        assert roads.count() == 1
+        assert list(roads) == [road]
 
-        roads = Road.objects.filter(line__geo_intersects={"$geometry": polygon}).count()
-        assert 1 == roads
+        roads = Road.objects.filter(line__geo_intersects={"$geometry": polygon})
+        assert roads.count() == 1
+        assert list(roads) == [road]
 
     def test_polygon(self):
         class Road(Document):
@@ -433,56 +472,72 @@ class TestGeoQueries(MongoDBTestCase):
 
         Road.drop_collection()
 
-        Road(name="66", poly=[[[40, 5], [40, 6], [41, 6], [40, 5]]]).save()
+        road = Road(name="66", poly=[[[40, 5], [40, 6], [41, 6], [40, 5]]])
+        road.save()
 
         # near
         point = {"type": "Point", "coordinates": [40, 5]}
-        roads = Road.objects.filter(poly__near=point["coordinates"]).count()
-        assert 1 == roads
+        roads = Road.objects.filter(poly__near=point["coordinates"])
+        if PYMONGO_VERSION < (4,):
+            assert roads.count() == 1
+        assert list(roads) == [road]
 
-        roads = Road.objects.filter(poly__near=point).count()
-        assert 1 == roads
+        roads = Road.objects.filter(poly__near=point)
+        if PYMONGO_VERSION < (4,):
+            assert roads.count() == 1
+        assert list(roads) == [road]
 
-        roads = Road.objects.filter(poly__near={"$geometry": point}).count()
-        assert 1 == roads
+        roads = Road.objects.filter(poly__near={"$geometry": point})
+        if PYMONGO_VERSION < (4,):
+            assert roads.count() == 1
+        assert list(roads) == [road]
 
         # Within
         polygon = {
             "type": "Polygon",
             "coordinates": [[[40, 5], [40, 6], [41, 6], [41, 5], [40, 5]]],
         }
-        roads = Road.objects.filter(poly__geo_within=polygon["coordinates"]).count()
-        assert 1 == roads
+        roads = Road.objects.filter(poly__geo_within=polygon["coordinates"])
+        assert roads.count() == 1
+        assert list(roads) == [road]
 
-        roads = Road.objects.filter(poly__geo_within=polygon).count()
-        assert 1 == roads
+        roads = Road.objects.filter(poly__geo_within=polygon)
+        assert roads.count() == 1
+        assert list(roads) == [road]
 
-        roads = Road.objects.filter(poly__geo_within={"$geometry": polygon}).count()
-        assert 1 == roads
+        roads = Road.objects.filter(poly__geo_within={"$geometry": polygon})
+        assert roads.count() == 1
+        assert list(roads) == [road]
 
         # Intersects
         line = {"type": "LineString", "coordinates": [[40, 5], [41, 6]]}
-        roads = Road.objects.filter(poly__geo_intersects=line["coordinates"]).count()
-        assert 1 == roads
+        roads = Road.objects.filter(poly__geo_intersects=line["coordinates"])
+        assert roads.count() == 1
+        assert list(roads) == [road]
 
-        roads = Road.objects.filter(poly__geo_intersects=line).count()
-        assert 1 == roads
+        roads = Road.objects.filter(poly__geo_intersects=line)
+        assert roads.count() == 1
+        assert list(roads) == [road]
 
-        roads = Road.objects.filter(poly__geo_intersects={"$geometry": line}).count()
-        assert 1 == roads
+        roads = Road.objects.filter(poly__geo_intersects={"$geometry": line})
+        assert roads.count() == 1
+        assert list(roads) == [road]
 
         polygon = {
             "type": "Polygon",
             "coordinates": [[[40, 5], [40, 6], [41, 6], [41, 5], [40, 5]]],
         }
-        roads = Road.objects.filter(poly__geo_intersects=polygon["coordinates"]).count()
-        assert 1 == roads
+        roads = Road.objects.filter(poly__geo_intersects=polygon["coordinates"])
+        assert roads.count() == 1
+        assert list(roads) == [road]
 
-        roads = Road.objects.filter(poly__geo_intersects=polygon).count()
-        assert 1 == roads
+        roads = Road.objects.filter(poly__geo_intersects=polygon)
+        assert roads.count() == 1
+        assert list(roads) == [road]
 
-        roads = Road.objects.filter(poly__geo_intersects={"$geometry": polygon}).count()
-        assert 1 == roads
+        roads = Road.objects.filter(poly__geo_intersects={"$geometry": polygon})
+        assert roads.count() == 1
+        assert list(roads) == [road]
 
     def test_aspymongo_with_only(self):
         """Ensure as_pymongo works with only"""

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -411,11 +411,14 @@ class ConnectionTest(unittest.TestCase):
         # OperationFailure means that mongoengine attempted authentication
         # w/ the provided username/password and failed - that's the desired
         # behavior. If the MongoDB URI would override the credentials
-        with pytest.raises(OperationFailure):
-            db = get_db()
-            # pymongo 4.x does not call db.authenticate and needs to perform an operation to trigger the failure
-            if PYMONGO_VERSION >= (4,):
+        if PYMONGO_VERSION >= (4,):
+            with pytest.raises(OperationFailure):
+                db = get_db()
+                # pymongo 4.x does not call db.authenticate and needs to perform an operation to trigger the failure
                 db.list_collection_names()
+        else:
+            with pytest.raises(OperationFailure):
+                db = get_db()
 
     def test_connect_uri_with_authsource(self):
         """Ensure that the connect() method works well with `authSource`

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -23,6 +23,7 @@ from mongoengine.connection import (
     get_connection,
     get_db,
 )
+from mongoengine.pymongo_support import PYMONGO_VERSION
 
 
 def get_tz_awareness(connection):
@@ -482,7 +483,10 @@ class ConnectionTest(unittest.TestCase):
         conn = connect(
             "mongoenginetest", alias="max_pool_size_via_kwarg", **pool_size_kwargs
         )
-        assert conn.max_pool_size == 100
+        if PYMONGO_VERSION >= (4,):
+            assert conn.options.pool_options.max_pool_size == 100
+        else:
+            assert conn.max_pool_size == 100
 
     def test_connection_pool_via_uri(self):
         """Ensure we can specify a max connection pool size using
@@ -492,7 +496,10 @@ class ConnectionTest(unittest.TestCase):
             host="mongodb://localhost/test?maxpoolsize=100",
             alias="max_pool_size_via_uri",
         )
-        assert conn.max_pool_size == 100
+        if PYMONGO_VERSION >= (4,):
+            assert conn.options.pool_options.max_pool_size == 100
+        else:
+            assert conn.max_pool_size == 100
 
     def test_write_concern(self):
         """Ensure write concern can be specified in connect() via

--- a/tests/test_context_managers.py
+++ b/tests/test_context_managers.py
@@ -269,17 +269,23 @@ class TestContextManagers:
         connect("mongoenginetest")
         db = get_db()
 
-        initial_profiling_level = db.profiling_level()
+        def _current_profiling_level():
+            return db.command({"profile": -1})["was"]
+
+        def _set_profiling_level(lvl):
+            db.command({"profile": lvl})
+
+        initial_profiling_level = _current_profiling_level()
 
         try:
             new_level = 1
-            db.set_profiling_level(new_level)
-            assert db.profiling_level() == new_level
+            _set_profiling_level(new_level)
+            assert _current_profiling_level() == new_level
             with query_counter():
-                assert db.profiling_level() == 2
-            assert db.profiling_level() == new_level
+                assert _current_profiling_level() == 2
+            assert _current_profiling_level() == new_level
         except Exception:
-            db.set_profiling_level(
+            _set_profiling_level(
                 initial_profiling_level
             )  # Ensures it gets reseted no matter the outcome of the test
             raise

--- a/tox.ini
+++ b/tox.ini
@@ -10,5 +10,6 @@ deps =
     mg39: pymongo>=3.9,<3.10
     mg311: pymongo>=3.11,<3.12
     mg312: pymongo>=3.12,<3.13
+    mg4: pymongo>=4.0,<4.1
 setenv =
     PYTHON_EGG_CACHE = {envdir}/python-eggs

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy3-{mg34,mg36,mg39,mg311,mg312}
+envlist = pypy3-{mg34,mg36,mg39,mg311,mg312,mg4}
 
 [testenv]
 commands =


### PR DESCRIPTION
This change follows up on top of #2600 and includes the following updates:

- merge master
- fixes for `GEOHAYSTACK` removal
- fixes for `max_pool_size` move
- fixes for `map_reduce` and `inline_map_reduce` removals
- fixes for `eval` removal
- fall back to the `pythonLegacy` UUID encoding for compatability with pymongo 3.x.
- fixes for SON.keys() not returning a list
- fixes for removed `collection.update`
- bubble up operation failure if an unsupported document count is attempted (The user can fetch the documents with `len(list(queryset))` or modify the query as needed).
- fixes for `db.authenticate` removal

The test suite is now passing locally and I'm opening this up in the main repo to run against the CI. I had originally opened https://github.com/bagerard/mongoengine/pull/20 to update #2600.

Fixes: #2598