### PR TITLE
Address flaky transaction tests

### DIFF
--- a/.github/workflows/start_mongo.sh
+++ b/.github/workflows/start_mongo.sh
@@ -6,13 +6,12 @@ mongodb_dir=$(find ${PWD}/ -type d -name "mongodb-linux-x86_64*")
 
 mkdir $mongodb_dir/data
 
-$mongodb_dir/bin/mongod \
- --dbpath $mongodb_dir/data \
- --logpath $mongodb_dir/mongodb.log \
- --fork \
- --setParameter maxTransactionLockRequestTimeoutMillis=1000 \
- --replSet \
- mongoengine
+args=(--dbpath $mongodb_dir/data --logpath $mongodb_dir/mongodb.log --fork --replSet mongoengine)
+if (( $(echo "$MONGODB > 3.8" | bc -l) )); then
+    args+=(--setParameter maxTransactionLockRequestTimeoutMillis=1000)
+fi
+
+$mongodb_dir/bin/mongod "${args[@]}"
 
 if (( $(echo "$MONGODB < 6.0" | bc -l) )); then
 mongo --verbose --eval "rs.initiate()"

--- a/.github/workflows/start_mongo.sh
+++ b/.github/workflows/start_mongo.sh
@@ -10,8 +10,8 @@ $mongodb_dir/bin/mongod \
  --dbpath $mongodb_dir/data \
  --logpath $mongodb_dir/mongodb.log \
  --fork \
- --replSet \
  --setParameter maxTransactionLockRequestTimeoutMillis=1000 \
+ --replSet \
  mongoengine
 
 if (( $(echo "$MONGODB < 6.0" | bc -l) )); then

--- a/.github/workflows/start_mongo.sh
+++ b/.github/workflows/start_mongo.sh
@@ -6,7 +6,14 @@ mongodb_dir=$(find ${PWD}/ -type d -name "mongodb-linux-x86_64*")
 
 mkdir $mongodb_dir/data
 
-$mongodb_dir/bin/mongod --dbpath $mongodb_dir/data --logpath $mongodb_dir/mongodb.log --fork --replSet mongoengine
+$mongodb_dir/bin/mongod \
+ --dbpath $mongodb_dir/data \
+ --logpath $mongodb_dir/mongodb.log \
+ --fork \
+ --replSet \
+ --setParameter maxTransactionLockRequestTimeoutMillis=1000 \
+ mongoengine
+
 if (( $(echo "$MONGODB < 6.0" | bc -l) )); then
 mongo --verbose --eval "rs.initiate()"
 mongo --quiet --eval "rs.status().ok"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,4 +3,4 @@
 mongod --replSet mongoengine --fork --logpath=/var/log/mongodb.log
 mongo db --eval "rs.initiate()"
 mongod --shutdown
-mongod --replSet mongoengine --bind_ip 0.0.0.0
+mongod --replSet mongoengine --bind_ip 0.0.0.0 --setParameter maxTransactionLockRequestTimeoutMillis=1000


### PR DESCRIPTION
Resolves https://github.com/MongoEngine/mongoengine/issues/2841

* Fix test that was source of most failures
* Update max transaction lock time for local container entrypoint
* Update max transaction lock time for github action

---

The majority of failures appeared to be attributed with the
`test_exception_in_child_of_a_nested_transaction_rolls_parent_back` unit test.

To resolve this test, I borrowed the approach taken by the test just below it:
`test_exception_in_parent_of_nested_transaction_after_child_completed_only_rolls_parent_back`
which was already creating a function for the work under test and simply
trapping the TransientTractionError.

After resolving this, I found that the max transaction lock request timeout
parameter needed to be modified. After doing so and letting the test suite run
indefinitely unless error, test failures appeared to have ceased.