### PR TITLE
Add `get` method in BaseDocument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ env/
 htmlcov/
 venv
 venv3
+.vscode/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
       - id: pyupgrade
         args: [--py36-plus]
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort

--- a/AUTHORS
+++ b/AUTHORS
@@ -264,3 +264,4 @@ that much better:
  * oleksandr-l5 (https://github.com/oleksandr-l5)
  * Ido Shraga (https://github.com/idoshr)
  * Terence Honles (https://github.com/terencehonles)
+ * Kamil Kołodziejski

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -236,7 +236,7 @@ class. So let's see how we can get our posts' titles::
     for post in Post.objects:
         print(post.title)
 
-Additionally, the :class:`~mongoengine.base.BaseDocument` class provides a method  :meth:`~mongoengine.base.BaseDocument.get` :meth:`~mongoengine.base.BaseDocument.get`, which returns the value of the field, but unlike the dot notation, it has a default value and does not raise an exception in case the field is missing in the document::
+:class:`~mongoengine.base.BaseDocument` class provides a dictionary-style method :meth:`~mongoengine.base.BaseDocument.get`, which returns the value of the field if present, otherwise return `default` value::
 
     for post in Post.object:
         print(post.get('title', default='No title'))

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -236,6 +236,11 @@ class. So let's see how we can get our posts' titles::
     for post in Post.objects:
         print(post.title)
 
+Additionally, the :class:`~mongoengine.base.BaseDocument` class provides a method  :meth:`~mongoengine.base.BaseDocument.get` :meth:`~mongoengine.base.BaseDocument.get`, which returns the value of the field, but unlike the dot notation, it has a default value and does not raise an exception in case the field is missing in the document::
+
+    for post in Post.object:
+        print(post.get('title', default='No title'))
+
 Retrieving type-specific information
 ------------------------------------
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -236,7 +236,9 @@ class. So let's see how we can get our posts' titles::
     for post in Post.objects:
         print(post.title)
 
-:class:`~mongoengine.base.BaseDocument` class provides a dictionary-style method :meth:`~mongoengine.base.BaseDocument.get`, which returns the value of the field if present, otherwise return `default` value::
+:class:`~mongoengine.base.BaseDocument` class provides a dictionary-style
+method :meth:`~mongoengine.base.BaseDocument.get`, which returns a value
+of the field if it's present, otherwise return ``default`` value::
 
     for post in Post.object:
         print(post.get('title', default='No title'))

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -306,17 +306,16 @@ class BaseDocument:
         return not self.__eq__(other)
 
     def get(self, name, default=None):
-        """Dictionary-style get method with default value.
+        """Dictionary-style get method.
 
-        Return default when field is not founded.
+        Return field value if preset otherwise return default value.
 
-        -- note:: Method never raises exception even if key doesn't exists.
-
-        :param name: key name
-        :param default: (optional) default value if key doesn't exists or isn't preset
+        :param name: field name
+        :param default: (optional) default value if field isn't present.
         """
         try:
-            return self.__getitem__(name) or default
+            val = self.__getitem__(name)
+            return default if val is None else val
         except KeyError:
             return default
 

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -311,7 +311,7 @@ class BaseDocument:
         Return field value if preset otherwise return default value.
 
         :param name: field name
-        :param default: (optional) default value if field isn't present.
+        :param default: (optional) return if field isn't present.
         """
         try:
             val = self.__getitem__(name)

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -305,6 +305,21 @@ class BaseDocument:
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def get(self, name, default=None):
+        """Dictionary-style get method with default value.
+
+        Return default when field is not founded.
+
+        -- note:: Method never raises exception even if key doesn't exists.
+
+        :param name: key name
+        :param default: (optional) default value if key doesn't exists or isn't preset
+        """
+        try:
+            return self.__getitem__(name) or default
+        except KeyError:
+            return default
+
     def clean(self):
         """
         Hook for doing document level data cleaning (usually validation or assignment)

--- a/tests/document/test_instance.py
+++ b/tests/document/test_instance.py
@@ -706,8 +706,11 @@ class TestDocumentInstance(MongoDBTestCase):
         assert person.get("salary") is None
         assert person.get("name", "Test Name") == "Test User"
         assert person.get("salary", 5000) == 5000
+
         assert person.job.get("name", "Unknown") == "Test Job"
-        assert person.job.get("years", 0) == 0
+        assert person.job.get("years", 5) == 5
+        person.job.years = 0
+        assert person.job.get("years", 5) == 0
 
     def test_embedded_document_to_mongo(self):
         class Person(EmbeddedDocument):

--- a/tests/document/test_instance.py
+++ b/tests/document/test_instance.py
@@ -698,6 +698,17 @@ class TestDocumentInstance(MongoDBTestCase):
         assert "age" not in person
         assert "nationality" not in person
 
+    def test_get_method(self):
+        """Ensure that dictionary-style get method works properly."""
+        person = self.Person(name="Test User", age=30, job=self.Job(name="Test Job"))
+
+        assert person.get("name") == "Test User"
+        assert person.get("salary") is None
+        assert person.get("name", "Test Name") == "Test User"
+        assert person.get("salary", 5000) == 5000
+        assert person.job.get("name", "Unknown") == "Test Job"
+        assert person.job.get("years", 0) == 0
+
     def test_embedded_document_to_mongo(self):
         class Person(EmbeddedDocument):
             name = StringField()


### PR DESCRIPTION
Small PR with new a method `get(name, default=None)` in BaseDocument implemented in the same way as dictionary `get` method.

The method will allow to return a default value and avoid key exceptions in case of missing field. I believe that this will help in working with nested, optional fields in the model.

- [X] docstring
- [X] add unit-tests
- [X] test on different python versions
- [X] add example in tutorial guide