### PR TITLE
[Clone] Fixing loading of EnumField inside ListField

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,7 @@ Development
 - Addition of Decimal128Field: :class:`~mongoengine.fields.Decimal128Field` for accurate representation of Decimals (much better than the legacy field DecimalField).
   Although it could work to switch an existing DecimalField to Decimal128Field without applying a migration script,
   it is not recommended to do so (DecimalField uses float/str to store the value, Decimal128Field uses Decimal128).
+- BREAKING CHANGE: When using ListField(EnumField) or DictField(EnumField), the values weren't always cast into the Enum (#2531)
 
 Changes in 0.25.0
 =================

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -1122,7 +1122,7 @@ class MapField(DictField):
     """
 
     def __init__(self, field=None, *args, **kwargs):
-        # XXX ValidationError raised outside of the "validate" method.
+        # XXX ValidationError raised outside the "validate" method.
         if not isinstance(field, BaseField):
             self.error("Argument to MapField constructor must be a valid field")
         super().__init__(field=field, *args, **kwargs)

--- a/tests/fields/test_binary_field.py
+++ b/tests/fields/test_binary_field.py
@@ -31,6 +31,14 @@ class TestBinaryField(MongoDBTestCase):
         assert MIME_TYPE == attachment_1.content_type
         assert BLOB == bytes(attachment_1.blob)
 
+    def test_bytearray_conversion_to_bytes(self):
+        class Dummy(Document):
+            blob = BinaryField()
+
+        byte_arr = bytearray(b"\x00\x00\x00\x00\x00")
+        dummy = Dummy(blob=byte_arr)
+        assert isinstance(dummy.blob, bytes)
+
     def test_validation_succeeds(self):
         """Ensure that valid values can be assigned to binary fields."""
 

--- a/tests/fields/test_enum_field.py
+++ b/tests/fields/test_enum_field.py
@@ -121,20 +121,24 @@ class TestStringEnumField(MongoDBTestCase):
         assert model.status == Status.NEW
         assert model.statuses == [Status.NEW]
         assert model.color_mapping == {"red": Color.RED}
+
         model.reload()
         assert model.status == Status.NEW
         assert model.statuses == [Status.NEW]
         assert model.color_mapping == {"red": Color.RED}
+
         model.status = "done"
         model.color_mapping = {"blue": 2}
         model.statuses = ["new", "done"]
+        model.save()
         assert model.status == Status.DONE
-        assert model.color_mapping == {"blue": Color.BLUE}, model.color_mapping
-        assert model.statuses == [Status.NEW, Status.DONE], model.statuses
-        model = model.save().reload()
+        assert model.statuses == [Status.NEW, Status.DONE]
+        assert model.color_mapping == {"blue": Color.BLUE}
+
+        model.reload()
         assert model.status == Status.DONE
-        assert model.color_mapping == {"blue": Color.BLUE}, model.color_mapping
-        assert model.statuses == [Status.NEW, Status.DONE], model.statuses
+        assert model.color_mapping == {"blue": Color.BLUE}
+        assert model.statuses == [Status.NEW, Status.DONE]
 
         with pytest.raises(ValidationError, match="must be one of ..Status"):
             model.statuses = [1]

--- a/tests/fields/test_object_id_field.py
+++ b/tests/fields/test_object_id_field.py
@@ -1,0 +1,30 @@
+import pytest
+from bson import ObjectId
+
+from mongoengine import Document, ObjectIdField, ValidationError
+from tests.utils import MongoDBTestCase, get_as_pymongo
+
+
+class TestObjectIdField(MongoDBTestCase):
+    def test_storage(self):
+        class MyDoc(Document):
+            oid = ObjectIdField()
+
+        doc = MyDoc(oid=ObjectId())
+        doc.save()
+        assert get_as_pymongo(doc) == {"_id": doc.id, "oid": doc.oid}
+
+    def test_constructor_converts_str_to_ObjectId(self):
+        class MyDoc(Document):
+            oid = ObjectIdField()
+
+        doc = MyDoc(oid=str(ObjectId()))
+        assert isinstance(doc.oid, ObjectId)
+
+    def test_validation_works(self):
+        class MyDoc(Document):
+            oid = ObjectIdField()
+
+        doc = MyDoc(oid="not-an-oid!")
+        with pytest.raises(ValidationError, match="Invalid ObjectID"):
+            doc.save()


### PR DESCRIPTION
Work on top of https://github.com/MongoEngine/mongoengine/pull/2531

Main change on top of the original PR is to only cast EnumField to reduce the blast impact of this breaking change. In fact the initial PR was affecting (casting) other fields than just EnumField. It was also affecting for instance ListField(ObjectId).

PR also includes some unrelated things that I spot while investigating this (missing tests, etc)