### PR TITLE
Breaking change: Improve save() performance by skipping index creation

### DIFF
--- a/benchmarks/test_basic_doc_ops.py
+++ b/benchmarks/test_basic_doc_ops.py
@@ -12,7 +12,7 @@ from mongoengine import (
     StringField,
 )
 
-mongoengine.connect(db="mongoengine_benchmark_test")
+mongoengine.connect(db="mongoengine_benchmark_test", w=1)
 
 
 def timeit(f, n=10000):

--- a/benchmarks/test_inserts.py
+++ b/benchmarks/test_inserts.py
@@ -5,15 +5,11 @@ def main():
     setup = """
 from pymongo import MongoClient
 
-connection = MongoClient()
+connection = MongoClient(w=1)
 connection.drop_database('mongoengine_benchmark_test')
 """
 
     stmt = """
-from pymongo import MongoClient
-
-connection = MongoClient()
-
 db = connection.mongoengine_benchmark_test
 noddy = db.noddy
 
@@ -29,13 +25,12 @@ myNoddys = noddy.find()
 """
 
     print("-" * 100)
-    print("PyMongo: Creating 10000 dictionaries.")
+    print('PyMongo: Creating 10000 dictionaries (write_concern={"w": 1}).')
     t = timeit.Timer(stmt=stmt, setup=setup)
     print(f"{t.timeit(1)}s")
 
     stmt = """
-from pymongo import MongoClient, WriteConcern
-connection = MongoClient()
+from pymongo import WriteConcern
 
 db = connection.mongoengine_benchmark_test
 noddy = db.noddy.with_options(write_concern=WriteConcern(w=0))
@@ -64,7 +59,7 @@ connection.drop_database('mongoengine_benchmark_test')
 connection.close()
 
 from mongoengine import Document, DictField, connect
-connect("mongoengine_benchmark_test")
+connect("mongoengine_benchmark_test", w=1)
 
 class Noddy(Document):
     fields = DictField()
@@ -82,7 +77,7 @@ myNoddys = Noddy.objects()
 """
 
     print("-" * 100)
-    print("MongoEngine: Creating 10000 dictionaries.")
+    print('MongoEngine: Creating 10000 dictionaries (write_concern={"w": 1}).')
     t = timeit.Timer(stmt=stmt, setup=setup)
     print(f"{t.timeit(1)}s")
 

--- a/benchmarks/test_save_with_indexes.py
+++ b/benchmarks/test_save_with_indexes.py
@@ -1,0 +1,87 @@
+import timeit
+
+
+def main():
+    setup = """
+from pymongo import MongoClient
+
+connection = MongoClient()
+connection.drop_database("mongoengine_benchmark_test")
+connection.close()
+
+from mongoengine import connect, Document, IntField, StringField
+connect("mongoengine_benchmark_test", w=1)
+
+class User0(Document):
+    name = StringField()
+    age = IntField()
+
+class User1(Document):
+    name = StringField()
+    age = IntField()
+    meta = {"indexes": [["name"]]}
+
+class User2(Document):
+    name = StringField()
+    age = IntField()
+    meta = {"indexes": [["name", "age"]]}
+
+class User3(Document):
+    name = StringField()
+    age = IntField()
+    meta = {"indexes": [["name"]], "auto_create_index_on_save": True}
+
+class User4(Document):
+    name = StringField()
+    age = IntField()
+    meta = {"indexes": [["name", "age"]], "auto_create_index_on_save": True}
+"""
+
+    stmt = """
+for i in range(10000):
+    User0(name="Nunu", age=9).save()
+"""
+    print("-" * 80)
+    print("Save 10000 documents with 0 indexes.")
+    t = timeit.Timer(stmt=stmt, setup=setup)
+    print(f"{min(t.repeat(repeat=3, number=1))}s")
+
+    stmt = """
+for i in range(10000):
+    User1(name="Nunu", age=9).save()
+"""
+    print("-" * 80)
+    print("Save 10000 documents with 1 index.")
+    t = timeit.Timer(stmt=stmt, setup=setup)
+    print(f"{min(t.repeat(repeat=3, number=1))}s")
+
+    stmt = """
+for i in range(10000):
+    User2(name="Nunu", age=9).save()
+"""
+    print("-" * 80)
+    print("Save 10000 documents with 2 indexes.")
+    t = timeit.Timer(stmt=stmt, setup=setup)
+    print(f"{min(t.repeat(repeat=3, number=1))}s")
+
+    stmt = """
+for i in range(10000):
+    User3(name="Nunu", age=9).save()
+"""
+    print("-" * 80)
+    print("Save 10000 documents with 1 index (auto_create_index_on_save=True).")
+    t = timeit.Timer(stmt=stmt, setup=setup)
+    print(f"{min(t.repeat(repeat=3, number=1))}s")
+
+    stmt = """
+for i in range(10000):
+    User4(name="Nunu", age=9).save()
+"""
+    print("-" * 80)
+    print("Save 10000 documents with 2 indexes (auto_create_index_on_save=True).")
+    t = timeit.Timer(stmt=stmt, setup=setup)
+    print(f"{min(t.repeat(repeat=3, number=1))}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,11 @@ Development
 - Support MONGODB-AWS authentication mechanism (with `authmechanismproperties`) #2507
 - Turning off dereferencing for the results of distinct query. #2663
 - Add tests against Mongo 5.0 in pipeline
+- BREAKING CHANGE: Improved the performance of :meth:`~mongoengine.Document.save()`
+  by removing the call to :meth:`~mongoengine.Document.ensure_indexes` unless
+  ``meta['auto_create_index_on_save']`` is set to True.
+- Added meta ``auto_create_index_on_save`` so you can enable index creation
+  on :meth:`~mongoengine.Document.save()`.
 
 Changes in 0.24.2
 =================

--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -574,6 +574,7 @@ There are a few top level defaults for all indexes that can be set::
             'index_background': True,
             'index_cls': False,
             'auto_create_index': True,
+            'auto_create_index_on_save': False,
         }
 
 
