### PR TITLE
Call mark_as_changed_wrapper for `list.clear` on ListField

### DIFF
--- a/mongoengine/base/datastructures.py
+++ b/mongoengine/base/datastructures.py
@@ -177,6 +177,7 @@ class BaseList(list):
     remove = mark_as_changed_wrapper(list.remove)
     reverse = mark_as_changed_wrapper(list.reverse)
     sort = mark_as_changed_wrapper(list.sort)
+    clear = mark_as_changed_wrapper(list.clear)
     __delitem__ = mark_as_changed_wrapper(list.__delitem__)
     __iadd__ = mark_as_changed_wrapper(list.__iadd__)
     __imul__ = mark_as_changed_wrapper(list.__imul__)

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -185,7 +185,7 @@ class TestBaseList:
         base_list = BaseList(values, instance=None, name="my_name")
         assert values == list(base_list)
 
-    def test___iter___allow_modification_while_iterating_withou_error(self):
+    def test___iter___allow_modification_while_iterating_without_error(self):
         # regular list allows for this, thus this subclass must comply to that
         base_list = BaseList([True, False, True, False], instance=None, name="my_name")
         for idx, val in enumerate(base_list):
@@ -364,6 +364,11 @@ class TestBaseList:
         base_list = self._get_baselist([1, 2, 11])
         base_list.sort(key=lambda i: str(i))
         assert base_list == [1, 11, 2]
+
+    def test_clear_calls_mark_as_changed(self):
+        base_list = self._get_baselist([True, False])
+        base_list.clear()
+        assert base_list._instance._changed_fields == ["my_name"]
 
 
 class TestStrictDict(unittest.TestCase):


### PR DESCRIPTION
Fixes #2808

`list.clear` was added in Python 3.3