### PR TITLE
Fix an issue when filtering on list of floats with not empty 

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -401,7 +401,7 @@ class FloatField(BaseField):
             self.error("Float value is too large")
 
     def prepare_query_value(self, op, value):
-        if value is None:
+        if value is None or value == []:
             return value
 
         return super().prepare_query_value(op, float(value))

--- a/tests/queryset/test_queryset.py
+++ b/tests/queryset/test_queryset.py
@@ -6006,6 +6006,14 @@ class TestQueryset(unittest.TestCase):
         for index in range(qs_disk.count()):
             assert qs_disk[index] == qs[index]
 
+    def test_filter_on_empty_list_of_floats(self):
+        class Family(Document):
+            ages = ListField(field=FloatField())
+
+        Family(ages = [7.5, 5.5, 29.5, 32.7]).save()
+        Family(ages = []).save()
+        assert Family.objects(ages__gt=[]).count() == 1
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
        class Family(Document):
            ages = ListField(field=FloatField())

when filtering with family.objects(ages__gt=[]) mongoengine raised an error  ( This does not happen with list of undeclared fields)
 This PR fix this issue.

        
        