### PR TITLE
fix RTD build error

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -115,6 +115,8 @@ jobs:
   build_doc_dryrun:
     # ensures that readthedocs can be built continuously
     # to avoid that it breaks when new releases are being created
+    # The way RTD works is that it builds the doc on its side
+    # builds are visible at https://readthedocs.org/projects/mongoengine-odm/builds/
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,10 +11,16 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.9
   install:
     - requirements: docs/requirements.txt
     # docs/conf.py is importing mongoengine
     # so mongoengine needs to be installed as well
     - method: setuptools
       path: .
+
+# Specify the build environment
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,6 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.9
   install:
     - requirements: docs/requirements.txt
     # docs/conf.py is importing mongoengine


### PR DESCRIPTION
Latest builds of RTD were failing silently https://readthedocs.org/projects/mongoengine-odm/builds/
This should address it