### PR TITLE
[#2685] implement a thread-safe switch db context manager

### DIFF
--- a/mongoengine/errors.py
+++ b/mongoengine/errors.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 
 __all__ = (
+    "DatabaseAliasError",
     "NotRegistered",
     "InvalidDocumentError",
     "LookUpError",
@@ -18,6 +19,10 @@ __all__ = (
 
 
 class MongoEngineException(Exception):
+    pass
+
+
+class DatabaseAliasError(MongoEngineException):
     pass
 
 


### PR DESCRIPTION
Proposal to address thread-safe db switching, as per: https://github.com/MongoEngine/mongoengine/issues/2685

Doesn't yet address thread-safe collection switching, but this could probably be considered in a similar way.
