### PR TITLE
Fixes querying nested fields in dynamic embedded docs

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -1150,19 +1150,20 @@ class BaseDocument:
                 if hasattr(getattr(field, "field", None), "lookup_member"):
                     new_field = field.field.lookup_member(field_name)
 
-                # If the parent field is a DynamicField or if it's part of
-                # a DynamicDocument, mark current field as a DynamicField
+                # If the parent field is a DynamicField, mark current field as a DynamicField
                 # with db_name equal to the field name.
-                elif cls._dynamic and (
-                    isinstance(field, DynamicField)
-                    or getattr(getattr(field, "document_type", None), "_dynamic", None)
-                ):
+                elif isinstance(field, DynamicField):
                     new_field = DynamicField(db_field=field_name)
 
-                # Else, try to use the parent field's lookup_member method
+                # Try to use the parent field's lookup_member method
                 # to find the subfield.
                 elif hasattr(field, "lookup_member"):
                     new_field = field.lookup_member(field_name)
+
+                # Else, if the current field it's part of a DynamicDocument, mark current field
+                # as a DynamicField with db_name equal to the field name.
+                elif cls._dynamic and getattr(getattr(field, "document_type", None), "_dynamic", None):
+                    new_field = DynamicField(db_field=field_name)
 
                 # Raise a LookUpError if all the other conditions failed.
                 else:


### PR DESCRIPTION
Changing field lookup for `DynamicDocument`s when the field is nested in a `DynamicEmbeddedDocument`.

Before these changes, the code was creating a dynamic field when the container document is a dynamic document regardless of the field being nested in an embedded document. In which case the field should be looked up there.

This PR fixes #2251.

There are two new tests that evidence this and another error:

1. test_complex_embedded_document_query: before the change this test raises a `LookUpError` (the error in #2251)
2. test_complex_embedded_document_with_aliased_field_query: this test shows up the query executed is not correct when a field in the `DynamicEmbeddedDocument` has defined a value for `db_field`.

