### PR TITLE
allow_workflow_dispatch as trigger

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - master
+  # Manual trigger from Action page
+  workflow_dispatch:
   # release tags
   create:
     tags:


### PR DESCRIPTION
Fix the fact that we can't run workflow manually on branches