### PR TITLE
Fix dynamic embedded document updates

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,7 @@ Development
 - BugFix - Calling .clear on a ListField wasn't being marked as changed (and flushed to db upon .save()) #2858
 - Improve error message in case a document assigned to a ReferenceField wasn't saved yet #1955
 - BugFix - Take `where()` into account when using `.modify()`, as in MyDocument.objects().where("this[field] >= this[otherfield]").modify(field='new') #2044
+- BugFix - Unable to add new fields during `QuerySet.update` on `DynamicEmbeddedDocument` fields #2486
 
 Changes in 0.29.0
 =================

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -777,6 +777,12 @@ class EmbeddedDocumentField(BaseField):
             if field:
                 return field
 
+        # DynamicEmbeddedDocuments should always return a field except for positional operators
+        if any(
+            doc_type._dynamic for doc_type in doc_and_subclasses
+        ) and member_name not in ("$", "S"):
+            return DynamicField(db_field=member_name)
+
     def prepare_query_value(self, op, value):
         if value is not None and not isinstance(value, self.document_type):
             # Short circuit for special operators, returning them as is
@@ -836,6 +842,12 @@ class GenericEmbeddedDocumentField(BaseField):
                 field = doc_type._fields.get(member_name)
                 if field:
                     return field
+
+        # DynamicEmbeddedDocuments should always return a field except for positional operators
+        if any(
+            document_choice._dynamic for document_choice in document_choices
+        ) and member_name not in ("$", "S"):
+            return DynamicField(db_field=member_name)
 
     def to_mongo(self, document, use_db_field=True, fields=None):
         if document is None:


### PR DESCRIPTION
In order to allow setting new fields that did not previouly exist on dynamic embedded documents, the `lookup_member` functions on `EmbeddedDocumentField` and `GenericEmbeddedDocumentField` return dynamic fields as appropriate. This enables operations like `A.objects(...).update(foo__newfield="bar")`.  Special awareness is given to positional operators - see the new test cases for examples of where this is important.

Resolves #2486