### PR TITLE
Update to support pymongo 4.9

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -29,6 +29,7 @@ env:
   PYMONGO_4_6: 4.6.2
   PYMONGO_4_7: 4.7.3
   PYMONGO_4_8: 4.8.0
+  PYMONGO_4_9: 4.9
 
   MAIN_PYTHON_VERSION: 3.9
 
@@ -83,6 +84,9 @@ jobs:
           - python-version: "3.11"
             MONGODB: $MONGODB_7_0
             PYMONGO: $PYMONGO_4_8
+          - python-version: "3.11"
+            MONGODB: $MONGODB_7_0
+            PYMONGO: $PYMONGO_4_9
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -4,7 +4,7 @@ import warnings
 
 from pymongo import MongoClient, ReadPreference, uri_parser
 from pymongo.common import _UUID_REPRESENTATIONS
-from pymongo.database import _check_name
+from pymongo.database_shared import _check_name
 
 # DriverInfo was added in PyMongo 3.7.
 try:

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -4,6 +4,7 @@ import warnings
 
 from pymongo import MongoClient, ReadPreference, uri_parser
 from pymongo.common import _UUID_REPRESENTATIONS
+
 try:
     from pymongo.database_shared import _check_name
 except ImportError:

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -4,7 +4,10 @@ import warnings
 
 from pymongo import MongoClient, ReadPreference, uri_parser
 from pymongo.common import _UUID_REPRESENTATIONS
-from pymongo.database_shared import _check_name
+try:
+    from pymongo.database_shared import _check_name
+except ImportError:
+    from pymongo.database import _check_name
 
 # DriverInfo was added in PyMongo 3.7.
 try:

--- a/tests/fields/test_datetime_field.py
+++ b/tests/fields/test_datetime_field.py
@@ -2,14 +2,15 @@ import datetime as dt
 
 import pytest
 
+from mongoengine import *
+from mongoengine import connection
+from tests.utils import MongoDBTestCase, get_as_pymongo
+
 try:
     import dateutil
 except ImportError:
     dateutil = None
 
-from mongoengine import *
-from mongoengine import connection
-from tests.utils import MongoDBTestCase, get_as_pymongo
 
 
 class TestDateTimeField(MongoDBTestCase):

--- a/tests/fields/test_datetime_field.py
+++ b/tests/fields/test_datetime_field.py
@@ -12,7 +12,6 @@ except ImportError:
     dateutil = None
 
 
-
 class TestDateTimeField(MongoDBTestCase):
     def test_datetime_from_empty_string(self):
         """

--- a/tests/queryset/test_queryset_aggregation.py
+++ b/tests/queryset/test_queryset_aggregation.py
@@ -19,10 +19,11 @@ class TestQuerysetAggregate(MongoDBTestCase):
         bars = Bar.objects.read_preference(
             ReadPreference.SECONDARY_PREFERRED
         ).aggregate(pipeline)
-        assert (
-            bars._CommandCursor__collection.read_preference
-            == ReadPreference.SECONDARY_PREFERRED
-        )
+        if hasattr(bars, "_CommandCursor__collection"):
+            read_pref = bars._CommandCursor__collection.read_preference
+        else:  # pymongo >= 4.9
+            read_pref = bars._collection.read_preference
+        assert read_pref == ReadPreference.SECONDARY_PREFERRED
 
     def test_queryset_aggregation_framework(self):
         class Person(Document):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -3,6 +3,8 @@ import unittest
 import uuid
 
 import pymongo
+import pymongo.database
+import pymongo.mongo_client
 import pytest
 from bson.tz_util import utc
 from pymongo import MongoClient, ReadPreference
@@ -608,7 +610,10 @@ class ConnectionTest(unittest.TestCase):
         connection kwargs
         """
         c = connect(replicaset="local-rs")
-        assert c._MongoClient__options.replica_set_name == "local-rs"
+        if hasattr(c, "_MongoClient__options"):
+            assert c._MongoClient__options.replica_set_name == "local-rs"
+        else:  # pymongo >= 4.9
+            assert c._options.replica_set_name == "local-rs"
         db = get_db()
         assert isinstance(db, pymongo.database.Database)
         assert db.name == "test"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy3-{mg34,mg36,mg39,mg311,mg312,mg4,mg432,mg441,mg462,mg473,mg480}
+envlist = pypy3-{mg34,mg36,mg39,mg311,mg312,mg4,mg432,mg441,mg462,mg473,mg480,mg49}
 skipsdist = True
 
 [testenv]
@@ -16,5 +16,6 @@ deps =
     mg462: pymongo>=4.6,<4.7
     mg473: pymongo>=4.7,<4.8
     mg480: pymongo>=4.8,<4.9
+    mg49: pymongo>=4.9,<5.0
 setenv =
     PYTHON_EGG_CACHE = {envdir}/python-eggs


### PR DESCRIPTION
Resolve issue where _check_name moved files between pymongo 4.8.0 and 4.9. This updates the import path. Also updated are other private members that the test rely on and a couple imports (`database` and `mongo_client`) that now must be explicitly declared.

The `_check_name` function can now be found [here](https://github.com/mongodb/mongo-python-driver/blob/9df635f10276d92e26b39c8ba35243c1064a29dd/pymongo/database_shared.py#L24). 

This closes #2847 and obsoletes #2848