### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -77,7 +77,7 @@ MongoDB connection before shipping v0.10.8 in production.
 ******
 
 `QuerySet.aggregate_sum` and `QuerySet.aggregate_average` are dropped. Use
-`QuerySet.sum` and `QuerySet.average` instead which use the aggreation framework
+`QuerySet.sum` and `QuerySet.average` instead which use the aggregation framework
 by default from now on.
 
 0.9.0

--- a/tests/document/test_instance.py
+++ b/tests/document/test_instance.py
@@ -1735,7 +1735,7 @@ class TestDocumentInstance(MongoDBTestCase):
 
         user = User.objects.first()
         # Even if stored as ObjectId's internally mongoengine uses DBRefs
-        # As ObjectId's aren't automatically derefenced
+        # As ObjectId's aren't automatically dereferenced
         assert isinstance(user._data["orgs"][0], DBRef)
         assert isinstance(user.orgs[0], Organization)
         assert isinstance(user._data["orgs"][0], Organization)

--- a/tests/fields/test_fields.py
+++ b/tests/fields/test_fields.py
@@ -126,7 +126,7 @@ class TestField(MongoDBTestCase):
 
     def test_default_values_set_to_None(self):
         """Ensure that default field values are used even when
-        we explcitly initialize the doc with None values.
+        we explicitly initialize the doc with None values.
         """
 
         class Person(Document):

--- a/tests/fields/test_file_field.py
+++ b/tests/fields/test_file_field.py
@@ -328,7 +328,7 @@ class TestFileField(MongoDBTestCase):
         assert len(list(files)) == 1
         assert len(list(chunks)) == 1
 
-        # Deleting the docoument should delete the files
+        # Deleting the document should delete the files
         testfile.delete()
 
         files = db.fs.files.find()

--- a/tests/queryset/test_geo.py
+++ b/tests/queryset/test_geo.py
@@ -237,7 +237,7 @@ class TestGeoQueries(MongoDBTestCase):
         assert events.count() == 0
 
     def test_2dsphere_near_and_min_max_distance(self):
-        """Ensure "min_distace" and "max_distance" operators work well
+        """Ensure "min_distance" and "max_distance" operators work well
         together with the "near" operator in a 2dsphere index.
         """
         event1, event2, event3 = self._create_event_data(point_field_class=PointField)


### PR DESCRIPTION
There are small typos in:
- docs/upgrade.rst
- tests/document/test_instance.py
- tests/fields/test_fields.py
- tests/fields/test_file_field.py
- tests/queryset/test_geo.py

Fixes:
- Should read `explicitly` rather than `explcitly`.
- Should read `document` rather than `docoument`.
- Should read `distance` rather than `distace`.
- Should read `dereferenced` rather than `derefenced`.
- Should read `aggregation` rather than `aggreation`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md