### PR TITLE
Error improvement for referenced Documents not saved yet

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,7 +22,7 @@ Development
 - Add support for collation/hint/comment to delete/update and aggregate #2842
 - BREAKING CHANGE: Remove LongField as it's equivalent to IntField since we drop support to Python2 long time ago (User should simply switch to IntField) #2309
 - BugFix - Calling .clear on a ListField wasn't being marked as changed (and flushed to db upon .save()) #2858
-
+- Improve error message in case a document assigned to a ReferenceField wasn't saved yet #1955
 
 Changes in 0.29.0
 =================


### PR DESCRIPTION
Improve error message in case a document assigned to a ReferenceField wasn't saved yet
Fixes #1955