### PR TITLE
Log MongoEngine version when connecting to the server

### DIFF
--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -3,6 +3,13 @@ import warnings
 from pymongo import MongoClient, ReadPreference, uri_parser
 from pymongo.database import _check_name
 
+# DriverInfo was added in PyMongo 3.7.
+try:
+    from pymongo.driver_info import DriverInfo
+except ImportError:
+    DriverInfo = None
+
+import mongoengine
 from mongoengine.pymongo_support import PYMONGO_VERSION
 
 __all__ = [
@@ -320,6 +327,10 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
     # alias and remove the database name and authentication info (we don't
     # care about them at this point).
     conn_settings = _clean_settings(raw_conn_settings)
+    if DriverInfo is not None:
+        conn_settings.setdefault(
+            "driver", DriverInfo("MongoEngine", mongoengine.__version__)
+        )
 
     # Determine if we should use PyMongo's or mongomock's MongoClient.
     if "mongo_client_class" in conn_settings:


### PR DESCRIPTION
Here's an example of the server log behavior after this change:
```
{"t":{"$date":"2023-04-13T10:56:07.619-05:00"},"s":"I",  "c":"NETWORK",  "id":22943,   "ctx":"listener","msg":"Connection accepted","attr":{"remote":"127.0.0.1:58812","uuid":"38175cc1-8c5c-44a2-8b05-afc38f35823e","connectionId":219,"connectionCount":8}}
{"t":{"$date":"2023-04-13T10:56:07.624-05:00"},"s":"I",  "c":"NETWORK",  "id":51800,   "ctx":"conn219","msg":"client metadata","attr":{"remote":"127.0.0.1:58812","client":"conn219","doc":{"driver":{"name":"PyMongo|MongoEngine","version":"4.2.0|0.27.0"}, ...}}}
```

This change helps identify mongoengine usage and version info for user reported issues.