### PR TITLE
Fix: Handle collection.objects when it's a partial function

### DIFF
--- a/mongoengine/dereference.py
+++ b/mongoengine/dereference.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 from bson import SON, DBRef
 
 from mongoengine.base import (
@@ -174,7 +176,10 @@ class DeReference:
                 refs = [
                     dbref for dbref in dbrefs if (col_name, dbref) not in object_map
                 ]
-                references = collection.objects.in_bulk(refs)
+                if isinstance(collection.objects, partial):
+                    references = collection.objects().in_bulk(refs)
+                else:
+                    references = collection.objects.in_bulk(refs)
                 for key, doc in references.items():
                     object_map[(col_name, key)] = doc
             else:  # Generic reference: use the refs data to convert to document


### PR DESCRIPTION
`collection.objects` can be a partial function. When it is, trying to call `in_bulk` on it was causing error.

Note: I added explicit type check before calling it, but I can change it to be always called (because query set is callable).