### PR TITLE
fix: exception on null embedded scalar values

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,7 @@ Development
 - BugFix - Calling .clear on a ListField wasn't being marked as changed (and flushed to db upon .save()) #2858
 - Improve error message in case a document assigned to a ReferenceField wasn't saved yet #1955
 - BugFix - Take `where()` into account when using `.modify()`, as in MyDocument.objects().where("this[field] >= this[otherfield]").modify(field='new') #2044
+- fix: exception on null embedded scalar values
 
 Changes in 0.29.0
 =================

--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -2036,6 +2036,8 @@ class BaseQuerySet:
             chunks = name.split("__")
             for chunk in chunks:
                 obj = getattr(obj, chunk)
+                if obj is None:
+                    break
             return obj
 
         data = [lookup(doc, n) for n in self._scalar]

--- a/tests/queryset/test_queryset.py
+++ b/tests/queryset/test_queryset.py
@@ -4685,11 +4685,13 @@ class TestQueryset(unittest.TestCase):
             source = EmbeddedDocumentField(EmbeddedModelA)
             target = EmbeddedDocumentField(EmbeddedModelA, null=True)
         
+        # Create one with both values
         Container(
             source=EmbeddedModelA(designator="value1"),
             target=EmbeddedModelB(designator="value2"),
         ).save()
         
+        # Create one with a null target, but the source value will match the query
         Container(
             source=EmbeddedModelA(designator="value1"),
             target=None,
@@ -4698,10 +4700,9 @@ class TestQueryset(unittest.TestCase):
         queryset = Container.objects.filter(
             Q(source__designator="value1") | Q(target__designator="value2")
         ).values_list("source__designator", "target__designator")
-        # This should not raise an AttributeError on NoneType for the second Container's
-        # target__designator
+        # This should not raise an AttributeError on NoneType for the second Container's target__designator
         values = list(queryset)
-        assert values == ["value1", "value2"]
+        assert values == ["value1", "value2", None]
 
     def test_scalar_decimal(self):
         from decimal import Decimal

--- a/tests/queryset/test_queryset.py
+++ b/tests/queryset/test_queryset.py
@@ -4702,7 +4702,7 @@ class TestQueryset(unittest.TestCase):
         ).values_list("source__designator", "target__designator")
         # This should not raise an AttributeError on NoneType for the second Container's target__designator
         values = list(queryset)
-        assert values == ["value1", "value2", None]
+        assert values == [("value1", "value2"), ("value1", None)]
 
     def test_scalar_decimal(self):
         from decimal import Decimal

--- a/tests/queryset/test_queryset.py
+++ b/tests/queryset/test_queryset.py
@@ -4680,17 +4680,17 @@ class TestQueryset(unittest.TestCase):
 
         class EmbeddedModelA(EmbeddedDocument):
             designator = StringField()
-        
+
         class Container(Document):
             source = EmbeddedDocumentField(EmbeddedModelA)
             target = EmbeddedDocumentField(EmbeddedModelA, null=True)
-        
+
         # Create one with both values
         Container(
             source=EmbeddedModelA(designator="value1"),
-            target=EmbeddedModelB(designator="value2"),
+            target=EmbeddedModelA(designator="value2"),
         ).save()
-        
+
         # Create one with a null target, but the source value will match the query
         Container(
             source=EmbeddedModelA(designator="value1"),

--- a/tests/queryset/test_queryset.py
+++ b/tests/queryset/test_queryset.py
@@ -21,6 +21,7 @@ from mongoengine.pymongo_support import PYMONGO_VERSION
 from mongoengine.queryset import (
     DoesNotExist,
     MultipleObjectsReturned,
+    Q,
     QuerySet,
     QuerySetManager,
     queryset_manager,
@@ -4673,6 +4674,34 @@ class TestQueryset(unittest.TestCase):
             ("Wilson Jr", 19, "Corumba-GO"),
             ("Gabriel Falcao", 23, "New York"),
         ]
+
+    def test_scalar_embedded_null_parents(self):
+        """Test a multi-scalar query on embedded fields raises an exception when the parent field is null."""
+
+        class EmbeddedModelA(EmbeddedDocument):
+            designator = StringField()
+        
+        class Container(Document):
+            source = EmbeddedDocumentField(EmbeddedModelA)
+            target = EmbeddedDocumentField(EmbeddedModelA, null=True)
+        
+        Container(
+            source=EmbeddedModelA(designator="value1"),
+            target=EmbeddedModelB(designator="value2"),
+        ).save()
+        
+        Container(
+            source=EmbeddedModelA(designator="value1"),
+            target=None,
+        ).save()
+
+        queryset = Container.objects.filter(
+            Q(source__designator="value1") | Q(target__designator="value2")
+        ).values_list("source__designator", "target__designator")
+        # This should not raise an AttributeError on NoneType for the second Container's
+        # target__designator
+        values = list(queryset)
+        assert values == ["value1", "value2"]
 
     def test_scalar_decimal(self):
         from decimal import Decimal


### PR DESCRIPTION
## Overview

When running a queryset like this: 

```python
values = set()
for results in MyModel.objects.filter(Q(a__subfield=1) | Q(b__subfield=1)).values_list("a__subfield", "b__subfield"):
    values.update(results)
```

Over documents like this:

```json
{"a": {"subfield": 1}, "b": {"subfield":1}},
{"a": {"subfield": 1}, "b": null},
{"a": {"subfield": 1}, "b": {"subfield":1}}
```

The method `_get_scalar` will raise an `AttributeError` on getting the attribute `subfield` of the second document where `b` is null.

The workaround currently is to instead do a `values_list` on `(a, b)` and then perform null checks on the client side, like this, which is much more verbose (assume `get_value` is a helper function roughly equivalent to getattr):

```python
values = set()
for (a_par, b_par) in MyModel.objects.filter(Q(a__subfield=1) | Q(b__subfield=1)).values_list("a", "b"):
    if a_par:
       values.add(get_value(a_par, "subfield"))
    if b_par:
       values.add(get_value(b_par, "subfield"))
    ...
```

This is also less efficient as the whole embedded document must be fetched from the database instead of just the two desired fields. A similar solution using `only` could be utilized but it is also less elegant.

## Fix

Add a simple null check into the `_get_scalar` method on `BaseQuerySet`, so that it returns `None` instead of raising an exception.