### PR TITLE
Implement lazy delete rules

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -264,3 +264,4 @@ that much better:
  * oleksandr-l5 (https://github.com/oleksandr-l5)
  * Ido Shraga (https://github.com/idoshr)
  * Terence Honles (https://github.com/terencehonles)
+ * Chris Combs (https://github.com/combscCode)

--- a/mongoengine/base/__init__.py
+++ b/mongoengine/base/__init__.py
@@ -14,6 +14,7 @@ __all__ = (
     # common
     "UPDATE_OPERATORS",
     "_document_registry",
+    "_undefined_document_delete_rules",
     "get_document",
     # datastructures
     "BaseDict",

--- a/mongoengine/base/common.py
+++ b/mongoengine/base/common.py
@@ -1,6 +1,12 @@
+from collections import defaultdict
 from mongoengine.errors import NotRegistered
 
-__all__ = ("UPDATE_OPERATORS", "get_document", "_document_registry")
+__all__ = (
+    "UPDATE_OPERATORS",
+    "get_document",
+    "_document_registry",
+    "_undefined_document_delete_rules",
+)
 
 
 UPDATE_OPERATORS = {
@@ -23,6 +29,7 @@ UPDATE_OPERATORS = {
 
 
 _document_registry = {}
+_undefined_document_delete_rules = defaultdict(list)
 
 
 def get_document(name):

--- a/mongoengine/base/common.py
+++ b/mongoengine/base/common.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+
 from mongoengine.errors import NotRegistered
 
 __all__ = (

--- a/mongoengine/base/metaclasses.py
+++ b/mongoengine/base/metaclasses.py
@@ -4,7 +4,6 @@ import warnings
 from mongoengine.base.common import (
     _document_registry,
     _undefined_document_delete_rules,
-    get_document,
 )
 from mongoengine.base.fields import (
     BaseField,

--- a/mongoengine/base/metaclasses.py
+++ b/mongoengine/base/metaclasses.py
@@ -1,14 +1,18 @@
 import itertools
 import warnings
 
-from mongoengine.base.common import _document_registry
+from mongoengine.base.common import (
+    _document_registry,
+    _undefined_document_delete_rules,
+    get_document,
+)
 from mongoengine.base.fields import (
     BaseField,
     ComplexBaseField,
     ObjectIdField,
 )
 from mongoengine.common import _import_class
-from mongoengine.errors import InvalidDocumentError
+from mongoengine.errors import InvalidDocumentError, NotRegistered
 from mongoengine.queryset import (
     DO_NOTHING,
     DoesNotExist,
@@ -206,7 +210,14 @@ class DocumentMetaclass(type):
                         "EmbeddedDocuments (field: %s)" % field.name
                     )
                     raise InvalidDocumentError(msg)
-                f.document_type.register_delete_rule(new_class, field.name, delete_rule)
+                try:
+                    f.document_type.register_delete_rule(
+                        new_class, field.name, delete_rule
+                    )
+                except NotRegistered:
+                    _undefined_document_delete_rules[f.owner_document].append(
+                        (new_class, field.name, delete_rule)
+                    )
 
             if (
                 field.name
@@ -362,6 +373,13 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
 
         # Call super and get the new class
         new_class = super_new(mcs, name, bases, attrs)
+        # Find any lazy delete rules and apply to current doc.
+        if new_class._class_name in _undefined_document_delete_rules:
+            rules_tuple_list = _undefined_document_delete_rules.pop(
+                new_class._class_name
+            )
+            for document_cls, field_name, rule in rules_tuple_list:
+                new_class.register_delete_rule(document_cls, field_name, rule)
 
         meta = new_class._meta
 

--- a/tests/document/test_instance.py
+++ b/tests/document/test_instance.py
@@ -2525,7 +2525,13 @@ class TestDocumentInstance(MongoDBTestCase):
             text = StringField()
             post = ReferenceField("BlogPost", reverse_delete_rule=CASCADE)
 
-        assert _undefined_document_delete_rules.get("BlogPost")
+        assert len(_undefined_document_delete_rules.get("BlogPost")) == 1
+
+        class CommentDos(Document):
+            textdos = StringField()
+            postdos = ReferenceField("BlogPost", reverse_delete_rule=CASCADE)
+
+        assert len(_undefined_document_delete_rules.get("BlogPost")) == 2
 
         class BlogPost(Document):
             content = StringField()

--- a/tests/document/test_instance.py
+++ b/tests/document/test_instance.py
@@ -12,7 +12,11 @@ from pymongo.errors import DuplicateKeyError
 
 from mongoengine import *
 from mongoengine import signals
-from mongoengine.base import _document_registry, _undefined_document_delete_rules, get_document
+from mongoengine.base import (
+    _document_registry,
+    _undefined_document_delete_rules,
+    get_document,
+)
 from mongoengine.connection import get_db
 from mongoengine.context_managers import query_counter, switch_db
 from mongoengine.errors import (


### PR DESCRIPTION
Fixes issue #2764, when delete rules are assigned to a Document that doesn't exist yet, store them in a global dict. Whenever a new Document class is defined, it checks said global dict for any outstanding delete rules that it needs to assign on itself.