### PR TITLE
Allow specifying alternative connection_class

### DIFF
--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -76,6 +76,9 @@ def _get_connection_settings(
         MONGODB-CR (MongoDB Challenge Response protocol) for older servers.
     :param is_mock: explicitly use mongomock for this connection
         (can also be done by using `mongomock: // ` as db host prefix)
+    :param connection_class: using alternative connection client other than
+        pymongo or mongomock, e.g. montydb, that provides pymongo alike
+        interface but not necessarily for connecting to a real mongo instance.
     :param kwargs: ad-hoc parameters to be passed into the pymongo driver,
         for example maxpoolsize, tz_aware, etc. See the documentation
         for pymongo's `MongoClient` for a full list.
@@ -221,6 +224,9 @@ def register_connection(
         MONGODB-CR (MongoDB Challenge Response protocol) for older servers.
     :param is_mock: explicitly use mongomock for this connection
         (can also be done by using `mongomock: // ` as db host prefix)
+    :param connection_class: using alternative connection client other than
+        pymongo or mongomock, e.g. montydb, that provides pymongo alike
+        interface but not necessarily for connecting to a real mongo instance.
     :param kwargs: ad-hoc parameters to be passed into the pymongo driver,
         for example maxpoolsize, tz_aware, etc. See the documentation
         for pymongo's `MongoClient` for a full list.
@@ -333,6 +339,10 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
         except ImportError:
             raise RuntimeError("You need mongomock installed to mock MongoEngine.")
         connection_class = mongomock.MongoClient
+
+    elif "connection_class" in conn_settings:
+        connection_class = conn_settings.pop("connection_class")
+
     else:
         connection_class = MongoClient
 


### PR DESCRIPTION
This addresses #1168 (an old issue 😄).

This pull request opens door for projects like [montydb](https://github.com/davidlatwe/montydb) or [mongita](https://github.com/scottrogowski/mongita) that provids mongo-like alternative for testing or simple production usage, able to gain benefit from mongoengine.

There's some small amount of discussions in said projects:
https://github.com/scottrogowski/mongita/issues/4
https://github.com/davidlatwe/montydb/issues/64

And the only workaround for this is to monkey-patch `pymongo.MongoClient` just like what #1168 has concluded.

But thanks to the evolution that mongoengine has been through, the codebase seems able to enable this feature easily. Hance this PR.

Please let me know what you think, thanks.
