### PR TITLE
Turning off dereferencing for the results of distinct query.

### DIFF
--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -953,9 +953,13 @@ class BaseQuerySet:
             field = self._fields_to_dbfields([field]).pop()
         except LookUpError:
             pass
+        
+        raw_values = queryset._cursor.distinct(field)
+        if not self._auto_dereference:
+            return raw_values
 
         distinct = self._dereference(
-            queryset._cursor.distinct(field), 1, name=field, instance=self._document
+            raw_values, 1, name=field, instance=self._document
         )
 
         doc_field = self._document._fields.get(field.split(".", 1)[0])


### PR DESCRIPTION
distinct automatically dereferences the results, however it should obey the  `_auto_dereference`, set by `no_dereference()`. This change makes distinct query not to dereference the values when `no_dereference()` is called on the queryset

For example, suppose I have a collection of BlogPost documents, each of which has a `user` ReferenceField pointing to a User document.  If I'd like to count the number of unique users who've written blog posts, I could do the following:

len(documents.BlogPost.objects(query).no_dereference().distinct("user"))

In this case, dereferencing all of those `user` fields just slows down the query as distinct doesn't obey the `_auto_dereference` field value set by the `no_dereference()` method.

The changes in the PR check for `_auto_dereference` value before dereferencing the results!

resolves https://github.com/MongoEngine/mongoengine/issues/2663