### PR TITLE
update dependency specifier to allow pymongo 4.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ setup(
     platforms=["any"],
     classifiers=CLASSIFIERS,
     python_requires=">=3.6",
-    install_requires=["pymongo>=3.4,<=4.0"],
+    install_requires=["pymongo>=3.4,<5.0"],
     cmdclass={"test": PyTest},
     **extra_opts
 )


### PR DESCRIPTION
I noticed this was missed in `0.24.0` as installing via `pip-tools` which is checking the version constraints.