### PR TITLE
Fix issue with flake8 and importlib_metadata 5.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,15 +8,17 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/ambv/black
-    rev: 22.8.0
+    rev: 22.10.0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:
       - id: flake8
+        additional_dependencies:
+          - importlib_metadata<5
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.3
+    rev: v3.1.0
     hooks:
       - id: pyupgrade
         args: [--py36-plus]


### PR DESCRIPTION
importlib_metadata 5.0 that introduced breaking changes (breaks on py 3.7)

flake8 was failing with

```
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

Traceback (most recent call last):
  File "/home/bgerard/.cache/pre-commit/repope3a67k1/py_env-python3.7/bin/flake8", line 8, in <module>
    sys.exit(main())
  File "/home/bgerard/.cache/pre-commit/repope3a67k1/py_env-python3.7/lib/python3.7/site-packages/flake8/main/cli.py", line ...
  File "/home/bgerard/.cache/pre-commit/repope3a67k1/py_env-python3.7/lib/python3.7/site-packages/flake8/plugins/manager.py", line 254, in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
AttributeError: 'EntryPoints' object has no attribute 'get'
```
