### PR TITLE
Add pymongo 4.7 and pymongo 4.8 to the CI

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -34,6 +34,8 @@ env:
 
   MAIN_PYTHON_VERSION: 3.9
 
+  MONGOSH: 2.2.15 # Needed for MongoDB 6.0+
+
 jobs:
   linting:
     # Run pre-commit (https://pre-commit.com/)
@@ -96,6 +98,7 @@ jobs:
     - name: install mongo and ci dependencies
       run: |
         bash .github/workflows/install_mongo.sh ${{ matrix.MONGODB }}
+        bash .github/workflows/install_mongosh.sh ${{ matrix.MONGODB }} ${{ env.MONGOSH }}
         bash .github/workflows/install_ci_python_dep.sh
         bash .github/workflows/start_mongo.sh ${{ matrix.MONGODB }}
     - name: tox dry-run (to pre-install venv)

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -29,6 +29,8 @@ env:
   PYMONGO_4_3: 4.3.3
   PYMONGO_4_4: 4.4.1
   PYMONGO_4_6: 4.6.2
+  PYMONGO_4_7: 4.7.3
+  PYMONGO_4_8: 4.8.0
 
   MAIN_PYTHON_VERSION: 3.9
 
@@ -78,6 +80,12 @@ jobs:
           - python-version: "3.11"
             MONGODB: $MONGODB_7_0
             PYMONGO: $PYMONGO_4_6
+          - python-version: "3.11"
+            MONGODB: $MONGODB_7_0
+            PYMONGO: $PYMONGO_4_7
+          - python-version: "3.11"
+            MONGODB: $MONGODB_7_0
+            PYMONGO: $PYMONGO_4_8
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/install_mongosh.sh
+++ b/.github/workflows/install_mongosh.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+MONGODB=$1
+MONGOSH=$2
+
+if (( $(echo "$MONGODB < 6.0" | bc -l) )); then
+  echo "mongosh is not needed for MongoDB versions less than 6.0"
+  exit 0
+fi
+
+wget https://downloads.mongodb.com/compass/mongosh-${MONGOSH}-linux-x64.tgz
+tar xzf mongosh-${MONGOSH}-linux-x64.tgz
+
+mongosh_dir=$(find ${PWD}/ -type d -name "mongosh-${MONGOSH}-linux-x64")
+$mongosh_dir/bin/mongosh --version

--- a/.github/workflows/start_mongo.sh
+++ b/.github/workflows/start_mongo.sh
@@ -6,4 +6,9 @@ mongodb_dir=$(find ${PWD}/ -type d -name "mongodb-linux-x86_64*")
 
 mkdir $mongodb_dir/data
 $mongodb_dir/bin/mongod --dbpath $mongodb_dir/data --logpath $mongodb_dir/mongodb.log --fork
-mongo --eval 'db.version();'    # Make sure mongo is awake
+
+if (( $(echo "$MONGODB < 6.0" | bc -l) )); then
+mongo --quiet --eval 'db.runCommand("ping").ok'    # Make sure mongo is awake
+else
+mongosh --quiet  --eval 'db.runCommand("ping").ok'  # Make sure mongo is awake
+fi

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy3-{mg34,mg36,mg39,mg311,mg312,mg4,mg432,mg441,mg460}
+envlist = pypy3-{mg34,mg36,mg39,mg311,mg312,mg4,mg432,mg441,mg462,mg473,mg480}
 skipsdist = True
 
 [testenv]
@@ -14,5 +14,7 @@ deps =
     mg433: pymongo>=4.3,<4.4
     mg441: pymongo>=4.4,<4.5
     mg462: pymongo>=4.6,<4.7
+    mg473: pymongo>=4.7,<4.8
+    mg480: pymongo>=4.8,<4.9
 setenv =
     PYTHON_EGG_CACHE = {envdir}/python-eggs


### PR DESCRIPTION
This adds support for testing PyMongo 4.7.3 and PyMongo 4.8.0 to the CI system (GHA).

It also installs `mongosh` if MongoDB >= 6.0