### PR TITLE
Added _instance for EmbeddedDocument then accessing dict values

### DIFF
--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -162,6 +162,10 @@ class BaseField:
             for v in value:
                 if isinstance(v, EmbeddedDocument):
                     v._instance = weakref.proxy(instance)
+        elif isinstance(value, dict):
+            for v in value.values():
+                if isinstance(v, EmbeddedDocument):
+                    v._instance = weakref.proxy(instance)
 
         instance._data[self.name] = value
 


### PR DESCRIPTION
In cases when we have a DictField and we have an EmbeddedDocument as a value of the dict, the values doesn't get _instance, thus not allowing us to reference parent document. 

But then we get access value directly, we can have _instance set correctly. So basically there is a workaround, but the code became a bit messy.

Consider the following example, where "vars" is DictField with string in key and EmbeddedDocument in value:

```python
# that won't work, would print "None"
for var in self.vars.values():
    print(var._instance)

# that is working, would print correct object
for var in self.vars:
   print(self.vars[var]._instance)
```

This small PR fixes it, as it seems like a bug, not an intended behaviour. Haven't found any issues with that, there is simply one extra isinstance check and impact on perfomance should not be noticable.  It also shoud not cause any incompability with any existing projects using MongoEngine.
