### PR TITLE
Don't use deprecated property for emptiness check

### DIFF
--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -722,7 +722,7 @@ class BaseQuerySet:
         :param object_id: the value for the id of the document to look up
         """
         queryset = self.clone()
-        if bool(queryset._query_obj):
+        if queryset._query_obj:
             msg = "Cannot use a filter whilst using `with_id`"
             raise InvalidQueryError(msg)
         return queryset.filter(pk=object_id).first()

--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -722,7 +722,7 @@ class BaseQuerySet:
         :param object_id: the value for the id of the document to look up
         """
         queryset = self.clone()
-        if not queryset._query_obj.empty:
+        if bool(queryset._query_obj):
             msg = "Cannot use a filter whilst using `with_id`"
             raise InvalidQueryError(msg)
         return queryset.filter(pk=object_id).first()


### PR DESCRIPTION
# Why?

The current check in https://github.com/mongoengine/mongoengine/blob/master/mongoengine/queryset/base.py#L725 uses the deprecated `empty` property.