### PR TITLE
Support update with aggregation pipeline in modify method

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -266,3 +266,4 @@ that much better:
  * Terence Honles (https://github.com/terencehonles)
  * Sean Bermejo (https://github.com/seanbermejo)
  * Juan Gutierrez (https://github.com/juannyg)
+ * Gowtham V Bhat (https://github.com/gowthamvbhat)

--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -733,7 +733,15 @@ class BaseQuerySet:
             query["$where"] = where_clause
 
         if not remove:
-            update = transform.update(queryset._document, **update)
+            if "__raw__" in update and isinstance(
+                update["__raw__"], list
+            ):  # Case of Update with Aggregation Pipeline
+                update = [
+                    transform.update(queryset._document, **{"__raw__": u})
+                    for u in update["__raw__"]
+                ]
+            else:
+                update = transform.update(queryset._document, **update)
         sort = queryset._ordering
 
         try:


### PR DESCRIPTION
Currently [updating with an aggregation pipeline](https://docs.mongoengine.org/guide/querying.html#update-with-aggregation-pipeline) is supported in `update()` and `update_one()` methods.

This PR add the same support in `modify()` method by following the original PR - https://github.com/MongoEngine/mongoengine/pull/2578

Related issue - https://github.com/MongoEngine/mongoengine/issues/2873

Please let me know if this requires any other changes.