### PR TITLE
refactor(models): add datetime import and replace deprecated utcnow

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,19 +77,20 @@ Examples
 Some simple examples of what MongoEngine code looks like:
 
 .. code :: python
-
+    import datetime
     from mongoengine import *
+    
     connect('mydb')
-
+    
     class BlogPost(Document):
         title = StringField(required=True, max_length=200)
-        posted = DateTimeField(default=datetime.datetime.utcnow)
+        posted = DateTimeField(default=lambda: datetime.datetime.now(datetime.timezone.utc))
         tags = ListField(StringField(max_length=50))
         meta = {'allow_inheritance': True}
-
+    
     class TextPost(BlogPost):
         content = StringField(required=True)
-
+    
     class LinkPost(BlogPost):
         url = StringField(required=True)
 


### PR DESCRIPTION
- Added `import datetime` to ensure datetime functionality is available
- Replaced deprecated `datetime.datetime.utcnow()` with `datetime.datetime.now(datetime.timezone.utc)`
- Used lambda for dynamic evaluation of default datetime in BlogPost.posted field