@@ -588,10 +589,15 @@ There are a few top level defaults for all indexes that can be set::
 
 :attr:`auto_create_index` (Optional)
     When this is True (default), MongoEngine will ensure that the correct
-    indexes exist in MongoDB each time a command is run. This can be disabled
+    indexes exist in MongoDB when the Document is first used. This can be disabled
     in systems where indexes are managed separately. Disabling this will improve
     performance.
 
+:attr:`auto_create_index_on_save` (Optional)
+    When this is True, MongoEngine will ensure that the correct
+    indexes exist in MongoDB each time :meth:`~mongoengine.document.Document.save`
+    is run. Enabling this will degrade performance. The default is False. This
+    option was added in version 0.25.
 
 Compound Indexes and Indexing sub documents
 -------------------------------------------


### PR DESCRIPTION
Indexes are now only created when a Model is first used, eg the first call to save() or on the first call to _get_collection(), or when the new meta["auto_create_index_on_save"] option is set to True. This is a minor breaking change for some applications. As a workaround apps can explicitly call ensure_indexes() or set meta["auto_create_index_on_save"] to True. 

Note that with the default settings (auto_create_index=True + auto_create_index_on_save=False) indexes are still created after on a Document's first use, or first use after Document.drop_collection().

I hope this PR can finally resolve https://github.com/MongoEngine/mongoengine/issues/1446. I reviewed that issue, the previous attempts to fix it (https://github.com/MongoEngine/mongoengine/pull/1457 and https://github.com/MongoEngine/mongoengine/pull/1511), and the original issue that added this behavior (https://github.com/MongoEngine/mongoengine/issues/812) and I believe the solution in this PR is a good compromise between having better default behavior while also offering an escape hatch for the old behavior (via auto_create_index_on_save).

Here are the benchmark results:
```
$ python benchmarks/test_save_with_indexes.py
--------------------------------------------------------------------------------
Save 10000 documents with 0 indexes.
2.8389482499987935s
--------------------------------------------------------------------------------
Save 10000 documents with 1 index.
2.782498458000191s
--------------------------------------------------------------------------------
Save 10000 documents with 2 indexes.
2.7451970830006758s
--------------------------------------------------------------------------------
Save 10000 documents with 1 index (auto_create_index_on_save=True).
4.725924582999141s
--------------------------------------------------------------------------------
Save 10000 documents with 2 indexes (auto_create_index_on_save=True).
4.777219208997849s
```

4.72/2.78 = a significant 1.7x speed up for save() on a document with one field and one index.


Note: I've made some relatively minor changes to the other benchmarks as well, mainly just to explicitly use w=1 write concern. This change significantly improves the runtime (and the effectiveness) of the benchmarks, otherwise they end up using the server's default writeConcern which is now w:majority. I can move this to a new PR if desired.